### PR TITLE
Add 78 verified playable demos with trial links

### DIFF
--- a/PLAYABLE.md
+++ b/PLAYABLE.md
@@ -1,0 +1,351 @@
+# 可玩 Demo 合集（含试玩链接）
+
+> 社区 GPT-6 Astra 可玩网页 / 浏览器 Demo 精选。每条都附带**试玩链接**；有原帖则附原帖。链接已探活，临时部署仍可能失效。
+
+- 收录：**78** 条（已剔除失效、新闻软文、PDF/指南、作品集等非试玩项）
+- 整理日期：2026-09-08
+- 维护：MaynorAI / [@xianyu110](https://github.com/xianyu110)
+
+## Contents
+
+- [经典复刻 / 知名玩法](#经典复刻--知名玩法) — 9
+- [竞速 / 驾驶](#竞速--驾驶) — 11
+- [射击 / 动作](#射击--动作) — 6
+- [模拟经营 / 策略](#模拟经营--策略) — 4
+- [联机 / 多人](#联机--多人) — 2
+- [街机 / 小游戏包](#街机--小游戏包) — 5
+- [音乐 / 表演](#音乐--表演) — 7
+- [教育 / 科普](#教育--科普) — 1
+- [3D 场景 / 氛围探索](#3D-场景--氛围探索) — 23
+- [工程 / 仿真](#工程--仿真) — 6
+- [其他可玩 Demo](#其他可玩-Demo) — 4
+
+## 经典复刻 / 知名玩法
+
+1. **Monopoly City — A board worth exploring** — [试玩](https://monopoly-city.eekosystems.chatgpt.site) · [原帖](https://x.com/thomasunise/status/2097121832159609145) · ❤ 2
+   - 试玩链接：`https://monopoly-city.eekosystems.chatgpt.site`
+   - 原帖：https://x.com/thomasunise/status/2097121832159609145
+
+2. **瓜体实验室 / 合成大西瓜** — [试玩](https://melon-game.jack-514.chatgpt.site/)
+   - 试玩链接：`https://melon-game.jack-514.chatgpt.site/`
+
+3. **超级马里奥·蘑菇王国** — [试玩](https://mushroom-arcade-0905.jumaomaomaoju.chatgpt.site/)
+   - 试玩链接：`https://mushroom-arcade-0905.jumaomaomaoju.chatgpt.site/`
+
+4. **DUSTⅡ·沙漠行动** — [试玩](https://dust-ii-map.yelin8130.chatgpt.site/)
+   - 试玩链接：`https://dust-ii-map.yelin8130.chatgpt.site/`
+
+5. **水果忍者** — [试玩](https://fruit-ninja-dojo-20260905.yongqixue666.chatgpt.site/)
+   - 试玩链接：`https://fruit-ninja-dojo-20260905.yongqixue666.chatgpt.site/`
+
+6. **植物大战僵尸** — [试玩](https://seth-xh.github.io/pvz/)
+   - 试玩链接：`https://seth-xh.github.io/pvz/`
+
+7. **小丑牌 Balatro** — [试玩](https://balatro-v1-1.longyh2333521818.chatgpt.site/)
+   - 试玩链接：`https://balatro-v1-1.longyh2333521818.chatgpt.site/`
+
+8. **PAC-MAN: Ghost Sharks — Bite back.** — [试玩](https://pacman.demyx.workers.dev/) · [原帖](https://x.com/awildnpc/status/2096034211782099313)
+   - 试玩链接：`https://pacman.demyx.workers.dev/`
+   - 原帖：https://x.com/awildnpc/status/2096034211782099313
+
+9. **Flappy Bird · Click to Fly** — [试玩](https://flappy-click-arcade-sept26.wesley-blomquist96.chatgpt.site/) · [原帖](https://x.com/i/status/2096347522226684105)
+   - 试玩链接：`https://flappy-click-arcade-sept26.wesley-blomquist96.chatgpt.site/`
+   - 原帖：https://x.com/i/status/2096347522226684105
+
+## 竞速 / 驾驶
+
+1. **STORM RACE · Tsuchiya Workshop** — [试玩](https://storm-race.vercel.app) · [原帖](https://x.com/BubuStd/status/2096587056755638553) · ❤ 4191
+   - 试玩链接：`https://storm-race.vercel.app`
+   - 原帖：https://x.com/BubuStd/status/2096587056755638553
+
+2. **Ashen Road — A journey to Ravenwatch** — [试玩](https://ashen-road.emad349385.chatgpt.site) · [原帖](https://x.com/i/status/2096359789525639290) · ❤ 286
+   - 试玩链接：`https://ashen-road.emad349385.chatgpt.site`
+   - 原帖：https://x.com/i/status/2096359789525639290
+
+3. **Tidal Rush — Paradise Grand Prix** — [试玩](https://tidal-rush-paradise-gp.skirano.chatgpt.site) · [原帖](https://x.com/alexgetmancom/status/2095598460921614825) · ❤ 24
+   - 试玩链接：`https://tidal-rush-paradise-gp.skirano.chatgpt.site`
+   - 原帖：https://x.com/alexgetmancom/status/2095598460921614825
+
+4. **Blue Bajaj Rally 1.0.1 | Highland Loop** — [试玩](https://bajaj.guzo.tech/) · [原帖](https://x.com/guzotech/status/2096209787864088638) · ❤ 12
+   - 试玩链接：`https://bajaj.guzo.tech/`
+   - 原帖：https://x.com/guzotech/status/2096209787864088638
+
+5. **THE ROAD DREAMS · 梦境之径** — [试玩](https://the-road-dreams.x2026283037.chatgpt.site) · [原帖](https://x.com/i/status/2096313256264765440) · ❤ 1
+   - 试玩链接：`https://the-road-dreams.x2026283037.chatgpt.site`
+   - 原帖：https://x.com/i/status/2096313256264765440
+
+6. **Zombie Escape Driver** — [试玩](https://zombiedriver.z.madsoftware.co) · [原帖](https://x.com/MarcDagatan/status/2096667577326190631) · ❤ 1
+   - 试玩链接：`https://zombiedriver.z.madsoftware.co`
+   - 原帖：https://x.com/MarcDagatan/status/2096667577326190631
+
+7. **COURTSIDE NBA2K** — [试玩](https://huhuhu.page.gd/COURTSIDE26.html)
+   - 试玩链接：`https://huhuhu.page.gd/COURTSIDE26.html`
+
+8. **AI Mini Racer - Astra Edition** — [试玩](https://ai-mini-racer.code-crunche-2353.chatgpt.site) · [原帖](https://x.com/i/status/2096320362736714233)
+   - 试玩链接：`https://ai-mini-racer.code-crunche-2353.chatgpt.site`
+   - 原帖：https://x.com/i/status/2096320362736714233
+
+9. **CYBER SUV · 互动设计展厅** — [试玩](https://cyber-suv-studio.banny911.chatgpt.site) · [原帖](https://x.com/i/status/2096384563459334256)
+   - 试玩链接：`https://cyber-suv-studio.banny911.chatgpt.site`
+   - 原帖：https://x.com/i/status/2096384563459334256
+
+10. **DUSKLINE — Canyon Circuit** — [试玩](https://duskline-canyon-run.abdulhadi-ai.chatgpt.site) · [原帖](https://x.com/1banke/status/2096394721115390301)
+   - 试玩链接：`https://duskline-canyon-run.abdulhadi-ai.chatgpt.site`
+   - 原帖：https://x.com/1banke/status/2096394721115390301
+
+11. **Lantern Cove · The Borrowed Light** — [试玩](https://lantern-cove.akartit.chatgpt.site/) · [原帖](https://x.com/akartit/status/2096520784449613981)
+   - 试玩链接：`https://lantern-cove.akartit.chatgpt.site/`
+   - 原帖：https://x.com/akartit/status/2096520784449613981
+
+## 射击 / 动作
+
+1. **LAST LIGHT — A Northline Story** — [试玩](https://last-light-northline.pages.dev) · [原帖](https://x.com/md_taqui_imam/status/2096255279650517081) · ❤ 5
+   - 试玩链接：`https://last-light-northline.pages.dev`
+   - 原帖：https://x.com/md_taqui_imam/status/2096255279650517081
+
+2. **FANG · STARLIGHT RUN** — [试玩](https://fang-starlight-run.yosshy666.chatgpt.site/) · [原帖](https://x.com/FANGsaikyou/status/2096192445667283326) · ❤ 2
+   - 试玩链接：`https://fang-starlight-run.yosshy666.chatgpt.site/`
+   - 原帖：https://x.com/FANGsaikyou/status/2096192445667283326
+
+3. **INFINITUM** — [试玩](https://infinitum-game.vercel.app/) · [原帖](https://x.com/HpMani56403/status/2097188417709002822) · ❤ 2
+   - 试玩链接：`https://infinitum-game.vercel.app/`
+   - 原帖：https://x.com/HpMani56403/status/2097188417709002822
+
+4. **Building Prism World ✳️ One idea, every feed.** — [试玩](https://prism-world-demo.krrish18.chatgpt.site) · [原帖](https://x.com/krishnap1810/status/2095633183567945941)
+   - 试玩链接：`https://prism-world-demo.krrish18.chatgpt.site`
+   - 原帖：https://x.com/krishnap1810/status/2095633183567945941
+
+5. **마성전설 — 메두사의 신전** — [试玩](https://knightmare-medusa-3d.robin-hwang.chatgpt.site/) · [原帖](https://x.com/i/status/2096984386566815920)
+   - 试玩链接：`https://knightmare-medusa-3d.robin-hwang.chatgpt.site/`
+   - 原帖：https://x.com/i/status/2096984386566815920
+
+6. **Neural Sight — Play the demo** — [试玩](https://monstercameron.github.io/Neural-Sight/) · [原帖](https://x.com/monstercameron/status/2097117275127959629)
+   - 试玩链接：`https://monstercameron.github.io/Neural-Sight/`
+   - 原帖：https://x.com/monstercameron/status/2097117275127959629
+
+## 模拟经营 / 策略
+
+1. **秦王拧螺丝** — [试玩](https://qin-imperial-factory-221.xyjwyf123.chatgpt.site/)
+   - 试玩链接：`https://qin-imperial-factory-221.xyjwyf123.chatgpt.site/`
+
+2. **Web 三国** — [试玩](https://sanguo-wind-cloud.amery2010.workers.dev/)
+   - 试玩链接：`https://sanguo-wind-cloud.amery2010.workers.dev/`
+
+3. **Little Kingdom — 작은 왕국 체스** — [试玩](https://little-kingdom-chess.echo3042.chatgpt.site) · [原帖](https://x.com/echo3042/status/2096123409029886250)
+   - 试玩链接：`https://little-kingdom-chess.echo3042.chatgpt.site`
+   - 原帖：https://x.com/echo3042/status/2096123409029886250
+
+4. **Le Bon Rayon — Épicerie de quartier** — [试玩](https://le-bon-rayon.alexxondre.chatgpt.site) · [原帖](https://x.com/i/status/2096652925527314554)
+   - 试玩链接：`https://le-bon-rayon.alexxondre.chatgpt.site`
+   - 原帖：https://x.com/i/status/2096652925527314554
+
+## 联机 / 多人
+
+1. **Lumbridge | Old-school multiplayer adventure** — [试玩](https://elderwood-realms.rohannvarma.chatgpt.site/) · [原帖](https://x.com/TheRohanVarma/status/2096744577332068549) · ❤ 702
+   - 试玩链接：`https://elderwood-realms.rohannvarma.chatgpt.site/`
+   - 原帖：https://x.com/TheRohanVarma/status/2096744577332068549
+
+2. **Unstable Stables Online** — [试玩](https://unstable-stables-online.danielgui30.chatgpt.site/) · [原帖](https://x.com/i/status/2096282857400652262)
+   - 试玩链接：`https://unstable-stables-online.danielgui30.chatgpt.site/`
+   - 原帖：https://x.com/i/status/2096282857400652262
+
+## 街机 / 小游戏包
+
+1. **ASTRA Arcade — Six original games** — [试玩](https://astra-arcade.antonioleivag.chatgpt.site) · [原帖](https://x.com/antonioleivag/status/2096509898481651770) · ❤ 21
+   - 试玩链接：`https://astra-arcade.antonioleivag.chatgpt.site`
+   - 原帖：https://x.com/antonioleivag/status/2096509898481651770
+
+2. **ASTEROIDS · Deepfield** — [试玩](https://asteroids-deepfield-cockpit.dan200200.chatgpt.site/) · [原帖](https://x.com/DantesClown/status/2096085439052452064) · ❤ 3
+   - 试玩链接：`https://asteroids-deepfield-cockpit.dan200200.chatgpt.site/`
+   - 原帖：https://x.com/DantesClown/status/2096085439052452064
+
+3. **Play Games Built with GPT-6 Astra | Astragames** — [试玩](https://astragames.lol) · [原帖](https://x.com/i/status/2096377756062027894) · ❤ 2
+   - 试玩链接：`https://astragames.lol`
+   - 原帖：https://x.com/i/status/2096377756062027894
+
+4. **Astra Games — Built with GPT-6 Astra** — [试玩](https://astragames.aigccreative.com/en) · [原帖](https://x.com/marindeloph/status/2096901528166793595) · ❤ 1
+   - 试玩链接：`https://astragames.aigccreative.com/en`
+   - 原帖：https://x.com/marindeloph/status/2096901528166793595
+
+5. **Kutular – Büyük Ödül Oyunu** — [试玩](https://kutular-oyunu.tuned-lion-2154.chatgpt.site) · [原帖](https://x.com/nzmdgnc/status/2095803218135544027)
+   - 试玩链接：`https://kutular-oyunu.tuned-lion-2154.chatgpt.site`
+   - 原帖：https://x.com/nzmdgnc/status/2095803218135544027
+
+## 音乐 / 表演
+
+1. **Brandenburg Piano — J. S. Bach** — [试玩](https://brandenburg-piano.vercel.app/) · [原帖](https://x.com/DeryaTR_/status/2096090915790069857) · ❤ 1531
+   - 试玩链接：`https://brandenburg-piano.vercel.app/`
+   - 原帖：https://x.com/DeryaTR_/status/2096090915790069857
+
+2. **Daybreak · A piano performance** — [试玩](https://daybreak-piano-film.lexn8.chatgpt.site/) · [原帖](https://x.com/LexnLin/status/2096166277849239804) · ❤ 1107
+   - 试玩链接：`https://daybreak-piano-film.lexn8.chatgpt.site/`
+   - 原帖：https://x.com/LexnLin/status/2096166277849239804
+
+3. **TR-909 / Play it.** — [试玩](https://tr909play.budrose681.chatgpt.site) · [原帖](https://x.com/i/status/2096288426115117350) · ❤ 2
+   - 试玩链接：`https://tr909play.budrose681.chatgpt.site`
+   - 原帖：https://x.com/i/status/2096288426115117350
+
+4. **LUMINA — Bloom of the Cosmos** — [试玩](https://lumina-cosmic-garden.vercel.app/) · [原帖](https://x.com/i/status/2096348348773028115) · ❤ 2
+   - 试玩链接：`https://lumina-cosmic-garden.vercel.app/`
+   - 原帖：https://x.com/i/status/2096348348773028115
+
+5. **Gravitational Bloom** — [试玩](https://gravitational-bloom.opencrepaldi01.chatgpt.site) · [原帖](https://x.com/BuilderGuest/status/2095946502988288116)
+   - 试玩链接：`https://gravitational-bloom.opencrepaldi01.chatgpt.site`
+   - 原帖：https://x.com/BuilderGuest/status/2095946502988288116
+
+6. **Piano libre — Piano virtuel** — [试玩](https://piano-libre-florian.flo111.chatgpt.site) · [原帖](https://x.com/i/status/2096291074587197588)
+   - 试玩链接：`https://piano-libre-florian.flo111.chatgpt.site`
+   - 原帖：https://x.com/i/status/2096291074587197588
+
+7. **Geometry Dash · Fan Remix** — [试玩](https://geometry-dash-fan-nako.deif79.chatgpt.site) · [原帖](https://x.com/17facet/status/2096856546512982486)
+   - 试玩链接：`https://geometry-dash-fan-nako.deif79.chatgpt.site`
+   - 原帖：https://x.com/17facet/status/2096856546512982486
+
+## 教育 / 科普
+
+1. **Anatomy, unfolded.** — [试玩](https://anatomy-unfolded.brianp.chatgpt.site) · [原帖](https://x.com/i/status/2096253408009486619) · ❤ 1156
+   - 试玩链接：`https://anatomy-unfolded.brianp.chatgpt.site`
+   - 原帖：https://x.com/i/status/2096253408009486619
+
+## 3D 场景 / 氛围探索
+
+1. **Pelagic — Ocean & Atmosphere** — [试玩](https://pelagic-ocean.lexn8.chatgpt.site) · [原帖](https://x.com/i/status/2096341945979383932) · ❤ 894
+   - 试玩链接：`https://pelagic-ocean.lexn8.chatgpt.site`
+   - 原帖：https://x.com/i/status/2096341945979383932
+
+2. **Moonlit Forge** — [试玩](https://moonlit-forge-studio.op7418.chatgpt.site) · [原帖](https://x.com/op7418/status/2096205141187956887) · ❤ 580
+   - 试玩链接：`https://moonlit-forge-studio.op7418.chatgpt.site`
+   - 原帖：https://x.com/op7418/status/2096205141187956887
+
+3. **Flora Brush** — [试玩](https://flora-brush.soumya-raj.chatgpt.site) · [原帖](https://x.com/soumyadesign/status/2096974030104666568) · ❤ 567
+   - 试玩链接：`https://flora-brush.soumya-raj.chatgpt.site`
+   - 原帖：https://x.com/soumyadesign/status/2096974030104666568
+
+4. **Verdant Forest** — [试玩](https://verdant-forest.lexn8.chatgpt.site/) · [原帖](https://x.com/i/status/2096367614805373200) · ❤ 326
+   - 试玩链接：`https://verdant-forest.lexn8.chatgpt.site/`
+   - 原帖：https://x.com/i/status/2096367614805373200
+
+5. **Diamond Light** — [试玩](https://diamond-light.lexn8.chatgpt.site/) · [原帖](https://x.com/LexnLin/status/2096103821470761033) · ❤ 113
+   - 试玩链接：`https://diamond-light.lexn8.chatgpt.site/`
+   - 原帖：https://x.com/LexnLin/status/2096103821470761033
+
+6. **Skyward: The Gathering** — [试玩](https://edge-city-skyward-quests.vercel.app/) · [原帖](https://x.com/timourxyz/status/2096379521926840339) · ❤ 80
+   - 试玩链接：`https://edge-city-skyward-quests.vercel.app/`
+   - 原帖：https://x.com/timourxyz/status/2096379521926840339
+
+7. **Fluid — a little space to get lost** — [试玩](https://fluid-playground.lunar-labs-7954.chatgpt.site/) · [原帖](https://x.com/LukeYoungblood/status/2095974873772568778) · ❤ 57
+   - 试玩链接：`https://fluid-playground.lunar-labs-7954.chatgpt.site/`
+   - 原帖：https://x.com/LukeYoungblood/status/2095974873772568778
+
+8. **Eiffel — Light & Perspective** — [试玩](https://eiffel-tower-omega.vercel.app/) · [原帖](https://x.com/ayaboch/status/2096178212883587094) · ❤ 36
+   - 试玩链接：`https://eiffel-tower-omega.vercel.app/`
+   - 原帖：https://x.com/ayaboch/status/2096178212883587094
+
+9. **NAVI City — A living liquidity network** — [试玩](https://navi-emerald-city.elliscopef802081.chatgpt.site/) · [原帖](https://x.com/i/status/2096293372071747591) · ❤ 16
+   - 试玩链接：`https://navi-emerald-city.elliscopef802081.chatgpt.site/`
+   - 原帖：https://x.com/i/status/2096293372071747591
+
+10. **Manu.Vision — SP Edition** — [试玩](https://manu.vision/gb/) · [原帖](https://x.com/i/status/2095999334034690340) · ❤ 5
+   - 试玩链接：`https://manu.vision/gb/`
+   - 原帖：https://x.com/i/status/2095999334034690340
+
+11. **Wildwood — A little world of your own** — [试玩](https://krit22.github.io/browser-minecraft/) · [原帖](https://x.com/Krit12007/status/2096141849841029610) · ❤ 3
+   - 试玩链接：`https://krit22.github.io/browser-minecraft/`
+   - 原帖：https://x.com/Krit12007/status/2096141849841029610
+
+12. **Persepolis — An Ancient World, Rediscovered** — [试玩](https://persepolis-explorer.vercel.app) · [原帖](https://x.com/made_by_hossein/status/2096454262817534111) · ❤ 3
+   - 试玩链接：`https://persepolis-explorer.vercel.app`
+   - 原帖：https://x.com/made_by_hossein/status/2096454262817534111
+
+13. **Komorebi — Cat World** — [试玩](https://komorebi-neon.vercel.app/) · [原帖](https://x.com/thisjiro/status/2096008437343949039) · ❤ 2
+   - 试玩链接：`https://komorebi-neon.vercel.app/`
+   - 原帖：https://x.com/thisjiro/status/2096008437343949039
+
+14. **Ember Causeway** — [试玩](https://ember-causeway.s0673468.chatgpt.site) · [原帖](https://x.com/i/status/2096331530951925840) · ❤ 2
+   - 试玩链接：`https://ember-causeway.s0673468.chatgpt.site`
+   - 原帖：https://x.com/i/status/2096331530951925840
+
+15. **Bernabéu · Visita 3D** — [试玩](https://bernabeu-tres-d.antihero11.chatgpt.site/) · [原帖](https://x.com/davidcanci/status/2096201214178308538)
+   - 试玩链接：`https://bernabeu-tres-d.antihero11.chatgpt.site/`
+   - 原帖：https://x.com/davidcanci/status/2096201214178308538
+
+16. **Model X Studio** — [试玩](https://model-x-studio.vercel.app) · [原帖](https://x.com/grok/status/2096216661011439951)
+   - 试玩链接：`https://model-x-studio.vercel.app`
+   - 原帖：https://x.com/grok/status/2096216661011439951
+
+17. **mosswing-quiet-flight** — [试玩](https://mosswing-quiet-flight.jack-514.chatgpt.site) · [原帖](https://x.com/i/status/2096263516181123300)
+   - 试玩链接：`https://mosswing-quiet-flight.jack-514.chatgpt.site`
+   - 原帖：https://x.com/i/status/2096263516181123300
+
+18. **Craft3D — More than a mesh.** — [试玩](https://craft3d.app/gallery) · [原帖](https://x.com/Craft3dApp/status/2096281079510659558)
+   - 试玩链接：`https://craft3d.app/gallery`
+   - 原帖：https://x.com/Craft3dApp/status/2096281079510659558
+
+19. **无限庭院** — [试玩](https://infinite-garden.yelin8130.chatgpt.site/) · [原帖](https://x.com/i/status/2096317379034935342)
+   - 试玩链接：`https://infinite-garden.yelin8130.chatgpt.site/`
+   - 原帖：https://x.com/i/status/2096317379034935342
+
+20. **One fingerprint button. Six Astra reconstructions.** — [试玩](https://magbicaleman.github.io/minis/fingerprint-study/) · [原帖](https://x.com/magbicaleman/status/2096393243508314176)
+   - 试玩链接：`https://magbicaleman.github.io/minis/fingerprint-study/`
+   - 原帖：https://x.com/magbicaleman/status/2096393243508314176
+
+21. **Astra — a dream in orbit** — [试玩](https://astra-dream.nxank4.chatgpt.site) · [原帖](https://x.com/ReadEpoch/status/2096505770204655989)
+   - 试玩链接：`https://astra-dream.nxank4.chatgpt.site`
+   - 原帖：https://x.com/ReadEpoch/status/2096505770204655989
+
+22. **Peel — your new main squeezes** — [试玩](https://peel-squishies.vercel.app) · [原帖](https://x.com/Cryptosphere14/status/2096650466511737000)
+   - 试玩链接：`https://peel-squishies.vercel.app`
+   - 原帖：https://x.com/Cryptosphere14/status/2096650466511737000
+
+23. **KLIPZI CITY** — [试玩](https://klipzi-city.deadcoolapps.chatgpt.site) · [原帖](https://x.com/i/status/2096951400106209628)
+   - 试玩链接：`https://klipzi-city.deadcoolapps.chatgpt.site`
+   - 原帖：https://x.com/i/status/2096951400106209628
+
+## 工程 / 仿真
+
+1. **Topological Rubik’s Synchronizer** — [试玩](https://topological-rubik-synchronizer.ela-dev-27.chatgpt.site/) · [原帖](https://x.com/i/status/2096304797687099568) · ❤ 10
+   - 试玩链接：`https://topological-rubik-synchronizer.ela-dev-27.chatgpt.site/`
+   - 原帖：https://x.com/i/status/2096304797687099568
+
+2. **MECHANICA — W12 Engine Lab** — [试玩](https://mechanica-w12-engine-lab.nm-8755.chatgpt.site/) · [原帖](https://x.com/i/status/2096346500364206536) · ❤ 2
+   - 试玩链接：`https://mechanica-w12-engine-lab.nm-8755.chatgpt.site/`
+   - 原帖：https://x.com/i/status/2096346500364206536
+
+3. **RB19 交互仿真** — [试玩](https://rb19-engineering-lab.moraxc.chatgpt.site/)
+   - 试玩链接：`https://rb19-engineering-lab.moraxc.chatgpt.site/`
+
+4. **スマートトレイン学習サイト｜マトレイン** — [试玩](https://matrain-smarttrain-learning.mato111.chatgpt.site/learn/lab/tracks) · [原帖](https://x.com/shosuke_railfan/status/2095825467886784550)
+   - 试玩链接：`https://matrain-smarttrain-learning.mato111.chatgpt.site/learn/lab/tracks`
+   - 原帖：https://x.com/shosuke_railfan/status/2095825467886784550
+
+5. **Portal Viewer** — [试玩](https://portal-headview-3d.leo1973.chatgpt.site/) · [原帖](https://x.com/SexyTechNews/status/2095982479396188179)
+   - 试玩链接：`https://portal-headview-3d.leo1973.chatgpt.site/`
+   - 原帖：https://x.com/SexyTechNews/status/2095982479396188179
+
+6. **CARGO LAB · 컨테이너 적재 시뮬레이터** — [试玩](https://cargo-lab.nanggo.chatgpt.site) · [原帖](https://x.com/nanggos/status/2096582509035438291)
+   - 试玩链接：`https://cargo-lab.nanggo.chatgpt.site`
+   - 原帖：https://x.com/nanggos/status/2096582509035438291
+
+## 其他可玩 Demo
+
+1. **コヨーテの正直レビュー | ボドゲミツカル** — [试玩](https://bodoge-mitsukaru.t-natsu-6-17.chatgpt.site/games/coyote) · [原帖](https://x.com/BoardgameMt/status/2095829226650021941)
+   - 试玩链接：`https://bodoge-mitsukaru.t-natsu-6-17.chatgpt.site/games/coyote`
+   - 原帖：https://x.com/BoardgameMt/status/2095829226650021941
+
+2. **TOP KNOWLEDGE — 30問チャレンジ** — [试玩](https://top-call-game.taisyou2525.chatgpt.site) · [原帖](https://x.com/taisyou2525/status/2096206177982099727)
+   - 试玩链接：`https://top-call-game.taisyou2525.chatgpt.site`
+   - 原帖：https://x.com/taisyou2525/status/2096206177982099727
+
+3. **Hand Replayer — PokerStars** — [试玩](https://hand-replayer.marko99999.chatgpt.site) · [原帖](https://x.com/i/status/2096299597689753600)
+   - 试玩链接：`https://hand-replayer.marko99999.chatgpt.site`
+   - 原帖：https://x.com/i/status/2096299597689753600
+
+4. **Play GTA Vice City Online in Your Browser | Quenq GTA Vice City** — [试玩](https://quenq.com/apps/vice-city-online/) · [原帖](https://x.com/noman23761/status/2096554926965154037)
+   - 试玩链接：`https://quenq.com/apps/vice-city-online/`
+   - 原帖：https://x.com/noman23761/status/2096554926965154037
+
+## 说明
+
+- 来源主要为 X 公开帖与社区部署；版权归原作者。
+- 欢迎 PR 补充：**必须带可打开的试玩 URL**。
+- 相关：[GPT-6 Astra 国内使用指南](https://xianyu110.github.io/GPT6/) · [Codex 国内站](https://codex.maynorai.top/)

--- a/README.en.md
+++ b/README.en.md
@@ -33,6 +33,8 @@ The [CheerSelfAI collection](https://cheerselfai.com/usecase/gpt-6-astra) covers
 
 ## Contents
 
+- [Playable demos with trial links](PLAYABLE.md)
+
 - [Official Resources](#official-resources)
 - [Community Projects](#community-projects)
 - [Viral Demos](#viral-demos)
@@ -43,6 +45,11 @@ The [CheerSelfAI collection](https://cheerselfai.com/usecase/gpt-6-astra) covers
 - [Contributing](#contributing)
 
 ---
+
+
+## Playable demos (with trial links)
+
+See **[PLAYABLE.md](PLAYABLE.md)** for **78** verified browser playable demos. Every entry includes a full trial URL. Structured data: [`data/playable-demos.json`](data/playable-demos.json).
 
 ## Official Resources
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 精选 GPT-6 Astra 上线首周的高质量案例。每条都有作者署名和可点回的原帖，精选带预览图。这是合集，不是教程，也不是 OpenAI 官方仓库。
 
-GPT-6 Astra 于 2026-09-03 发布，9 月 4–5 日向 Plus / Pro / 企业用户铺开。现收 **16 条精选**，目录另约 39 条，合计约 55 条；另有 **4 个可直接体验的游戏/沙盒**、17 个社区项目、23 个病毒级 Demo、社区热帖与深度评测。本仓库另整理了 3three_AI X 线程中已核验的 **28 个独立案例（公开线程编号 1–30，其中 2 条重复）**，并收录 CheerSelfAI 的 **610 条公开案例**。全部来源按原帖 URL 去重后，网站展示 **667 个独立案例**。
+GPT-6 Astra 于 2026-09-03 发布，9 月 4–5 日向 Plus / Pro / 企业用户铺开。现收 **16 条精选**，目录另约 39 条，合计约 55 条；另有 **[78 个已核验可玩 Demo](PLAYABLE.md)**（每条附试玩链接）、17 个社区项目、23 个病毒级 Demo、社区热帖与深度评测。本仓库另整理了 3three_AI X 线程中已核验的 **28 个独立案例（公开线程编号 1–30，其中 2 条重复）**，并收录 CheerSelfAI 的 **610 条公开案例**。全部来源按原帖 URL 去重后，网站展示 **667 个独立案例**。
 
 配套入口： [GPT-6 Astra 国内使用指南](https://xianyu110.github.io/GPT6/) · [指南仓库](https://github.com/xianyu110/GPT6)
 
@@ -44,6 +44,8 @@ GPT-6 Astra 于 2026-09-03 发布，9 月 4–5 日向 Plus / Pro / 企业用户
 - [X 线程新增案例（去重 28 条）](#x-线程新增案例去重-28-条)
 - [收录说明](#收录说明)
 - [关于作者](#关于作者)
+- [可玩 Demo 合集（含试玩链接）](PLAYABLE.md)
+
 
 ## 精选 16
 
@@ -251,20 +253,23 @@ Computer Use 在 Canva 里实操组装画像。
 
 ## 可直接体验的游戏与沙盒
 
-以下 4 项来自 MartinDelophy 清单，保留试玩、源码和模型参与说明。
+完整清单（**78** 条，每条都附带试玩链接，已探活去重）见：**[PLAYABLE.md](PLAYABLE.md)** · 数据：[`data/playable-demos.json`](data/playable-demos.json)
 
-### 动作与街机
+下面是一组高信号速览（完整 URL，可直接点开）：
 
-- **[Mosswing](https://mosswing-quiet-flight.jack-514.chatgpt.site/)** — 3D 单键飞行，控制小翼穿越障碍间隙得分。作者：[Ayi1337](https://github.com/Ayi1337)。[One Shot Prompt 与记录](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/README.md) · [源码](https://github.com/Ayi1337/gpt6-astra-one-shot-games/tree/main/mosswing/src) · [单文件 HTML](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/mosswing/mosswing.html)。
-- **[Magic Carpet Wizard — A Thousand Skies](https://threapchills.github.io/MagicCarpetWizard/)** — 驾驶魔毯探索球形世界，穿环、施法并挑战 Boss。作者：[threapchills](https://github.com/threapchills)。桌面浏览器，需要 WebGL 2；[Three.js/Vite 源码](https://github.com/threapchills/MagicCarpetWizard)。
+1. **STORM RACE** — 试玩：https://storm-race.vercel.app · 原帖：https://x.com/BubuStd/status/2096587056755638553
+2. **Brandenburg Piano** — 试玩：https://brandenburg-piano.vercel.app/ · 原帖：https://x.com/DeryaTR_/status/2096090915790069857
+3. **Anatomy, unfolded.** — 试玩：https://anatomy-unfolded.brianp.chatgpt.site · 原帖：https://x.com/i/status/2096253408009486619
+4. **Daybreak 钢琴** — 试玩：https://daybreak-piano-film.lexn8.chatgpt.site/ · 原帖：https://x.com/LexnLin/status/2096166277849239804
+5. **Lumbridge 多人冒险** — 试玩：https://elderwood-realms.rohannvarma.chatgpt.site/ · 原帖：https://x.com/TheRohanVarma/status/2096744577332068549
+6. **Pelagic 海洋** — 试玩：https://pelagic-ocean.lexn8.chatgpt.site · 原帖：https://x.com/i/status/2096341945979383932
+7. **Moonlit Forge** — 试玩：https://moonlit-forge-studio.op7418.chatgpt.site · 原帖：https://x.com/op7418/status/2096205141187956887
+8. **Flora Brush** — 试玩：https://flora-brush.soumya-raj.chatgpt.site · 原帖：https://x.com/soumyadesign/status/2096974030104666568
+9. **INFINITUM** — 试玩：https://infinitum-game.vercel.app/ · 原帖：https://x.com/HpMani56403/status/2097188417709002822
+10. **Neural Sight FPS** — 试玩：https://monstercameron.github.io/Neural-Sight/ · 原帖：https://x.com/monstercameron/status/2097117275127959629
+11. **秦王拧螺丝** — 试玩：https://qin-imperial-factory-221.xyjwyf123.chatgpt.site/
+12. **超级马里奥·蘑菇王国** — 试玩：https://mushroom-arcade-0905.jumaomaomaoju.chatgpt.site/
 
-### 解谜与益智
-
-- **[瓜体实验室](https://melon-game.jack-514.chatgpt.site/)** — 半流体水果形变与碰撞的西瓜合成玩法。作者：[Ayi1337](https://github.com/Ayi1337)。[源码](https://github.com/Ayi1337/gpt6-astra-one-shot-games/tree/main/melon-lab/src) · [单文件 HTML](https://github.com/Ayi1337/gpt6-astra-one-shot-games/blob/main/melon-lab/%E7%93%9C%E4%BD%93%E5%AE%9E%E9%AA%8C%E5%AE%A4.html)。
-
-### 实验玩法
-
-- **[ORBITAL GARDEN · 轨道花园](https://orbital-garden.hp20230404.chatgpt.site)** — 48,000 颗光点在花、引力环和星系之间变形的粒子艺术沙盒。作者：[jackroc](https://github.com/jackroc)。支持 WebGL 的现代浏览器，免费、无需登录或 API Key；[创作记录](sources/martin/works/orbital-garden/README.md) · [源码与运行说明](sources/martin/works/orbital-garden/README.md) · [离线 HTML](sources/martin/works/orbital-garden/index.html) · [Prompt](sources/martin/works/orbital-garden/PROMPT.md)。
 
 ## 官方资源与模型信息
 

--- a/data/playable-demos.json
+++ b/data/playable-demos.json
@@ -1,0 +1,548 @@
+[
+  {
+    "title": "STORM RACE · Tsuchiya Workshop",
+    "demo_url": "https://storm-race.vercel.app",
+    "post_url": "https://x.com/BubuStd/status/2096587056755638553",
+    "likes": 4191,
+    "category": "竞速 / 驾驶"
+  },
+  {
+    "title": "Brandenburg Piano — J. S. Bach",
+    "demo_url": "https://brandenburg-piano.vercel.app/",
+    "post_url": "https://x.com/DeryaTR_/status/2096090915790069857",
+    "likes": 1531,
+    "category": "音乐 / 表演"
+  },
+  {
+    "title": "Anatomy, unfolded.",
+    "demo_url": "https://anatomy-unfolded.brianp.chatgpt.site",
+    "post_url": "https://x.com/i/status/2096253408009486619",
+    "likes": 1156,
+    "category": "教育 / 科普"
+  },
+  {
+    "title": "Daybreak · A piano performance",
+    "demo_url": "https://daybreak-piano-film.lexn8.chatgpt.site/",
+    "post_url": "https://x.com/LexnLin/status/2096166277849239804",
+    "likes": 1107,
+    "category": "音乐 / 表演"
+  },
+  {
+    "title": "Pelagic — Ocean & Atmosphere",
+    "demo_url": "https://pelagic-ocean.lexn8.chatgpt.site",
+    "post_url": "https://x.com/i/status/2096341945979383932",
+    "likes": 894,
+    "category": "3D 场景 / 氛围探索"
+  },
+  {
+    "title": "Lumbridge | Old-school multiplayer adventure",
+    "demo_url": "https://elderwood-realms.rohannvarma.chatgpt.site/",
+    "post_url": "https://x.com/TheRohanVarma/status/2096744577332068549",
+    "likes": 702,
+    "category": "联机 / 多人"
+  },
+  {
+    "title": "Moonlit Forge",
+    "demo_url": "https://moonlit-forge-studio.op7418.chatgpt.site",
+    "post_url": "https://x.com/op7418/status/2096205141187956887",
+    "likes": 580,
+    "category": "3D 场景 / 氛围探索"
+  },
+  {
+    "title": "Flora Brush",
+    "demo_url": "https://flora-brush.soumya-raj.chatgpt.site",
+    "post_url": "https://x.com/soumyadesign/status/2096974030104666568",
+    "likes": 567,
+    "category": "3D 场景 / 氛围探索"
+  },
+  {
+    "title": "Verdant Forest",
+    "demo_url": "https://verdant-forest.lexn8.chatgpt.site/",
+    "post_url": "https://x.com/i/status/2096367614805373200",
+    "likes": 326,
+    "category": "3D 场景 / 氛围探索"
+  },
+  {
+    "title": "Ashen Road — A journey to Ravenwatch",
+    "demo_url": "https://ashen-road.emad349385.chatgpt.site",
+    "post_url": "https://x.com/i/status/2096359789525639290",
+    "likes": 286,
+    "category": "竞速 / 驾驶"
+  },
+  {
+    "title": "Diamond Light",
+    "demo_url": "https://diamond-light.lexn8.chatgpt.site/",
+    "post_url": "https://x.com/LexnLin/status/2096103821470761033",
+    "likes": 113,
+    "category": "3D 场景 / 氛围探索"
+  },
+  {
+    "title": "Skyward: The Gathering",
+    "demo_url": "https://edge-city-skyward-quests.vercel.app/",
+    "post_url": "https://x.com/timourxyz/status/2096379521926840339",
+    "likes": 80,
+    "category": "3D 场景 / 氛围探索"
+  },
+  {
+    "title": "Fluid — a little space to get lost",
+    "demo_url": "https://fluid-playground.lunar-labs-7954.chatgpt.site/",
+    "post_url": "https://x.com/LukeYoungblood/status/2095974873772568778",
+    "likes": 57,
+    "category": "3D 场景 / 氛围探索"
+  },
+  {
+    "title": "Eiffel — Light & Perspective",
+    "demo_url": "https://eiffel-tower-omega.vercel.app/",
+    "post_url": "https://x.com/ayaboch/status/2096178212883587094",
+    "likes": 36,
+    "category": "3D 场景 / 氛围探索"
+  },
+  {
+    "title": "Tidal Rush — Paradise Grand Prix",
+    "demo_url": "https://tidal-rush-paradise-gp.skirano.chatgpt.site",
+    "post_url": "https://x.com/alexgetmancom/status/2095598460921614825",
+    "likes": 24,
+    "category": "竞速 / 驾驶"
+  },
+  {
+    "title": "ASTRA Arcade — Six original games",
+    "demo_url": "https://astra-arcade.antonioleivag.chatgpt.site",
+    "post_url": "https://x.com/antonioleivag/status/2096509898481651770",
+    "likes": 21,
+    "category": "街机 / 小游戏包"
+  },
+  {
+    "title": "NAVI City — A living liquidity network",
+    "demo_url": "https://navi-emerald-city.elliscopef802081.chatgpt.site/",
+    "post_url": "https://x.com/i/status/2096293372071747591",
+    "likes": 16,
+    "category": "3D 场景 / 氛围探索"
+  },
+  {
+    "title": "Blue Bajaj Rally 1.0.1 | Highland Loop",
+    "demo_url": "https://bajaj.guzo.tech/",
+    "post_url": "https://x.com/guzotech/status/2096209787864088638",
+    "likes": 12,
+    "category": "竞速 / 驾驶"
+  },
+  {
+    "title": "Topological Rubik’s Synchronizer",
+    "demo_url": "https://topological-rubik-synchronizer.ela-dev-27.chatgpt.site/",
+    "post_url": "https://x.com/i/status/2096304797687099568",
+    "likes": 10,
+    "category": "工程 / 仿真"
+  },
+  {
+    "title": "Manu.Vision — SP Edition",
+    "demo_url": "https://manu.vision/gb/",
+    "post_url": "https://x.com/i/status/2095999334034690340",
+    "likes": 5,
+    "category": "3D 场景 / 氛围探索"
+  },
+  {
+    "title": "LAST LIGHT — A Northline Story",
+    "demo_url": "https://last-light-northline.pages.dev",
+    "post_url": "https://x.com/md_taqui_imam/status/2096255279650517081",
+    "likes": 5,
+    "category": "射击 / 动作"
+  },
+  {
+    "title": "ASTEROIDS · Deepfield",
+    "demo_url": "https://asteroids-deepfield-cockpit.dan200200.chatgpt.site/",
+    "post_url": "https://x.com/DantesClown/status/2096085439052452064",
+    "likes": 3,
+    "category": "街机 / 小游戏包"
+  },
+  {
+    "title": "Wildwood — A little world of your own",
+    "demo_url": "https://krit22.github.io/browser-minecraft/",
+    "post_url": "https://x.com/Krit12007/status/2096141849841029610",
+    "likes": 3,
+    "category": "3D 场景 / 氛围探索"
+  },
+  {
+    "title": "Persepolis — An Ancient World, Rediscovered",
+    "demo_url": "https://persepolis-explorer.vercel.app",
+    "post_url": "https://x.com/made_by_hossein/status/2096454262817534111",
+    "likes": 3,
+    "category": "3D 场景 / 氛围探索"
+  },
+  {
+    "title": "Komorebi — Cat World",
+    "demo_url": "https://komorebi-neon.vercel.app/",
+    "post_url": "https://x.com/thisjiro/status/2096008437343949039",
+    "likes": 2,
+    "category": "3D 场景 / 氛围探索"
+  },
+  {
+    "title": "FANG · STARLIGHT RUN",
+    "demo_url": "https://fang-starlight-run.yosshy666.chatgpt.site/",
+    "post_url": "https://x.com/FANGsaikyou/status/2096192445667283326",
+    "likes": 2,
+    "category": "射击 / 动作"
+  },
+  {
+    "title": "TR-909 / Play it.",
+    "demo_url": "https://tr909play.budrose681.chatgpt.site",
+    "post_url": "https://x.com/i/status/2096288426115117350",
+    "likes": 2,
+    "category": "音乐 / 表演"
+  },
+  {
+    "title": "Ember Causeway",
+    "demo_url": "https://ember-causeway.s0673468.chatgpt.site",
+    "post_url": "https://x.com/i/status/2096331530951925840",
+    "likes": 2,
+    "category": "3D 场景 / 氛围探索"
+  },
+  {
+    "title": "MECHANICA — W12 Engine Lab",
+    "demo_url": "https://mechanica-w12-engine-lab.nm-8755.chatgpt.site/",
+    "post_url": "https://x.com/i/status/2096346500364206536",
+    "likes": 2,
+    "category": "工程 / 仿真"
+  },
+  {
+    "title": "LUMINA — Bloom of the Cosmos",
+    "demo_url": "https://lumina-cosmic-garden.vercel.app/",
+    "post_url": "https://x.com/i/status/2096348348773028115",
+    "likes": 2,
+    "category": "音乐 / 表演"
+  },
+  {
+    "title": "Play Games Built with GPT-6 Astra | Astragames",
+    "demo_url": "https://astragames.lol",
+    "post_url": "https://x.com/i/status/2096377756062027894",
+    "likes": 2,
+    "category": "街机 / 小游戏包"
+  },
+  {
+    "title": "Monopoly City — A board worth exploring",
+    "demo_url": "https://monopoly-city.eekosystems.chatgpt.site",
+    "post_url": "https://x.com/thomasunise/status/2097121832159609145",
+    "likes": 2,
+    "category": "经典复刻 / 知名玩法"
+  },
+  {
+    "title": "INFINITUM",
+    "demo_url": "https://infinitum-game.vercel.app/",
+    "post_url": "https://x.com/HpMani56403/status/2097188417709002822",
+    "likes": 2,
+    "category": "射击 / 动作"
+  },
+  {
+    "title": "THE ROAD DREAMS · 梦境之径",
+    "demo_url": "https://the-road-dreams.x2026283037.chatgpt.site",
+    "post_url": "https://x.com/i/status/2096313256264765440",
+    "likes": 1,
+    "category": "竞速 / 驾驶"
+  },
+  {
+    "title": "Zombie Escape Driver",
+    "demo_url": "https://zombiedriver.z.madsoftware.co",
+    "post_url": "https://x.com/MarcDagatan/status/2096667577326190631",
+    "likes": 1,
+    "category": "竞速 / 驾驶"
+  },
+  {
+    "title": "Astra Games — Built with GPT-6 Astra",
+    "demo_url": "https://astragames.aigccreative.com/en",
+    "post_url": "https://x.com/marindeloph/status/2096901528166793595",
+    "likes": 1,
+    "category": "街机 / 小游戏包"
+  },
+  {
+    "title": "秦王拧螺丝",
+    "demo_url": "https://qin-imperial-factory-221.xyjwyf123.chatgpt.site/",
+    "post_url": "",
+    "likes": 0,
+    "category": "模拟经营 / 策略"
+  },
+  {
+    "title": "瓜体实验室 / 合成大西瓜",
+    "demo_url": "https://melon-game.jack-514.chatgpt.site/",
+    "post_url": "",
+    "likes": 0,
+    "category": "经典复刻 / 知名玩法"
+  },
+  {
+    "title": "超级马里奥·蘑菇王国",
+    "demo_url": "https://mushroom-arcade-0905.jumaomaomaoju.chatgpt.site/",
+    "post_url": "",
+    "likes": 0,
+    "category": "经典复刻 / 知名玩法"
+  },
+  {
+    "title": "DUSTⅡ·沙漠行动",
+    "demo_url": "https://dust-ii-map.yelin8130.chatgpt.site/",
+    "post_url": "",
+    "likes": 0,
+    "category": "经典复刻 / 知名玩法"
+  },
+  {
+    "title": "水果忍者",
+    "demo_url": "https://fruit-ninja-dojo-20260905.yongqixue666.chatgpt.site/",
+    "post_url": "",
+    "likes": 0,
+    "category": "经典复刻 / 知名玩法"
+  },
+  {
+    "title": "COURTSIDE NBA2K",
+    "demo_url": "https://huhuhu.page.gd/COURTSIDE26.html",
+    "post_url": "",
+    "likes": 0,
+    "category": "竞速 / 驾驶"
+  },
+  {
+    "title": "Web 三国",
+    "demo_url": "https://sanguo-wind-cloud.amery2010.workers.dev/",
+    "post_url": "",
+    "likes": 0,
+    "category": "模拟经营 / 策略"
+  },
+  {
+    "title": "植物大战僵尸",
+    "demo_url": "https://seth-xh.github.io/pvz/",
+    "post_url": "",
+    "likes": 0,
+    "category": "经典复刻 / 知名玩法"
+  },
+  {
+    "title": "小丑牌 Balatro",
+    "demo_url": "https://balatro-v1-1.longyh2333521818.chatgpt.site/",
+    "post_url": "",
+    "likes": 0,
+    "category": "经典复刻 / 知名玩法"
+  },
+  {
+    "title": "RB19 交互仿真",
+    "demo_url": "https://rb19-engineering-lab.moraxc.chatgpt.site/",
+    "post_url": "",
+    "likes": 0,
+    "category": "工程 / 仿真"
+  },
+  {
+    "title": "Building Prism World ✳️ One idea, every feed.",
+    "demo_url": "https://prism-world-demo.krrish18.chatgpt.site",
+    "post_url": "https://x.com/krishnap1810/status/2095633183567945941",
+    "likes": 0,
+    "category": "射击 / 动作"
+  },
+  {
+    "title": "Kutular – Büyük Ödül Oyunu",
+    "demo_url": "https://kutular-oyunu.tuned-lion-2154.chatgpt.site",
+    "post_url": "https://x.com/nzmdgnc/status/2095803218135544027",
+    "likes": 0,
+    "category": "街机 / 小游戏包"
+  },
+  {
+    "title": "スマートトレイン学習サイト｜マトレイン",
+    "demo_url": "https://matrain-smarttrain-learning.mato111.chatgpt.site/learn/lab/tracks",
+    "post_url": "https://x.com/shosuke_railfan/status/2095825467886784550",
+    "likes": 0,
+    "category": "工程 / 仿真"
+  },
+  {
+    "title": "コヨーテの正直レビュー | ボドゲミツカル",
+    "demo_url": "https://bodoge-mitsukaru.t-natsu-6-17.chatgpt.site/games/coyote",
+    "post_url": "https://x.com/BoardgameMt/status/2095829226650021941",
+    "likes": 0,
+    "category": "其他可玩 Demo"
+  },
+  {
+    "title": "Gravitational Bloom",
+    "demo_url": "https://gravitational-bloom.opencrepaldi01.chatgpt.site",
+    "post_url": "https://x.com/BuilderGuest/status/2095946502988288116",
+    "likes": 0,
+    "category": "音乐 / 表演"
+  },
+  {
+    "title": "Portal Viewer",
+    "demo_url": "https://portal-headview-3d.leo1973.chatgpt.site/",
+    "post_url": "https://x.com/SexyTechNews/status/2095982479396188179",
+    "likes": 0,
+    "category": "工程 / 仿真"
+  },
+  {
+    "title": "PAC-MAN: Ghost Sharks — Bite back.",
+    "demo_url": "https://pacman.demyx.workers.dev/",
+    "post_url": "https://x.com/awildnpc/status/2096034211782099313",
+    "likes": 0,
+    "category": "经典复刻 / 知名玩法"
+  },
+  {
+    "title": "Little Kingdom — 작은 왕국 체스",
+    "demo_url": "https://little-kingdom-chess.echo3042.chatgpt.site",
+    "post_url": "https://x.com/echo3042/status/2096123409029886250",
+    "likes": 0,
+    "category": "模拟经营 / 策略"
+  },
+  {
+    "title": "Bernabéu · Visita 3D",
+    "demo_url": "https://bernabeu-tres-d.antihero11.chatgpt.site/",
+    "post_url": "https://x.com/davidcanci/status/2096201214178308538",
+    "likes": 0,
+    "category": "3D 场景 / 氛围探索"
+  },
+  {
+    "title": "TOP KNOWLEDGE — 30問チャレンジ",
+    "demo_url": "https://top-call-game.taisyou2525.chatgpt.site",
+    "post_url": "https://x.com/taisyou2525/status/2096206177982099727",
+    "likes": 0,
+    "category": "其他可玩 Demo"
+  },
+  {
+    "title": "Model X Studio",
+    "demo_url": "https://model-x-studio.vercel.app",
+    "post_url": "https://x.com/grok/status/2096216661011439951",
+    "likes": 0,
+    "category": "3D 场景 / 氛围探索"
+  },
+  {
+    "title": "mosswing-quiet-flight",
+    "demo_url": "https://mosswing-quiet-flight.jack-514.chatgpt.site",
+    "post_url": "https://x.com/i/status/2096263516181123300",
+    "likes": 0,
+    "category": "3D 场景 / 氛围探索"
+  },
+  {
+    "title": "Craft3D — More than a mesh.",
+    "demo_url": "https://craft3d.app/gallery",
+    "post_url": "https://x.com/Craft3dApp/status/2096281079510659558",
+    "likes": 0,
+    "category": "3D 场景 / 氛围探索"
+  },
+  {
+    "title": "Unstable Stables Online",
+    "demo_url": "https://unstable-stables-online.danielgui30.chatgpt.site/",
+    "post_url": "https://x.com/i/status/2096282857400652262",
+    "likes": 0,
+    "category": "联机 / 多人"
+  },
+  {
+    "title": "Piano libre — Piano virtuel",
+    "demo_url": "https://piano-libre-florian.flo111.chatgpt.site",
+    "post_url": "https://x.com/i/status/2096291074587197588",
+    "likes": 0,
+    "category": "音乐 / 表演"
+  },
+  {
+    "title": "Hand Replayer — PokerStars",
+    "demo_url": "https://hand-replayer.marko99999.chatgpt.site",
+    "post_url": "https://x.com/i/status/2096299597689753600",
+    "likes": 0,
+    "category": "其他可玩 Demo"
+  },
+  {
+    "title": "无限庭院",
+    "demo_url": "https://infinite-garden.yelin8130.chatgpt.site/",
+    "post_url": "https://x.com/i/status/2096317379034935342",
+    "likes": 0,
+    "category": "3D 场景 / 氛围探索"
+  },
+  {
+    "title": "AI Mini Racer - Astra Edition",
+    "demo_url": "https://ai-mini-racer.code-crunche-2353.chatgpt.site",
+    "post_url": "https://x.com/i/status/2096320362736714233",
+    "likes": 0,
+    "category": "竞速 / 驾驶"
+  },
+  {
+    "title": "Flappy Bird · Click to Fly",
+    "demo_url": "https://flappy-click-arcade-sept26.wesley-blomquist96.chatgpt.site/",
+    "post_url": "https://x.com/i/status/2096347522226684105",
+    "likes": 0,
+    "category": "经典复刻 / 知名玩法"
+  },
+  {
+    "title": "CYBER SUV · 互动设计展厅",
+    "demo_url": "https://cyber-suv-studio.banny911.chatgpt.site",
+    "post_url": "https://x.com/i/status/2096384563459334256",
+    "likes": 0,
+    "category": "竞速 / 驾驶"
+  },
+  {
+    "title": "One fingerprint button. Six Astra reconstructions.",
+    "demo_url": "https://magbicaleman.github.io/minis/fingerprint-study/",
+    "post_url": "https://x.com/magbicaleman/status/2096393243508314176",
+    "likes": 0,
+    "category": "3D 场景 / 氛围探索"
+  },
+  {
+    "title": "DUSKLINE — Canyon Circuit",
+    "demo_url": "https://duskline-canyon-run.abdulhadi-ai.chatgpt.site",
+    "post_url": "https://x.com/1banke/status/2096394721115390301",
+    "likes": 0,
+    "category": "竞速 / 驾驶"
+  },
+  {
+    "title": "Astra — a dream in orbit",
+    "demo_url": "https://astra-dream.nxank4.chatgpt.site",
+    "post_url": "https://x.com/ReadEpoch/status/2096505770204655989",
+    "likes": 0,
+    "category": "3D 场景 / 氛围探索"
+  },
+  {
+    "title": "Lantern Cove · The Borrowed Light",
+    "demo_url": "https://lantern-cove.akartit.chatgpt.site/",
+    "post_url": "https://x.com/akartit/status/2096520784449613981",
+    "likes": 0,
+    "category": "竞速 / 驾驶"
+  },
+  {
+    "title": "Play GTA Vice City Online in Your Browser | Quenq GTA Vice City",
+    "demo_url": "https://quenq.com/apps/vice-city-online/",
+    "post_url": "https://x.com/noman23761/status/2096554926965154037",
+    "likes": 0,
+    "category": "其他可玩 Demo"
+  },
+  {
+    "title": "CARGO LAB · 컨테이너 적재 시뮬레이터",
+    "demo_url": "https://cargo-lab.nanggo.chatgpt.site",
+    "post_url": "https://x.com/nanggos/status/2096582509035438291",
+    "likes": 0,
+    "category": "工程 / 仿真"
+  },
+  {
+    "title": "Peel — your new main squeezes",
+    "demo_url": "https://peel-squishies.vercel.app",
+    "post_url": "https://x.com/Cryptosphere14/status/2096650466511737000",
+    "likes": 0,
+    "category": "3D 场景 / 氛围探索"
+  },
+  {
+    "title": "Le Bon Rayon — Épicerie de quartier",
+    "demo_url": "https://le-bon-rayon.alexxondre.chatgpt.site",
+    "post_url": "https://x.com/i/status/2096652925527314554",
+    "likes": 0,
+    "category": "模拟经营 / 策略"
+  },
+  {
+    "title": "Geometry Dash · Fan Remix",
+    "demo_url": "https://geometry-dash-fan-nako.deif79.chatgpt.site",
+    "post_url": "https://x.com/17facet/status/2096856546512982486",
+    "likes": 0,
+    "category": "音乐 / 表演"
+  },
+  {
+    "title": "KLIPZI CITY",
+    "demo_url": "https://klipzi-city.deadcoolapps.chatgpt.site",
+    "post_url": "https://x.com/i/status/2096951400106209628",
+    "likes": 0,
+    "category": "3D 场景 / 氛围探索"
+  },
+  {
+    "title": "마성전설 — 메두사의 신전",
+    "demo_url": "https://knightmare-medusa-3d.robin-hwang.chatgpt.site/",
+    "post_url": "https://x.com/i/status/2096984386566815920",
+    "likes": 0,
+    "category": "射击 / 动作"
+  },
+  {
+    "title": "Neural Sight — Play the demo",
+    "demo_url": "https://monstercameron.github.io/Neural-Sight/",
+    "post_url": "https://x.com/monstercameron/status/2097117275127959629",
+    "likes": 0,
+    "category": "射击 / 动作"
+  }
+]


### PR DESCRIPTION
## Summary
- Add `PLAYABLE.md`: curated GPT-6 Astra browser playables, every entry with a full trial URL
- Add `data/playable-demos.json` for structured reuse
- Update `README.md` / `README.en.md` to link the catalog and show a high-signal Top 12

## Notes
- Links were HTTP-probed; temporary chatgpt.site deploys may still expire
- Dead / non-playable items were filtered before upload