### PR TITLE
Sync 2 new X playables: Butterball Run + Chao Party

### DIFF
--- a/PLAYABLE.md
+++ b/PLAYABLE.md
@@ -2,7 +2,7 @@
 
 > 社区 GPT-6 Astra 可玩网页 / 浏览器 Demo 精选。每条都附带**试玩链接**；有原帖则附原帖。链接已探活，临时部署仍可能失效。
 
-- 收录：**78** 条（已剔除失效、新闻软文、PDF/指南、作品集等非试玩项）
+- 收录：**80** 条（已剔除失效、新闻软文、PDF/指南、作品集等非试玩项）
 - 整理日期：2026-09-08
 - 维护：MaynorAI / [@xianyu110](https://github.com/xianyu110)
 
@@ -12,8 +12,8 @@
 - [竞速 / 驾驶](#竞速--驾驶) — 11
 - [射击 / 动作](#射击--动作) — 6
 - [模拟经营 / 策略](#模拟经营--策略) — 4
-- [联机 / 多人](#联机--多人) — 2
-- [街机 / 小游戏包](#街机--小游戏包) — 5
+- [联机 / 多人](#联机--多人) — 3
+- [街机 / 小游戏包](#街机--小游戏包) — 6
 - [音乐 / 表演](#音乐--表演) — 7
 - [教育 / 科普](#教育--科普) — 1
 - [3D 场景 / 氛围探索](#3D-场景--氛围探索) — 23
@@ -141,33 +141,41 @@
 
 ## 联机 / 多人
 
-1. **Lumbridge | Old-school multiplayer adventure** — [试玩](https://elderwood-realms.rohannvarma.chatgpt.site/) · [原帖](https://x.com/TheRohanVarma/status/2096744577332068549) · ❤ 702
+1. **Chao Garden / Chao Party — SA2 browser multiplayer** — [试玩](https://chao.party) · [原帖](https://x.com/h4nkdog/status/2097308970431987857) · ❤ 6
+   - 试玩链接：`https://chao.party`
+   - 原帖：https://x.com/h4nkdog/status/2097308970431987857
+
+2. **Lumbridge | Old-school multiplayer adventure** — [试玩](https://elderwood-realms.rohannvarma.chatgpt.site/) · [原帖](https://x.com/TheRohanVarma/status/2096744577332068549) · ❤ 702
    - 试玩链接：`https://elderwood-realms.rohannvarma.chatgpt.site/`
    - 原帖：https://x.com/TheRohanVarma/status/2096744577332068549
 
-2. **Unstable Stables Online** — [试玩](https://unstable-stables-online.danielgui30.chatgpt.site/) · [原帖](https://x.com/i/status/2096282857400652262)
+3. **Unstable Stables Online** — [试玩](https://unstable-stables-online.danielgui30.chatgpt.site/) · [原帖](https://x.com/i/status/2096282857400652262)
    - 试玩链接：`https://unstable-stables-online.danielgui30.chatgpt.site/`
    - 原帖：https://x.com/i/status/2096282857400652262
 
 ## 街机 / 小游戏包
 
-1. **ASTRA Arcade — Six original games** — [试玩](https://astra-arcade.antonioleivag.chatgpt.site) · [原帖](https://x.com/antonioleivag/status/2096509898481651770) · ❤ 21
+1. **Butterball Run — dinner-table three.js** — [试玩](https://butterball-run.jeraldine-t.chatgpt.site) · [原帖](https://x.com/SecretSeoul/status/2097315757931811081) · ❤ 1
+   - 试玩链接：`https://butterball-run.jeraldine-t.chatgpt.site`
+   - 原帖：https://x.com/SecretSeoul/status/2097315757931811081
+
+2. **ASTRA Arcade — Six original games** — [试玩](https://astra-arcade.antonioleivag.chatgpt.site) · [原帖](https://x.com/antonioleivag/status/2096509898481651770) · ❤ 21
    - 试玩链接：`https://astra-arcade.antonioleivag.chatgpt.site`
    - 原帖：https://x.com/antonioleivag/status/2096509898481651770
 
-2. **ASTEROIDS · Deepfield** — [试玩](https://asteroids-deepfield-cockpit.dan200200.chatgpt.site/) · [原帖](https://x.com/DantesClown/status/2096085439052452064) · ❤ 3
+3. **ASTEROIDS · Deepfield** — [试玩](https://asteroids-deepfield-cockpit.dan200200.chatgpt.site/) · [原帖](https://x.com/DantesClown/status/2096085439052452064) · ❤ 3
    - 试玩链接：`https://asteroids-deepfield-cockpit.dan200200.chatgpt.site/`
    - 原帖：https://x.com/DantesClown/status/2096085439052452064
 
-3. **Play Games Built with GPT-6 Astra | Astragames** — [试玩](https://astragames.lol) · [原帖](https://x.com/i/status/2096377756062027894) · ❤ 2
+4. **Play Games Built with GPT-6 Astra | Astragames** — [试玩](https://astragames.lol) · [原帖](https://x.com/i/status/2096377756062027894) · ❤ 2
    - 试玩链接：`https://astragames.lol`
    - 原帖：https://x.com/i/status/2096377756062027894
 
-4. **Astra Games — Built with GPT-6 Astra** — [试玩](https://astragames.aigccreative.com/en) · [原帖](https://x.com/marindeloph/status/2096901528166793595) · ❤ 1
+5. **Astra Games — Built with GPT-6 Astra** — [试玩](https://astragames.aigccreative.com/en) · [原帖](https://x.com/marindeloph/status/2096901528166793595) · ❤ 1
    - 试玩链接：`https://astragames.aigccreative.com/en`
    - 原帖：https://x.com/marindeloph/status/2096901528166793595
 
-5. **Kutular – Büyük Ödül Oyunu** — [试玩](https://kutular-oyunu.tuned-lion-2154.chatgpt.site) · [原帖](https://x.com/nzmdgnc/status/2095803218135544027)
+6. **Kutular – Büyük Ödül Oyunu** — [试玩](https://kutular-oyunu.tuned-lion-2154.chatgpt.site) · [原帖](https://x.com/nzmdgnc/status/2095803218135544027)
    - 试玩链接：`https://kutular-oyunu.tuned-lion-2154.chatgpt.site`
    - 原帖：https://x.com/nzmdgnc/status/2095803218135544027
 

--- a/data/playable-demos.json
+++ b/data/playable-demos.json
@@ -544,5 +544,19 @@
     "post_url": "https://x.com/monstercameron/status/2097117275127959629",
     "likes": 0,
     "category": "射击 / 动作"
+  },
+  {
+    "title": "Butterball Run — dinner-table three.js",
+    "demo_url": "https://butterball-run.jeraldine-t.chatgpt.site",
+    "post_url": "https://x.com/SecretSeoul/status/2097315757931811081",
+    "likes": 1,
+    "category": "街机 / 小游戏包"
+  },
+  {
+    "title": "Chao Garden / Chao Party — SA2 browser multiplayer",
+    "demo_url": "https://chao.party",
+    "post_url": "https://x.com/h4nkdog/status/2097308970431987857",
+    "likes": 6,
+    "category": "联机 / 多人"
   }
 ]

--- a/sources/martin/website/public/data/catalog-fallback.json
+++ b/sources/martin/website/public/data/catalog-fallback.json
@@ -1,1 +1,13424 @@
-{"works":[{"id":"work-ecf583f0ae9d3dd7","name":"Neural Sight — Play the demo","description":"可玩 Demo · 射击 / 动作","category":"game","sourceCategory":"PLAYABLE · 射击 / 动作","author":{"name":"monstercameron","url":"https://x.com/monstercameron"},"demoUrl":"https://monstercameron.github.io/Neural-Sight/","sourceUrl":"https://x.com/monstercameron/status/2097117275127959629","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2097116847938338816%2Fimg%2F5dg30Fk-R-cxdla3.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2097116847938338816%2Fimg%2F5dg30Fk-R-cxdla3.jpg","videoUrl":"https://video.twimg.com/amplify_video/2097116847938338816/vid/avc1/1496x720/Jrx90x0eKDOcvuu_.mp4?tag=14","sourceOrder":-925},{"id":"work-fb963c122de8725a","name":"마성전설 — 메두사의 신전","description":"可玩 Demo · 射击 / 动作","category":"game","sourceCategory":"PLAYABLE · 射击 / 动作","author":{"name":"community","url":null},"demoUrl":"https://knightmare-medusa-3d.robin-hwang.chatgpt.site/","sourceUrl":"https://x.com/i/status/2096984386566815920","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FHRn8LSjaIAE7X6V.jpg%3Fname%3Dorig","posterUrl":null,"videoUrl":null,"sourceOrder":-926},{"id":"work-956b39d586362f91","name":"KLIPZI CITY","description":"可玩 Demo · 3D 场景 / 氛围探索","category":"game","sourceCategory":"PLAYABLE · 3D 场景 / 氛围探索","author":{"name":"community","url":null},"demoUrl":"https://klipzi-city.deadcoolapps.chatgpt.site","sourceUrl":"https://x.com/i/status/2096951400106209628","repoUrl":null,"imageUrl":"https://klipzi-city.deadcoolapps.chatgpt.site/og.png","posterUrl":null,"videoUrl":null,"sourceOrder":-927},{"id":"work-d7cf1ece56fa1dce","name":"Geometry Dash · Fan Remix","description":"可玩 Demo · 音乐 / 表演","category":"game","sourceCategory":"PLAYABLE · 音乐 / 表演","author":{"name":"17facet","url":"https://x.com/17facet"},"demoUrl":"https://geometry-dash-fan-nako.deif79.chatgpt.site","sourceUrl":"https://x.com/17facet/status/2096856546512982486","repoUrl":null,"imageUrl":"/previews/playable-d7cf1ece56fa1dce.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-928},{"id":"work-ac1fe0d9a1514ef4","name":"Le Bon Rayon — Épicerie de quartier","description":"可玩 Demo · 模拟经营 / 策略","category":"game","sourceCategory":"PLAYABLE · 模拟经营 / 策略","author":{"name":"community","url":null},"demoUrl":"https://le-bon-rayon.alexxondre.chatgpt.site","sourceUrl":"https://x.com/i/status/2096652925527314554","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FHRjOicRbwAAN8mR.jpg%3Fname%3Dorig","posterUrl":null,"videoUrl":null,"sourceOrder":-929},{"id":"work-dbebeceae8db26c6","name":"Peel — your new main squeezes","description":"可玩 Demo · 3D 场景 / 氛围探索","category":"game","sourceCategory":"PLAYABLE · 3D 场景 / 氛围探索","author":{"name":"Cryptosphere14","url":"https://x.com/Cryptosphere14"},"demoUrl":"https://peel-squishies.vercel.app","sourceUrl":"https://x.com/Cryptosphere14/status/2096650466511737000","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096650421284622336%2Fimg%2FMeWgVi6MagsDyCyw.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096650421284622336%2Fimg%2FMeWgVi6MagsDyCyw.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096650421284622336/vid/avc1/1280x696/nB-YxUAF4_VG6UcT.mp4?tag=29","sourceOrder":-930},{"id":"work-d1923b6b876a5a84","name":"CARGO LAB · 컨테이너 적재 시뮬레이터","description":"可玩 Demo · 工程 / 仿真","category":"game","sourceCategory":"PLAYABLE · 工程 / 仿真","author":{"name":"nanggos","url":"https://x.com/nanggos"},"demoUrl":"https://cargo-lab.nanggo.chatgpt.site","sourceUrl":"https://x.com/nanggos/status/2096582509035438291","repoUrl":null,"imageUrl":"/previews/playable-d1923b6b876a5a84.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-931},{"id":"work-5b6ae5368e10b2b5","name":"Play GTA Vice City Online in Your Browser | Quenq GTA Vice City","description":"可玩 Demo · 其他可玩 Demo","category":"game","sourceCategory":"PLAYABLE · 其他可玩 Demo","author":{"name":"noman23761","url":"https://x.com/noman23761"},"demoUrl":"https://quenq.com/apps/vice-city-online/","sourceUrl":"https://x.com/noman23761/status/2096554926965154037","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096213774130929664%2Fimg%2F67kPAD2USOad5bI5.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096213774130929664%2Fimg%2F67kPAD2USOad5bI5.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096213774130929664/vid/avc1/1108x720/A48T1ScPXKwqXNPv.mp4?tag=14","sourceOrder":-932},{"id":"work-26a1853b26b7a5f4","name":"Lantern Cove · The Borrowed Light","description":"可玩 Demo · 竞速 / 驾驶","category":"game","sourceCategory":"PLAYABLE · 竞速 / 驾驶","author":{"name":"akartit","url":"https://x.com/akartit"},"demoUrl":"https://lantern-cove.akartit.chatgpt.site/","sourceUrl":"https://x.com/akartit/status/2096520784449613981","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096520419826171905%2Fimg%2FCVEMco_7vn0_hUZJ.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096520419826171905%2Fimg%2FCVEMco_7vn0_hUZJ.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096520419826171905/vid/avc1/1228x720/F27bpm5EaiLR_QjA.mp4?tag=14","sourceOrder":-933},{"id":"work-757d386b5d00cea0","name":"Astra — a dream in orbit","description":"可玩 Demo · 3D 场景 / 氛围探索","category":"game","sourceCategory":"PLAYABLE · 3D 场景 / 氛围探索","author":{"name":"ReadEpoch","url":"https://x.com/ReadEpoch"},"demoUrl":"https://astra-dream.nxank4.chatgpt.site","sourceUrl":"https://x.com/ReadEpoch/status/2096505770204655989","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096504176373342208%2Fimg%2FBMiiejnUj45pQg9Q.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096504176373342208%2Fimg%2FBMiiejnUj45pQg9Q.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096504176373342208/vid/avc1/1920x1080/M0Yjc7R4ME3IDZ_Z.mp4?tag=29","sourceOrder":-934},{"id":"work-d3a59b5cac45d79d","name":"DUSKLINE — Canyon Circuit","description":"可玩 Demo · 竞速 / 驾驶","category":"game","sourceCategory":"PLAYABLE · 竞速 / 驾驶","author":{"name":"1banke","url":"https://x.com/1banke"},"demoUrl":"https://duskline-canyon-run.abdulhadi-ai.chatgpt.site","sourceUrl":"https://x.com/1banke/status/2096394721115390301","repoUrl":null,"imageUrl":"/previews/playable-d3a59b5cac45d79d.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-935},{"id":"work-f130ed7649cf4ae1","name":"One fingerprint button. Six Astra reconstructions.","description":"可玩 Demo · 3D 场景 / 氛围探索","category":"game","sourceCategory":"PLAYABLE · 3D 场景 / 氛围探索","author":{"name":"magbicaleman","url":"https://x.com/magbicaleman"},"demoUrl":"https://magbicaleman.github.io/minis/fingerprint-study/","sourceUrl":"https://x.com/magbicaleman/status/2096393243508314176","repoUrl":null,"imageUrl":"https://magbicaleman.github.io/minis/fingerprint-study/share-card.png","posterUrl":null,"videoUrl":null,"sourceOrder":-936},{"id":"work-9437252d7ba5cfe6","name":"CYBER SUV · 互动设计展厅","description":"可玩 Demo · 竞速 / 驾驶","category":"game","sourceCategory":"PLAYABLE · 竞速 / 驾驶","author":{"name":"community","url":null},"demoUrl":"https://cyber-suv-studio.banny911.chatgpt.site","sourceUrl":"https://x.com/i/status/2096384563459334256","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096384440108978176%2Fimg%2Fq0zg3za_tA_N5Fqe.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096384440108978176%2Fimg%2Fq0zg3za_tA_N5Fqe.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096384440108978176/vid/avc1/1280x632/uQgR38HU_FmDzqXc.mp4?tag=29","sourceOrder":-937},{"id":"work-b8a54d3d86159543","name":"Flappy Bird · Click to Fly","description":"可玩 Demo · 经典复刻 / 知名玩法","category":"game","sourceCategory":"PLAYABLE · 经典复刻 / 知名玩法","author":{"name":"community","url":null},"demoUrl":"https://flappy-click-arcade-sept26.wesley-blomquist96.chatgpt.site/","sourceUrl":"https://x.com/i/status/2096347522226684105","repoUrl":null,"imageUrl":"/previews/playable-b8a54d3d86159543.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-938},{"id":"work-253644bed5090c38","name":"AI Mini Racer - Astra Edition","description":"可玩 Demo · 竞速 / 驾驶","category":"game","sourceCategory":"PLAYABLE · 竞速 / 驾驶","author":{"name":"community","url":null},"demoUrl":"https://ai-mini-racer.code-crunche-2353.chatgpt.site","sourceUrl":"https://x.com/i/status/2096320362736714233","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FHRegGMNWYAAMLxf.jpg%3Fname%3Dorig","posterUrl":null,"videoUrl":null,"sourceOrder":-939},{"id":"work-4dad37a3a6287ef1","name":"无限庭院","description":"可玩 Demo · 3D 场景 / 氛围探索","category":"game","sourceCategory":"PLAYABLE · 3D 场景 / 氛围探索","author":{"name":"community","url":null},"demoUrl":"https://infinite-garden.yelin8130.chatgpt.site/","sourceUrl":"https://x.com/i/status/2096317379034935342","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FHRedgffbYAArRrx.jpg%3Fname%3Dorig","posterUrl":null,"videoUrl":null,"sourceOrder":-940},{"id":"work-d7f15f9030c7e60b","name":"Hand Replayer — PokerStars","description":"可玩 Demo · 其他可玩 Demo","category":"game","sourceCategory":"PLAYABLE · 其他可玩 Demo","author":{"name":"community","url":null},"demoUrl":"https://hand-replayer.marko99999.chatgpt.site","sourceUrl":"https://x.com/i/status/2096299597689753600","repoUrl":null,"imageUrl":"/previews/playable-d7f15f9030c7e60b.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-941},{"id":"work-9b08aa629a627596","name":"Piano libre — Piano virtuel","description":"可玩 Demo · 音乐 / 表演","category":"game","sourceCategory":"PLAYABLE · 音乐 / 表演","author":{"name":"community","url":null},"demoUrl":"https://piano-libre-florian.flo111.chatgpt.site","sourceUrl":"https://x.com/i/status/2096291074587197588","repoUrl":null,"imageUrl":"/previews/playable-9b08aa629a627596.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-942},{"id":"work-d9b9ad6feb69ed48","name":"Unstable Stables Online","description":"可玩 Demo · 联机 / 多人","category":"game","sourceCategory":"PLAYABLE · 联机 / 多人","author":{"name":"community","url":null},"demoUrl":"https://unstable-stables-online.danielgui30.chatgpt.site/","sourceUrl":"https://x.com/i/status/2096282857400652262","repoUrl":null,"imageUrl":"/previews/playable-d9b9ad6feb69ed48.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-943},{"id":"work-1dfa79c2205bde9e","name":"Craft3D — More than a mesh.","description":"可玩 Demo · 3D 场景 / 氛围探索","category":"game","sourceCategory":"PLAYABLE · 3D 场景 / 氛围探索","author":{"name":"Craft3dApp","url":"https://x.com/Craft3dApp"},"demoUrl":"https://craft3d.app/gallery","sourceUrl":"https://x.com/Craft3dApp/status/2096281079510659558","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FHRd7bBZbkAAhIs6.jpg%3Fname%3Dorig","posterUrl":null,"videoUrl":null,"sourceOrder":-944},{"id":"work-7165f122f8556d68","name":"Model X Studio","description":"可玩 Demo · 3D 场景 / 氛围探索","category":"game","sourceCategory":"PLAYABLE · 3D 场景 / 氛围探索","author":{"name":"grok","url":"https://x.com/grok"},"demoUrl":"https://model-x-studio.vercel.app","sourceUrl":"https://x.com/grok/status/2096216661011439951","repoUrl":null,"imageUrl":"/previews/playable-7165f122f8556d68.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-945},{"id":"work-e583d20731ccd5ee","name":"TOP KNOWLEDGE — 30問チャレンジ","description":"可玩 Demo · 其他可玩 Demo","category":"game","sourceCategory":"PLAYABLE · 其他可玩 Demo","author":{"name":"taisyou2525","url":"https://x.com/taisyou2525"},"demoUrl":"https://top-call-game.taisyou2525.chatgpt.site","sourceUrl":"https://x.com/taisyou2525/status/2096206177982099727","repoUrl":null,"imageUrl":"/previews/playable-e583d20731ccd5ee.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-946},{"id":"work-77c3940254bab267","name":"Bernabéu · Visita 3D","description":"可玩 Demo · 3D 场景 / 氛围探索","category":"game","sourceCategory":"PLAYABLE · 3D 场景 / 氛围探索","author":{"name":"davidcanci","url":"https://x.com/davidcanci"},"demoUrl":"https://bernabeu-tres-d.antihero11.chatgpt.site/","sourceUrl":"https://x.com/davidcanci/status/2096201214178308538","repoUrl":null,"imageUrl":"/previews/playable-77c3940254bab267.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-947},{"id":"work-bf1462ef10c78211","name":"Little Kingdom — 작은 왕국 체스","description":"可玩 Demo · 模拟经营 / 策略","category":"game","sourceCategory":"PLAYABLE · 模拟经营 / 策略","author":{"name":"echo3042","url":"https://x.com/echo3042"},"demoUrl":"https://little-kingdom-chess.echo3042.chatgpt.site","sourceUrl":"https://x.com/echo3042/status/2096123409029886250","repoUrl":null,"imageUrl":"/previews/playable-bf1462ef10c78211.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-948},{"id":"work-29cd37b27d1039bb","name":"PAC-MAN: Ghost Sharks — Bite back.","description":"可玩 Demo · 经典复刻 / 知名玩法","category":"game","sourceCategory":"PLAYABLE · 经典复刻 / 知名玩法","author":{"name":"awildnpc","url":"https://x.com/awildnpc"},"demoUrl":"https://pacman.demyx.workers.dev/","sourceUrl":"https://x.com/awildnpc/status/2096034211782099313","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FHRabu3pbIAAEKy4.jpg%3Fname%3Dorig","posterUrl":null,"videoUrl":null,"sourceOrder":-949},{"id":"work-4fa359aa839d7e31","name":"Portal Viewer","description":"可玩 Demo · 工程 / 仿真","category":"game","sourceCategory":"PLAYABLE · 工程 / 仿真","author":{"name":"SexyTechNews","url":"https://x.com/SexyTechNews"},"demoUrl":"https://portal-headview-3d.leo1973.chatgpt.site/","sourceUrl":"https://x.com/SexyTechNews/status/2095982479396188179","repoUrl":null,"imageUrl":"https://portal-headview-3d.leo1973.chatgpt.site/og.png","posterUrl":null,"videoUrl":null,"sourceOrder":-950},{"id":"work-11d55bcd1d526f34","name":"Gravitational Bloom","description":"可玩 Demo · 音乐 / 表演","category":"game","sourceCategory":"PLAYABLE · 音乐 / 表演","author":{"name":"BuilderGuest","url":"https://x.com/BuilderGuest"},"demoUrl":"https://gravitational-bloom.opencrepaldi01.chatgpt.site","sourceUrl":"https://x.com/BuilderGuest/status/2095946502988288116","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FHRZMNxCWsAIMVDl.jpg%3Fname%3Dorig","posterUrl":null,"videoUrl":null,"sourceOrder":-951},{"id":"work-46edc130b4dbbe11","name":"コヨーテの正直レビュー | ボドゲミツカル","description":"可玩 Demo · 其他可玩 Demo","category":"game","sourceCategory":"PLAYABLE · 其他可玩 Demo","author":{"name":"BoardgameMt","url":"https://x.com/BoardgameMt"},"demoUrl":"https://bodoge-mitsukaru.t-natsu-6-17.chatgpt.site/games/coyote","sourceUrl":"https://x.com/BoardgameMt/status/2095829226650021941","repoUrl":null,"imageUrl":"https://image.rakuten.co.jp/boardgame-sugorokuya/cabinet/09766721/coyote.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-952},{"id":"work-a29273ac68e188b2","name":"スマートトレイン学習サイト｜マトレイン","description":"可玩 Demo · 工程 / 仿真","category":"game","sourceCategory":"PLAYABLE · 工程 / 仿真","author":{"name":"shosuke_railfan","url":"https://x.com/shosuke_railfan"},"demoUrl":"https://matrain-smarttrain-learning.mato111.chatgpt.site/learn/lab/tracks","sourceUrl":"https://x.com/shosuke_railfan/status/2095825467886784550","repoUrl":null,"imageUrl":"https://matrain-smarttrain-learning.mato111.chatgpt.site/og.png","posterUrl":null,"videoUrl":null,"sourceOrder":-953},{"id":"work-80b6a38ac6ed436d","name":"Kutular – Büyük Ödül Oyunu","description":"可玩 Demo · 街机 / 小游戏包","category":"game","sourceCategory":"PLAYABLE · 街机 / 小游戏包","author":{"name":"nzmdgnc","url":"https://x.com/nzmdgnc"},"demoUrl":"https://kutular-oyunu.tuned-lion-2154.chatgpt.site","sourceUrl":"https://x.com/nzmdgnc/status/2095803218135544027","repoUrl":null,"imageUrl":"/previews/playable-80b6a38ac6ed436d.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-954},{"id":"work-43c0770636615c0b","name":"Building Prism World ✳️ One idea, every feed.","description":"可玩 Demo · 射击 / 动作","category":"game","sourceCategory":"PLAYABLE · 射击 / 动作","author":{"name":"krishnap1810","url":"https://x.com/krishnap1810"},"demoUrl":"https://prism-world-demo.krrish18.chatgpt.site","sourceUrl":"https://x.com/krishnap1810/status/2095633183567945941","repoUrl":null,"imageUrl":"/previews/playable-43c0770636615c0b.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-955},{"id":"work-fa8bd141aa1127bb","name":"RB19 交互仿真","description":"可玩 Demo · 工程 / 仿真","category":"game","sourceCategory":"PLAYABLE · 工程 / 仿真","author":{"name":"community","url":null},"demoUrl":"https://rb19-engineering-lab.moraxc.chatgpt.site/","sourceUrl":"https://github.com/xianyu110/awesome-gpt-6-astra/blob/main/PLAYABLE.md","repoUrl":null,"imageUrl":"/previews/playable-fa8bd141aa1127bb.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-956},{"id":"work-87c25182141b18ac","name":"小丑牌 Balatro","description":"可玩 Demo · 经典复刻 / 知名玩法","category":"game","sourceCategory":"PLAYABLE · 经典复刻 / 知名玩法","author":{"name":"community","url":null},"demoUrl":"https://balatro-v1-1.longyh2333521818.chatgpt.site/","sourceUrl":"https://github.com/xianyu110/awesome-gpt-6-astra/blob/main/PLAYABLE.md","repoUrl":null,"imageUrl":"/previews/playable-87c25182141b18ac.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-957},{"id":"work-1e955ed7f9b2774e","name":"植物大战僵尸","description":"可玩 Demo · 经典复刻 / 知名玩法","category":"game","sourceCategory":"PLAYABLE · 经典复刻 / 知名玩法","author":{"name":"community","url":null},"demoUrl":"https://seth-xh.github.io/pvz/","sourceUrl":"https://github.com/xianyu110/awesome-gpt-6-astra/blob/main/PLAYABLE.md","repoUrl":null,"imageUrl":"/previews/playable-1e955ed7f9b2774e.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-958},{"id":"work-ced8b8f9a50c3f1e","name":"Web 三国","description":"可玩 Demo · 模拟经营 / 策略","category":"game","sourceCategory":"PLAYABLE · 模拟经营 / 策略","author":{"name":"community","url":null},"demoUrl":"https://sanguo-wind-cloud.amery2010.workers.dev/","sourceUrl":"https://github.com/xianyu110/awesome-gpt-6-astra/blob/main/PLAYABLE.md","repoUrl":null,"imageUrl":"/previews/playable-ced8b8f9a50c3f1e.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-959},{"id":"work-2402bddbcc779d41","name":"COURTSIDE NBA2K","description":"可玩 Demo · 竞速 / 驾驶","category":"game","sourceCategory":"PLAYABLE · 竞速 / 驾驶","author":{"name":"community","url":null},"demoUrl":"https://huhuhu.page.gd/COURTSIDE26.html","sourceUrl":"https://github.com/xianyu110/awesome-gpt-6-astra/blob/main/PLAYABLE.md","repoUrl":null,"imageUrl":"/previews/playable-2402bddbcc779d41.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-960},{"id":"work-4ed8bcd308c9e390","name":"水果忍者","description":"可玩 Demo · 经典复刻 / 知名玩法","category":"game","sourceCategory":"PLAYABLE · 经典复刻 / 知名玩法","author":{"name":"community","url":null},"demoUrl":"https://fruit-ninja-dojo-20260905.yongqixue666.chatgpt.site/","sourceUrl":"https://github.com/xianyu110/awesome-gpt-6-astra/blob/main/PLAYABLE.md","repoUrl":null,"imageUrl":"/previews/playable-4ed8bcd308c9e390.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-961},{"id":"work-a6f37a0568d91d09","name":"DUSTⅡ·沙漠行动","description":"可玩 Demo · 经典复刻 / 知名玩法","category":"game","sourceCategory":"PLAYABLE · 经典复刻 / 知名玩法","author":{"name":"community","url":null},"demoUrl":"https://dust-ii-map.yelin8130.chatgpt.site/","sourceUrl":"https://github.com/xianyu110/awesome-gpt-6-astra/blob/main/PLAYABLE.md","repoUrl":null,"imageUrl":"/previews/playable-a6f37a0568d91d09.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-962},{"id":"work-0c17c6584c5ee104","name":"超级马里奥·蘑菇王国","description":"可玩 Demo · 经典复刻 / 知名玩法","category":"game","sourceCategory":"PLAYABLE · 经典复刻 / 知名玩法","author":{"name":"community","url":null},"demoUrl":"https://mushroom-arcade-0905.jumaomaomaoju.chatgpt.site/","sourceUrl":"https://github.com/xianyu110/awesome-gpt-6-astra/blob/main/PLAYABLE.md","repoUrl":null,"imageUrl":"/previews/playable-0c17c6584c5ee104.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-963},{"id":"work-7bbcfad4ed46e813","name":"秦王拧螺丝","description":"可玩 Demo · 模拟经营 / 策略","category":"game","sourceCategory":"PLAYABLE · 模拟经营 / 策略","author":{"name":"community","url":null},"demoUrl":"https://qin-imperial-factory-221.xyjwyf123.chatgpt.site/","sourceUrl":"https://github.com/xianyu110/awesome-gpt-6-astra/blob/main/PLAYABLE.md","repoUrl":null,"imageUrl":"/previews/playable-7bbcfad4ed46e813.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-964},{"id":"work-e8981a90d32a1658","name":"Astra Games — Built with GPT-6 Astra","description":"可玩 Demo · 街机 / 小游戏包 · ❤ 1","category":"game","sourceCategory":"PLAYABLE · 街机 / 小游戏包","author":{"name":"marindeloph","url":"https://x.com/marindeloph"},"demoUrl":"https://astragames.aigccreative.com/en","sourceUrl":"https://x.com/marindeloph/status/2096901528166793595","repoUrl":null,"imageUrl":"https://astragames.aigccreative.com/en/opengraph-image?91623e0095e6cbc6","posterUrl":null,"videoUrl":null,"sourceOrder":-965},{"id":"work-95939deaa22eeb76","name":"Zombie Escape Driver","description":"可玩 Demo · 竞速 / 驾驶 · ❤ 1","category":"game","sourceCategory":"PLAYABLE · 竞速 / 驾驶","author":{"name":"MarcDagatan","url":"https://x.com/MarcDagatan"},"demoUrl":"https://zombiedriver.z.madsoftware.co","sourceUrl":"https://x.com/MarcDagatan/status/2096667577326190631","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096667418450178048%2Fimg%2F9CiA7EFs6BMR4M9-.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096667418450178048%2Fimg%2F9CiA7EFs6BMR4M9-.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096667418450178048/vid/avc1/1920x1080/ExYty11ZORmw9OGr.mp4?tag=29","sourceOrder":-966},{"id":"work-0321dc254e6ff5e5","name":"THE ROAD DREAMS · 梦境之径","description":"可玩 Demo · 竞速 / 驾驶 · ❤ 1","category":"game","sourceCategory":"PLAYABLE · 竞速 / 驾驶","author":{"name":"community","url":null},"demoUrl":"https://the-road-dreams.x2026283037.chatgpt.site","sourceUrl":"https://x.com/i/status/2096313256264765440","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FHReZtEXa4AAzRhC.jpg%3Fname%3Dorig","posterUrl":null,"videoUrl":null,"sourceOrder":-967},{"id":"work-8b75f1869923ec76","name":"INFINITUM","description":"可玩 Demo · 射击 / 动作 · ❤ 2","category":"game","sourceCategory":"PLAYABLE · 射击 / 动作","author":{"name":"HpMani56403","url":"https://x.com/HpMani56403"},"demoUrl":"https://infinitum-game.vercel.app/","sourceUrl":"https://x.com/HpMani56403/status/2097188417709002822","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2097187889839038464%2Fimg%2F0UtDGuMmz01etvXZ.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2097187889839038464%2Fimg%2F0UtDGuMmz01etvXZ.jpg","videoUrl":"https://video.twimg.com/amplify_video/2097187889839038464/vid/avc1/1280x720/0r3aT7HAdolRVuy0.mp4?tag=14","sourceOrder":-968},{"id":"work-bb6ece3340e276ae","name":"Monopoly City — A board worth exploring","description":"可玩 Demo · 经典复刻 / 知名玩法 · ❤ 2","category":"game","sourceCategory":"PLAYABLE · 经典复刻 / 知名玩法","author":{"name":"thomasunise","url":"https://x.com/thomasunise"},"demoUrl":"https://monopoly-city.eekosystems.chatgpt.site","sourceUrl":"https://x.com/thomasunise/status/2097121832159609145","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2097121658750578688%2Fimg%2FmhqTm-uIT4p0ITcm.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2097121658750578688%2Fimg%2FmhqTm-uIT4p0ITcm.jpg","videoUrl":"https://video.twimg.com/amplify_video/2097121658750578688/vid/avc1/1320x2868/u10kR29m5z80Tm2v.mp4?tag=29","sourceOrder":-969},{"id":"work-ae809a5a3b804233","name":"Play Games Built with GPT-6 Astra | Astragames","description":"可玩 Demo · 街机 / 小游戏包 · ❤ 2","category":"game","sourceCategory":"PLAYABLE · 街机 / 小游戏包","author":{"name":"community","url":null},"demoUrl":"https://astragames.lol","sourceUrl":"https://x.com/i/status/2096377756062027894","repoUrl":null,"imageUrl":"https://astragames.lol/astragames-og.png","posterUrl":null,"videoUrl":null,"sourceOrder":-970},{"id":"work-4360a63589232070","name":"LUMINA — Bloom of the Cosmos","description":"可玩 Demo · 音乐 / 表演 · ❤ 2","category":"game","sourceCategory":"PLAYABLE · 音乐 / 表演","author":{"name":"community","url":null},"demoUrl":"https://lumina-cosmic-garden.vercel.app/","sourceUrl":"https://x.com/i/status/2096348348773028115","repoUrl":null,"imageUrl":"/previews/playable-4360a63589232070.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-971},{"id":"work-9a90a285371c742d","name":"MECHANICA — W12 Engine Lab","description":"可玩 Demo · 工程 / 仿真 · ❤ 2","category":"game","sourceCategory":"PLAYABLE · 工程 / 仿真","author":{"name":"community","url":null},"demoUrl":"https://mechanica-w12-engine-lab.nm-8755.chatgpt.site/","sourceUrl":"https://x.com/i/status/2096346500364206536","repoUrl":null,"imageUrl":"/previews/playable-9a90a285371c742d.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-972},{"id":"work-3ddbcd74f6f4ab34","name":"Ember Causeway","description":"可玩 Demo · 3D 场景 / 氛围探索 · ❤ 2","category":"game","sourceCategory":"PLAYABLE · 3D 场景 / 氛围探索","author":{"name":"community","url":null},"demoUrl":"https://ember-causeway.s0673468.chatgpt.site","sourceUrl":"https://x.com/i/status/2096331530951925840","repoUrl":null,"imageUrl":"/previews/playable-3ddbcd74f6f4ab34.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-973},{"id":"work-058ae9b80c886e3d","name":"TR-909 / Play it.","description":"可玩 Demo · 音乐 / 表演 · ❤ 2","category":"game","sourceCategory":"PLAYABLE · 音乐 / 表演","author":{"name":"community","url":null},"demoUrl":"https://tr909play.budrose681.chatgpt.site","sourceUrl":"https://x.com/i/status/2096288426115117350","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096287504328806401%2Fimg%2Fi1HgkN_Aw8J_KmGX.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096287504328806401%2Fimg%2Fi1HgkN_Aw8J_KmGX.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096287504328806401/vid/avc1/1152x720/hy2_9SvJgplN_D0V.mp4?tag=14","sourceOrder":-974},{"id":"work-0a0eab83c010fbb8","name":"FANG · STARLIGHT RUN","description":"可玩 Demo · 射击 / 动作 · ❤ 2","category":"game","sourceCategory":"PLAYABLE · 射击 / 动作","author":{"name":"FANGsaikyou","url":"https://x.com/FANGsaikyou"},"demoUrl":"https://fang-starlight-run.yosshy666.chatgpt.site/","sourceUrl":"https://x.com/FANGsaikyou/status/2096192445667283326","repoUrl":null,"imageUrl":"/previews/playable-0a0eab83c010fbb8.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-975},{"id":"work-36d59fad1c131e78","name":"Komorebi — Cat World","description":"可玩 Demo · 3D 场景 / 氛围探索 · ❤ 2","category":"game","sourceCategory":"PLAYABLE · 3D 场景 / 氛围探索","author":{"name":"thisjiro","url":"https://x.com/thisjiro"},"demoUrl":"https://komorebi-neon.vercel.app/","sourceUrl":"https://x.com/thisjiro/status/2096008437343949039","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096008338798723073%2Fimg%2FOkShGTbe1emvhg8y.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096008338798723073%2Fimg%2FOkShGTbe1emvhg8y.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096008338798723073/vid/avc1/1280x720/nELz9fYgrC0RRmQp.mp4?tag=29","sourceOrder":-976},{"id":"work-730a5d657b6c5cdd","name":"Persepolis — An Ancient World, Rediscovered","description":"可玩 Demo · 3D 场景 / 氛围探索 · ❤ 3","category":"game","sourceCategory":"PLAYABLE · 3D 场景 / 氛围探索","author":{"name":"made_by_hossein","url":"https://x.com/made_by_hossein"},"demoUrl":"https://persepolis-explorer.vercel.app","sourceUrl":"https://x.com/made_by_hossein/status/2096454262817534111","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096453010536751104%2Fimg%2FLeLi8P1JX8Ulsk8L.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096453010536751104%2Fimg%2FLeLi8P1JX8Ulsk8L.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096453010536751104/vid/avc1/1330x720/nChgcBIaVJTeyjBA.mp4?tag=14","sourceOrder":-977},{"id":"work-3bd2a089eb538b6a","name":"Wildwood — A little world of your own","description":"可玩 Demo · 3D 场景 / 氛围探索 · ❤ 3","category":"game","sourceCategory":"PLAYABLE · 3D 场景 / 氛围探索","author":{"name":"Krit12007","url":"https://x.com/Krit12007"},"demoUrl":"https://krit22.github.io/browser-minecraft/","sourceUrl":"https://x.com/Krit12007/status/2096141849841029610","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096139552549474305%2Fimg%2FUWyg2tHmMkQ3Ya0m.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096139552549474305%2Fimg%2FUWyg2tHmMkQ3Ya0m.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096139552549474305/vid/avc1/1280x720/MutZIn29IlbKPBBe.mp4?tag=14","sourceOrder":-978},{"id":"work-aa8b54d05376d2d7","name":"ASTEROIDS · Deepfield","description":"可玩 Demo · 街机 / 小游戏包 · ❤ 3","category":"game","sourceCategory":"PLAYABLE · 街机 / 小游戏包","author":{"name":"DantesClown","url":"https://x.com/DantesClown"},"demoUrl":"https://asteroids-deepfield-cockpit.dan200200.chatgpt.site/","sourceUrl":"https://x.com/DantesClown/status/2096085439052452064","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FHRbI_KrbYAEhUTK.jpg%3Fname%3Dorig","posterUrl":null,"videoUrl":null,"sourceOrder":-979},{"id":"work-fc014391d199f861","name":"LAST LIGHT — A Northline Story","description":"可玩 Demo · 射击 / 动作 · ❤ 5","category":"game","sourceCategory":"PLAYABLE · 射击 / 动作","author":{"name":"md_taqui_imam","url":"https://x.com/md_taqui_imam"},"demoUrl":"https://last-light-northline.pages.dev","sourceUrl":"https://x.com/md_taqui_imam/status/2096255279650517081","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096255107558219776%2Fimg%2Fqs62uLoxv_Wp9nE-.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096255107558219776%2Fimg%2Fqs62uLoxv_Wp9nE-.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096255107558219776/vid/avc1/1208x718/votjNT5NgOfJWh6p.mp4?tag=29","sourceOrder":-980},{"id":"work-298cd080307f4f0e","name":"Manu.Vision — SP Edition","description":"可玩 Demo · 3D 场景 / 氛围探索 · ❤ 5","category":"game","sourceCategory":"PLAYABLE · 3D 场景 / 氛围探索","author":{"name":"community","url":null},"demoUrl":"https://manu.vision/gb/","sourceUrl":"https://x.com/i/status/2095999334034690340","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2095999255907303424%2Fimg%2FXtn5tOcG1h2NsrwI.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2095999255907303424%2Fimg%2FXtn5tOcG1h2NsrwI.jpg","videoUrl":"https://video.twimg.com/amplify_video/2095999255907303424/vid/avc1/632x1280/a5tSr3Y8aEPhx5WN.mp4?tag=29","sourceOrder":-981},{"id":"work-f804e082866c6e0c","name":"Topological Rubik’s Synchronizer","description":"可玩 Demo · 工程 / 仿真 · ❤ 10","category":"game","sourceCategory":"PLAYABLE · 工程 / 仿真","author":{"name":"community","url":null},"demoUrl":"https://topological-rubik-synchronizer.ela-dev-27.chatgpt.site/","sourceUrl":"https://x.com/i/status/2096304797687099568","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096304637750247424%2Fimg%2Fs4iUfX1zLvZXd-9y.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096304637750247424%2Fimg%2Fs4iUfX1zLvZXd-9y.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096304637750247424/vid/avc1/1280x804/1Hs1tbSkjRtMI-VF.mp4?tag=29","sourceOrder":-982},{"id":"work-6a7d687439bfc86c","name":"Blue Bajaj Rally 1.0.1 | Highland Loop","description":"可玩 Demo · 竞速 / 驾驶 · ❤ 12","category":"game","sourceCategory":"PLAYABLE · 竞速 / 驾驶","author":{"name":"guzotech","url":"https://x.com/guzotech"},"demoUrl":"https://bajaj.guzo.tech/","sourceUrl":"https://x.com/guzotech/status/2096209787864088638","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096209636680486912%2Fimg%2FZPUvTKGcVliwSgk0.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096209636680486912%2Fimg%2FZPUvTKGcVliwSgk0.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096209636680486912/vid/avc1/960x720/d48z8TTwTQvoWhc3.mp4?tag=14","sourceOrder":-983},{"id":"work-d01e6d454686c531","name":"NAVI City — A living liquidity network","description":"可玩 Demo · 3D 场景 / 氛围探索 · ❤ 16","category":"game","sourceCategory":"PLAYABLE · 3D 场景 / 氛围探索","author":{"name":"community","url":null},"demoUrl":"https://navi-emerald-city.elliscopef802081.chatgpt.site/","sourceUrl":"https://x.com/i/status/2096293372071747591","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096293071260684290%2Fimg%2FpyihlSyG0FHoPmCO.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096293071260684290%2Fimg%2FpyihlSyG0FHoPmCO.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096293071260684290/vid/avc1/1320x2330/DRV_cW4NfN1ZpC_X.mp4?tag=29","sourceOrder":-984},{"id":"work-1a24f09d60367192","name":"ASTRA Arcade — Six original games","description":"可玩 Demo · 街机 / 小游戏包 · ❤ 21","category":"game","sourceCategory":"PLAYABLE · 街机 / 小游戏包","author":{"name":"antonioleivag","url":"https://x.com/antonioleivag"},"demoUrl":"https://astra-arcade.antonioleivag.chatgpt.site","sourceUrl":"https://x.com/antonioleivag/status/2096509898481651770","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096505353705795586%2Fimg%2FHcaXk1TLXBMsIv8e.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096505353705795586%2Fimg%2FHcaXk1TLXBMsIv8e.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096505353705795586/vid/avc1/1280x810/MYzPxqYK_hmABgoz.mp4?tag=29","sourceOrder":-985},{"id":"work-4c139268a2a87531","name":"Tidal Rush — Paradise Grand Prix","description":"可玩 Demo · 竞速 / 驾驶 · ❤ 24","category":"game","sourceCategory":"PLAYABLE · 竞速 / 驾驶","author":{"name":"alexgetmancom","url":"https://x.com/alexgetmancom"},"demoUrl":"https://tidal-rush-paradise-gp.skirano.chatgpt.site","sourceUrl":"https://x.com/alexgetmancom/status/2095598460921614825","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FHRUPSgYawAAPeR1.jpg%3Fname%3Dorig","posterUrl":null,"videoUrl":null,"sourceOrder":-986},{"id":"work-c45391db51a65a85","name":"Eiffel — Light & Perspective","description":"可玩 Demo · 3D 场景 / 氛围探索 · ❤ 36","category":"game","sourceCategory":"PLAYABLE · 3D 场景 / 氛围探索","author":{"name":"ayaboch","url":"https://x.com/ayaboch"},"demoUrl":"https://eiffel-tower-omega.vercel.app/","sourceUrl":"https://x.com/ayaboch/status/2096178212883587094","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096176537926012934%2Fimg%2FM-AJoz-Wx60OTtyB.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096176537926012934%2Fimg%2FM-AJoz-Wx60OTtyB.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096176537926012934/vid/avc1/1956x1080/rRgKQ56A9Y-ZKx-H.mp4?tag=29","sourceOrder":-987},{"id":"work-7f7c2adf0265cb0b","name":"Fluid — a little space to get lost","description":"可玩 Demo · 3D 场景 / 氛围探索 · ❤ 57","category":"game","sourceCategory":"PLAYABLE · 3D 场景 / 氛围探索","author":{"name":"LukeYoungblood","url":"https://x.com/LukeYoungblood"},"demoUrl":"https://fluid-playground.lunar-labs-7954.chatgpt.site/","sourceUrl":"https://x.com/LukeYoungblood/status/2095974873772568778","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2095974217414291456%2Fimg%2FXsDwEfvUxWChZBgZ.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2095974217414291456%2Fimg%2FXsDwEfvUxWChZBgZ.jpg","videoUrl":"https://video.twimg.com/amplify_video/2095974217414291456/vid/avc1/2160x2274/3tgOkRubJlyKAFfn.mp4?tag=29","sourceOrder":-988},{"id":"work-197a0c9ae8686fdc","name":"Skyward: The Gathering","description":"可玩 Demo · 3D 场景 / 氛围探索 · ❤ 80","category":"game","sourceCategory":"PLAYABLE · 3D 场景 / 氛围探索","author":{"name":"timourxyz","url":"https://x.com/timourxyz"},"demoUrl":"https://edge-city-skyward-quests.vercel.app/","sourceUrl":"https://x.com/timourxyz/status/2096379521926840339","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096378530619936768%2Fimg%2FXI4U8_pqXPcKqsiu.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096378530619936768%2Fimg%2FXI4U8_pqXPcKqsiu.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096378530619936768/vid/avc1/1716x1288/mhRR914ueuZO_i3m.mp4?tag=29","sourceOrder":-989},{"id":"work-cb353236f8be8396","name":"Diamond Light","description":"可玩 Demo · 3D 场景 / 氛围探索 · ❤ 113","category":"game","sourceCategory":"PLAYABLE · 3D 场景 / 氛围探索","author":{"name":"LexnLin","url":"https://x.com/LexnLin"},"demoUrl":"https://diamond-light.lexn8.chatgpt.site/","sourceUrl":"https://x.com/LexnLin/status/2096103821470761033","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FHRbbRCfbkAAAv9D.jpg%3Fname%3Dorig","posterUrl":null,"videoUrl":null,"sourceOrder":-990},{"id":"work-f11beb9fb3b8b4d9","name":"Ashen Road — A journey to Ravenwatch","description":"可玩 Demo · 竞速 / 驾驶 · ❤ 286","category":"game","sourceCategory":"PLAYABLE · 竞速 / 驾驶","author":{"name":"community","url":null},"demoUrl":"https://ashen-road.emad349385.chatgpt.site","sourceUrl":"https://x.com/i/status/2096359789525639290","repoUrl":null,"imageUrl":"/previews/playable-f11beb9fb3b8b4d9.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":-991},{"id":"work-14b4be584f4f33fc","name":"Verdant Forest","description":"可玩 Demo · 3D 场景 / 氛围探索 · ❤ 326","category":"game","sourceCategory":"PLAYABLE · 3D 场景 / 氛围探索","author":{"name":"community","url":null},"demoUrl":"https://verdant-forest.lexn8.chatgpt.site/","sourceUrl":"https://x.com/i/status/2096367614805373200","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096262956774490112%2Fimg%2F9UcY8pI6LuZ8v2c_.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096262956774490112%2Fimg%2F9UcY8pI6LuZ8v2c_.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096262956774490112/vid/avc1/1440x900/vWZ5XdJsINV2T-mD.mp4?tag=29","sourceOrder":-992},{"id":"work-5c901aeba8108376","name":"Flora Brush","description":"可玩 Demo · 3D 场景 / 氛围探索 · ❤ 567","category":"game","sourceCategory":"PLAYABLE · 3D 场景 / 氛围探索","author":{"name":"soumyadesign","url":"https://x.com/soumyadesign"},"demoUrl":"https://flora-brush.soumya-raj.chatgpt.site","sourceUrl":"https://x.com/soumyadesign/status/2096974030104666568","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096973854774312960%2Fimg%2F6pikJwMO3pbAfrVo.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096973854774312960%2Fimg%2F6pikJwMO3pbAfrVo.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096973854774312960/vid/avc1/2600x2160/RqjVYDHxASbKNOIR.mp4?tag=29","sourceOrder":-993},{"id":"work-e57cb552d2209a34","name":"Moonlit Forge","description":"可玩 Demo · 3D 场景 / 氛围探索 · ❤ 580","category":"game","sourceCategory":"PLAYABLE · 3D 场景 / 氛围探索","author":{"name":"op7418","url":"https://x.com/op7418"},"demoUrl":"https://moonlit-forge-studio.op7418.chatgpt.site","sourceUrl":"https://x.com/op7418/status/2096205141187956887","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096204966549663744%2Fimg%2FUzdz8t2v75PQhifx.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096204966549663744%2Fimg%2FUzdz8t2v75PQhifx.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096204966549663744/vid/avc1/1794x1080/zr9d2OPCL3gDAEjD.mp4?tag=29","sourceOrder":-994},{"id":"work-722dc1a5f8ce1737","name":"Lumbridge | Old-school multiplayer adventure","description":"可玩 Demo · 联机 / 多人 · ❤ 702","category":"game","sourceCategory":"PLAYABLE · 联机 / 多人","author":{"name":"TheRohanVarma","url":"https://x.com/TheRohanVarma"},"demoUrl":"https://elderwood-realms.rohannvarma.chatgpt.site/","sourceUrl":"https://x.com/TheRohanVarma/status/2096744577332068549","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096743123301117952%2Fimg%2FW_anzk30lopccNnJ.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096743123301117952%2Fimg%2FW_anzk30lopccNnJ.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096743123301117952/vid/avc1/1568x1200/ez652NHj1oUrNftW.mp4?tag=29","sourceOrder":-995},{"id":"work-431d6e9afe8ca660","name":"Pelagic — Ocean & Atmosphere","description":"可玩 Demo · 3D 场景 / 氛围探索 · ❤ 894","category":"game","sourceCategory":"PLAYABLE · 3D 场景 / 氛围探索","author":{"name":"community","url":null},"demoUrl":"https://pelagic-ocean.lexn8.chatgpt.site","sourceUrl":"https://x.com/i/status/2096341945979383932","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096341910197846016%2Fimg%2F8pK3VK4IcgfWtEob.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096341910197846016%2Fimg%2F8pK3VK4IcgfWtEob.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096341910197846016/vid/avc1/854x480/_-aKpcLmeLPIGmeC.mp4?tag=29","sourceOrder":-996},{"id":"work-c9fc9328dcc828ae","name":"Daybreak · A piano performance","description":"可玩 Demo · 音乐 / 表演 · ❤ 1107","category":"game","sourceCategory":"PLAYABLE · 音乐 / 表演","author":{"name":"LexnLin","url":"https://x.com/LexnLin"},"demoUrl":"https://daybreak-piano-film.lexn8.chatgpt.site/","sourceUrl":"https://x.com/LexnLin/status/2096166277849239804","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096165676897779712%2Fimg%2F2t9Gk4pv4bmd7QOW.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096165676897779712%2Fimg%2F2t9Gk4pv4bmd7QOW.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096165676897779712/vid/avc1/1920x1080/wOq4V1m8aSu6CBr8.mp4?tag=29","sourceOrder":-997},{"id":"work-58161a636c39b27d","name":"Anatomy, unfolded.","description":"可玩 Demo · 教育 / 科普 · ❤ 1156","category":"game","sourceCategory":"PLAYABLE · 教育 / 科普","author":{"name":"community","url":null},"demoUrl":"https://anatomy-unfolded.brianp.chatgpt.site","sourceUrl":"https://x.com/i/status/2096253408009486619","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096253095894528000%2Fimg%2FVdx2NZnXEqoaOX5R.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096253095894528000%2Fimg%2FVdx2NZnXEqoaOX5R.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096253095894528000/vid/avc1/2880x2160/WtOqB5aRnUN3fl6C.mp4?tag=29","sourceOrder":-998},{"id":"work-788e9a167d0ea571","name":"Brandenburg Piano — J. S. Bach","description":"可玩 Demo · 音乐 / 表演 · ❤ 1531","category":"game","sourceCategory":"PLAYABLE · 音乐 / 表演","author":{"name":"DeryaTR_","url":"https://x.com/DeryaTR_"},"demoUrl":"https://brandenburg-piano.vercel.app/","sourceUrl":"https://x.com/DeryaTR_/status/2096090915790069857","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096090005085077511%2Fimg%2F36OGv0ZYv9Ap7Xgc.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096090005085077511%2Fimg%2F36OGv0ZYv9Ap7Xgc.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096090005085077511/vid/avc1/1920x1080/HZQT7bedn-2Pj3Dw.mp4?tag=29","sourceOrder":-999},{"id":"work-325a78cdc3209d88","name":"STORM RACE · Tsuchiya Workshop","description":"可玩 Demo · 竞速 / 驾驶 · ❤ 4191","category":"game","sourceCategory":"PLAYABLE · 竞速 / 驾驶","author":{"name":"BubuStd","url":"https://x.com/BubuStd"},"demoUrl":"https://storm-race.vercel.app","sourceUrl":"https://x.com/BubuStd/status/2096587056755638553","repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096586972567646209%2Fimg%2FxK4KpEljcPLZORCx.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096586972567646209%2Fimg%2FxK4KpEljcPLZORCx.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096586972567646209/vid/avc1/1920x1080/RabBv3UNIGc7UmTt.mp4?tag=29","sourceOrder":-1000},{"id":"work-6f19f9c3e72c1609","name":"Afterlight · 45 分钟 3D 游戏","description":"概念图对标到 60fps 的 one-shot 原型。","category":"experiment","sourceCategory":"01. Afterlight · 45 分钟 3D 游戏","author":{"name":"Anshu","url":"https://x.com/anshuc"},"demoUrl":"https://x.com/anshuc/status/2096008083826725132","sourceUrl":"https://x.com/3three_AI/status/2096483429437354372","repoUrl":null,"imageUrl":"/previews/x-thread-05.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":0},{"id":"work-960682b876a67556","name":"运行时生成的活火车","description":"没有模型文件，TypeScript / Three.js 几何函数驱动轮子和爆炸。","category":"experiment","sourceCategory":"02. 运行时生成的活火车","author":{"name":"Tom Krcha","url":"https://x.com/tomkrcha"},"demoUrl":"https://x.com/tomkrcha/status/2096082580554777041","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-183.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":1},{"id":"work-4168b43897d5a4c4","name":"梵高小镇 + Gogh Strike","description":"6 幅梵高画合成可漫游小镇，后又做成 5v5 射击。","category":"other","sourceCategory":"03. 梵高小镇 + Gogh Strike","author":{"name":"Peter Gostev","url":"https://x.com/petergostev"},"demoUrl":"https://x.com/petergostev/status/2095776685807346105","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-014.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":2},{"id":"work-0ed5012771a36f16","name":"15 分钟 3D iPod","description":"Blender 做机身，用原版 iPod 交互浏览 Codex threads。","category":"experiment","sourceCategory":"04. 15 分钟 3D iPod","author":{"name":"Pietro Schirano","url":"https://x.com/skirano"},"demoUrl":"https://x.com/skirano/status/2095648379455861054","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":3},{"id":"work-740caf4780fbb968","name":"Fall Guys 到 5 天 SimCity","description":"早期最完整长线程之一，含游戏、世界与浏览器控制。","category":"game","sourceCategory":"05. Fall Guys 到 5 天 SimCity","author":{"name":"Matthew Berman","url":"https://x.com/MatthewBerman"},"demoUrl":"https://x.com/MatthewBerman/status/2095595892464333065","sourceUrl":null,"repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2095578042618052608%2Fimg%2FRyBElYNzg3S7Efc4.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2095578042618052608%2Fimg%2FRyBElYNzg3S7Efc4.jpg","videoUrl":"https://video.twimg.com/amplify_video/2095578042618052608/vid/avc1/1280x720/_EOXtMDQrQABTtHy.mp4?tag=29","sourceOrder":4},{"id":"work-92af8aece28bd61f","name":"10 分钟 Blender 甜甜圈","description":"新手课通常 1–2 小时的模型，约 10 分钟出可改工程文件。","category":"experiment","sourceCategory":"06. 10 分钟 Blender 甜甜圈","author":{"name":"歸藏","url":"https://x.com/op7418"},"demoUrl":"https://x.com/op7418/status/2096065904828416286","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":5},{"id":"work-29c6aba6030f419b","name":"Zillow 房源图 → 3D 宣传片","description":"真房源照片建出可漫游房屋。作者自认细节有误。","category":"experiment","sourceCategory":"07. Zillow 房源图 → 3D 宣传片","author":{"name":"Yunfan Ye","url":"https://x.com/realYunfanYe"},"demoUrl":"https://x.com/realYunfanYe/status/2095612137582526615","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":6},{"id":"work-d673e57297fb526d","name":"Apple Notes 里画自像","description":"不是生成一张图，是在 Mac 上打开 Notes 一笔一笔画。","category":"other","sourceCategory":"08. Apple Notes 里画自像","author":{"name":"Federico Viticci","url":"https://x.com/viticci"},"demoUrl":"https://x.com/viticci/status/2096025249582039180","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":7},{"id":"work-e90553f09ef19acd","name":"只看屏幕通关《火红》","description":"Astra 18h12m；Sol 96h35m；GPT-5.5 跑 218h 未完。","category":"other","sourceCategory":"09. 只看屏幕通关《火红》","author":{"name":"Clad3815","url":"https://x.com/Clad3815"},"demoUrl":"https://x.com/Clad3815/status/2095596013168050551","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":8},{"id":"work-adf06a77853769b8","name":"11 分钟巴赫钢琴","description":"可弹虚拟钢琴，内置全部 6 首《勃兰登堡协奏曲》。","category":"other","sourceCategory":"10. 11 分钟巴赫钢琴","author":{"name":"Derya Unutmaz","url":"https://x.com/DeryaTR_"},"demoUrl":"https://x.com/DeryaTR_/status/2096090915790069857","sourceUrl":"https://x.com/3three_AI/status/2096483681942872449","repoUrl":null,"imageUrl":"/previews/x-thread-25.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":9},{"id":"work-62b8c5afbee9edce","name":"机械臂 40% → 95%","description":"真实抓取对照 Fable 5.1，输出 token 少 6.2 倍。","category":"other","sourceCategory":"11. 机械臂 40% → 95%","author":{"name":"Jay Chooi","url":"https://x.com/chooi_jeq"},"demoUrl":"https://x.com/chooi_jeq/status/2096064315115839904","sourceUrl":"https://x.com/3three_AI/status/2096483473490067788","repoUrl":null,"imageUrl":"/previews/x-thread-21.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":10},{"id":"work-595b5c450c64a100","name":"Canva 里一块块拼肖像","description":"Computer Use 在 Canva 里实操组装画像。","category":"other","sourceCategory":"12. Canva 里一块块拼肖像","author":{"name":"iam_zachi","url":"https://x.com/iam_zachi"},"demoUrl":"https://x.com/iam_zachi/status/2095992132620136677","sourceUrl":"https://x.com/3three_AI/status/2096483419127762986","repoUrl":null,"imageUrl":"/previews/x-thread-01.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":11},{"id":"work-fe2ddca89a1193f4","name":"语音通关《杀戮尖塔 2》","description":"没写复杂 prompt，模型自学键位打了 48 层。","category":"experiment","sourceCategory":"13. 语音通关《杀戮尖塔 2》","author":{"name":"paulwei","url":"https://x.com/coolish"},"demoUrl":"https://x.com/coolish/status/2096195104809873710","sourceUrl":"https://x.com/3three_AI/status/2096483478556782739","repoUrl":null,"imageUrl":"/previews/x-thread-23.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":12},{"id":"work-a5686a9aa8ea7b7d","name":"Godot 索尼克 Max vs Medium","description":"同一提示词：53 分钟 / 4% vs 25 分钟 / 1%。","category":"other","sourceCategory":"14. Godot 索尼克 Max vs Medium","author":{"name":"AiBattle","url":"https://x.com/AiBattle_"},"demoUrl":"https://x.com/AiBattle_/status/2095994051354919049","sourceUrl":"https://x.com/3three_AI/status/2096483807767781453","repoUrl":null,"imageUrl":"/previews/x-thread-27.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":13},{"id":"work-11aa79598c612921","name":"官方 KiCad / UE5 演示","description":"原理图到 PCB，Blender 房子导入 Unreal Engine 5。","category":"other","sourceCategory":"15. 官方 KiCad / UE5 演示","author":{"name":"OpenAI","url":"https://x.com/OpenAI"},"demoUrl":"https://x.com/OpenAI/status/2095595741528125780","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":14},{"id":"work-d54525fd95f093cc","name":"早餐时给布加迪发了邮件","description":"已连 Gmail 的 Astra 在画车时主动发了两封邮件。","category":"other","sourceCategory":"16. 早餐时给布加迪发了邮件","author":{"name":"SKEL","url":"https://x.com/skel"},"demoUrl":"https://x.com/skel/status/2096113092736540685","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":15},{"id":"work-f9ff904926bd8d18","name":"三岁小孩动力沙 / 卡车 / 恐龙","description":"一句 prompt，约 27 分钟可玩。imoutoftokensFR · original · 09-05","category":"game","sourceCategory":"游戏与可玩原型","author":{"name":"imoutoftokensFR","url":"https://x.com/imoutoftokensFR"},"demoUrl":"https://x.com/imoutoftokensFR/status/2096202083561054342","sourceUrl":null,"repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096201923280117760%2Fimg%2F_R4_8j_xB9Pbvamn.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096201923280117760%2Fimg%2F_R4_8j_xB9Pbvamn.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096201923280117760/vid/avc1/1912x1080/EV53js3rFCEQtUMu.mp4?tag=29","sourceOrder":16},{"id":"work-ce04d02d30d0bd4d","name":"Astral War","description":"浏览器 FPS，一天做出。RealFedeURU · original · 09-05","category":"game","sourceCategory":"游戏与可玩原型","author":{"name":"RealFedeURU","url":"https://x.com/RealFedeURU"},"demoUrl":"https://x.com/RealFedeURU/status/2096202133532008758","sourceUrl":null,"repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096062838892814336%2Fimg%2FME5ZS6OhoEsNAfH6.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096062838892814336%2Fimg%2FME5ZS6OhoEsNAfH6.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096062838892814336/vid/avc1/3840x2160/qG8K0QsahuhNt8q2.mp4?tag=29","sourceOrder":17},{"id":"work-b44b856eb604423f","name":"Three.js MMORPG 区域","description":"网页端 one prompt：营地、交易、技能栏。oceanbennett · original · 09-05","category":"game","sourceCategory":"游戏与可玩原型","author":{"name":"oceanbennett","url":"https://x.com/oceanbennett"},"demoUrl":"https://x.com/oceanbennett/status/2096049972437209510","sourceUrl":null,"repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096048861491933188%2Fimg%2Fjm-TH_77jzA0aj6B.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096048861491933188%2Fimg%2Fjm-TH_77jzA0aj6B.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096048861491933188/vid/avc1/3840x2160/6Vqanl_WiHs3k8P1.mp4?tag=29","sourceOrder":18},{"id":"work-89d78b1ddffd5478","name":"Fernando Galaxy","description":"原生 iOS，Swift + RealityKit + Blender MCP，5h48m。RayFernando1337 · original · 09-05","category":"game","sourceCategory":"游戏与可玩原型","author":{"name":"RayFernando1337","url":"https://x.com/RayFernando1337"},"demoUrl":"https://x.com/RayFernando1337/status/2096150987031633961","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-258.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":19},{"id":"work-b8ea85df0fb036d1","name":"宝可梦风 3D / 渋谷 / 东京塔","description":"日语回顾视频，剪辑也用了 Codex。masahirochaen · original · 09-05","category":"game","sourceCategory":"游戏与可玩原型","author":{"name":"masahirochaen","url":"https://x.com/masahirochaen"},"demoUrl":"https://x.com/masahirochaen/status/2096196861287878877","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-310.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":20},{"id":"work-fedc8626a3fb24f1","name":"可玩射击 + 赛车","description":"两条简单 prompt，两个可玩回合。k2sbhai · original · 09-05","category":"game","sourceCategory":"游戏与可玩原型","author":{"name":"k2sbhai","url":"https://x.com/k2sbhai"},"demoUrl":"https://x.com/k2sbhai/status/2096182794737402183","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-294.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":21},{"id":"work-f1fce8541ce14b4a","name":"1-shot 浏览器游戏","description":"上线日 Theo 的即席游戏演示。theo · original · 09-03","category":"game","sourceCategory":"游戏与可玩原型","author":{"name":"theo","url":"https://x.com/theo"},"demoUrl":"https://x.com/theo/status/2095599934766764338","sourceUrl":null,"repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2095599652796272640%2Fimg%2F-alGPQCkf-Z8Cs-n.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2095599652796272640%2Fimg%2F-alGPQCkf-Z8Cs-n.jpg","videoUrl":"https://video.twimg.com/amplify_video/2095599652796272640/vid/avc1/3472x2160/OYo0vVmQjfchUfL5.mp4?tag=29","sourceOrder":22},{"id":"work-64f4a084e0abc383","name":"三主题赛车","description":"Playco 团队的多主题 kart 原型。chetaslua · original · 09-03","category":"game","sourceCategory":"游戏与可玩原型","author":{"name":"chetaslua","url":"https://x.com/chetaslua"},"demoUrl":"https://x.com/chetaslua/status/2095580402505400369","sourceUrl":null,"repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2095580316710879232%2Fimg%2F4wyWA9mIaUJywIlc.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2095580316710879232%2Fimg%2F4wyWA9mIaUJywIlc.jpg","videoUrl":"https://video.twimg.com/amplify_video/2095580316710879232/vid/avc1/1920x1080/Co7RPYXqGzSkNESG.mp4?tag=29","sourceOrder":23},{"id":"work-e484d63ac21088fa","name":"Forgotten Horizon","description":"更完整的探索游戏原型。ashthepeasant · original · 09-05","category":"game","sourceCategory":"游戏与可玩原型","author":{"name":"ashthepeasant","url":"https://x.com/ashthepeasant"},"demoUrl":"https://x.com/ashthepeasant/status/2096172063241515218","sourceUrl":null,"repoUrl":null,"imageUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096168307766513664%2Fimg%2Fixt5KKFzpf-WlH80.jpg","posterUrl":"https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096168307766513664%2Fimg%2Fixt5KKFzpf-WlH80.jpg","videoUrl":"https://video.twimg.com/amplify_video/2096168307766513664/vid/avc1/2560x1380/zjrhDLO_vMhDD-LM.mp4?tag=29","sourceOrder":24},{"id":"work-d3f14703da032e8e","name":"房子照片 → 完整 Blender 场景","description":"家具玩具都在，可 60fps 浏览。tomkrcha · original · 09-03","category":"experiment","sourceCategory":"3D 世界与建模","author":{"name":"tomkrcha","url":"https://x.com/tomkrcha"},"demoUrl":"https://x.com/tomkrcha/status/2095598645190291775","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":25},{"id":"work-52bc1cb1a35f1b74","name":"火车草图 → 3295 个可编辑物体","description":"同作者的工程级 3D。tomkrcha · original · 09-04","category":"experiment","sourceCategory":"3D 世界与建模","author":{"name":"tomkrcha","url":"https://x.com/tomkrcha"},"demoUrl":"https://x.com/tomkrcha/status/2095756085890310311","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":26},{"id":"work-ba6009a735a79e35","name":"椭圆形办公室","description":"Astra 写几何，视频模型收尾。higgsfield_ai · original · 09-03","category":"experiment","sourceCategory":"3D 世界与建模","author":{"name":"higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2095630197257367857","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-044.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":27},{"id":"work-737afb9beb24c75b","name":"一条 prompt 用基本体拼出整车","description":"作者说四个月前还摆不好物体。Stefan_3D_AI · original · 09-05","category":"experiment","sourceCategory":"3D 世界与建模","author":{"name":"Stefan_3D_AI","url":"https://x.com/Stefan_3D_AI"},"demoUrl":"https://x.com/Stefan_3D_AI/status/2096185294165103049","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":28},{"id":"work-b03c1e0c7e94abab","name":"Cinema 4D 建模","description":"不只有 Blender。mojon1 · original · 09-05","category":"experiment","sourceCategory":"3D 世界与建模","author":{"name":"mojon1","url":"https://x.com/mojon1"},"demoUrl":"https://x.com/mojon1/status/2096189580752081024","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":29},{"id":"work-3e5057f690c19264","name":"澳洲宿舍照片还原","description":"约 20 分钟做成可交互场景。rionaifantasy · original · 09-05","category":"experiment","sourceCategory":"3D 世界与建模","author":{"name":"rionaifantasy","url":"https://x.com/rionaifantasy"},"demoUrl":"https://x.com/rionaifantasy/status/2096163579925770671","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-269.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":30},{"id":"work-1bb82bc128dc3cf0","name":"零 Blender 经验做美式厨房","description":"语音 + 出图 + Computer Use。berryxia · original · 09-05","category":"experiment","sourceCategory":"3D 世界与建模","author":{"name":"berryxia","url":"https://x.com/berryxia"},"demoUrl":"https://x.com/berryxia/status/2096158415894835518","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":31},{"id":"work-48035a9a97a4c159","name":"GTA6 画风新加坡街道","description":"Three.js，iPhone POV。birdabo · original · 09-05","category":"experiment","sourceCategory":"3D 世界与建模","author":{"name":"birdabo","url":"https://x.com/birdabo"},"demoUrl":"https://x.com/birdabo/status/2096156461365960837","sourceUrl":"https://x.com/3three_AI/status/2096483437507211489","repoUrl":null,"imageUrl":"/previews/x-thread-08.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":32},{"id":"work-fc4ab7c8e69f71db","name":"Tesla Model X 拆解站","description":"334 个零件的 3D 网页。ashebytes · original · 09-04","category":"experiment","sourceCategory":"3D 世界与建模","author":{"name":"ashebytes","url":"https://x.com/ashebytes"},"demoUrl":"https://x.com/ashebytes/status/2096009146248122416","sourceUrl":"https://x.com/3three_AI/status/2096483440418013570","repoUrl":null,"imageUrl":"/previews/x-thread-09.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":33},{"id":"work-ed7d9b1987f15236","name":"Forest Retreat","description":"Blender 森林别墅，约 7 小时。UNIBRACITY · original · 09-05","category":"experiment","sourceCategory":"3D 世界与建模","author":{"name":"UNIBRACITY","url":"https://x.com/UNIBRACITY"},"demoUrl":"https://x.com/UNIBRACITY/status/2096142182050927035","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-250.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":34},{"id":"work-858d9cdfbf63722a","name":"Backrooms","description":"Duncan Trussell 的 Blender 限制空间。duncantrussell · original · 09-04","category":"experiment","sourceCategory":"3D 世界与建模","author":{"name":"duncantrussell","url":"https://x.com/duncantrussell"},"demoUrl":"https://x.com/duncantrussell/status/2096003511104508411","sourceUrl":"https://x.com/3three_AI/status/2096483426950086800","repoUrl":null,"imageUrl":"/previews/x-thread-04.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":35},{"id":"work-71752ba6c3bc618f","name":"地图钉 → 3D 街区","description":"Pietro 把地图标记重建成街区。skirano · original · 09-04","category":"experiment","sourceCategory":"3D 世界与建模","author":{"name":"skirano","url":"https://x.com/skirano"},"demoUrl":"https://x.com/skirano/status/2095899479308144981","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":36},{"id":"work-056dad315e3c96b6","name":"自动 bind 的功夫动作","description":"角色自动绑骨与动画。thebuggeddev · original · 09-05","category":"experiment","sourceCategory":"3D 世界与建模","author":{"name":"thebuggeddev","url":"https://x.com/thebuggeddev"},"demoUrl":"https://x.com/thebuggeddev/status/2096141728487178503","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-248.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":37},{"id":"work-da9971651633531a","name":"3D 钢琴家","description":"可观看的演奏场景。LexnLin · original · 09-05","category":"experiment","sourceCategory":"3D 世界与建模","author":{"name":"LexnLin","url":"https://x.com/LexnLin"},"demoUrl":"https://x.com/LexnLin/status/2096166277849239804","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-276.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":38},{"id":"work-e46a99c0b2f0d016","name":"Hangzhou in Three.js","description":"西湖到钱江新城的可漫游微缩杭州。NFT_Chen · original · 09-05","category":"experiment","sourceCategory":"3D 世界与建模","author":{"name":"NFT_Chen","url":"https://x.com/NFT_Chen"},"demoUrl":"https://x.com/NFT_Chen/status/2096143589151756638","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-252.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":39},{"id":"work-a2e33f3ab152b11b","name":"Paint 里画你","description":"广被引用的 Computer Use 小检。The_Alex · original · 09-04","category":"other","sourceCategory":"Computer Use / 工程","author":{"name":"The_Alex","url":"https://x.com/The_Alex"},"demoUrl":"https://x.com/The_Alex/status/2095962639386239400","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":40},{"id":"work-18faf5ef255e0962","name":"55 段素材自动剪辑","description":"选曲、切点、遮罩一起做。0xTykoo · original · 09-05","category":"other","sourceCategory":"Computer Use / 工程","author":{"name":"0xTykoo","url":"https://x.com/0xTykoo"},"demoUrl":"https://x.com/0xTykoo/status/2096183262255386833","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":41},{"id":"work-70598a90d7015088","name":"无人机飞控 PCB","description":"原理图到布局走线再自查。GoGoFly23 · original · 09-05","category":"other","sourceCategory":"Computer Use / 工程","author":{"name":"GoGoFly23","url":"https://x.com/GoGoFly23"},"demoUrl":"https://x.com/GoGoFly23/status/2096145124950708512","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":42},{"id":"work-bd992b2b89d998e8","name":"KiCad PCB 布线","description":"另一条被广泛转发的 EE 案例。ChihYang04 · original · 09-03","category":"other","sourceCategory":"Computer Use / 工程","author":{"name":"ChihYang04","url":"https://x.com/ChihYang04"},"demoUrl":"https://x.com/ChihYang04/status/2095637507337826741","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":43},{"id":"work-1ced54bbe489402a","name":"Agentic CAD","description":"作者称 CAD agent 有一阶跳变。adamdotnew · original · 09-05","category":"other","sourceCategory":"Computer Use / 工程","author":{"name":"adamdotnew","url":"https://x.com/adamdotnew"},"demoUrl":"https://x.com/adamdotnew/status/2096053889141489669","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":44},{"id":"work-72c812918fd98212","name":"开发—验收闭环","description":"中文圈对 Computer Use 的早期观察。dotey · original · 09-05","category":"other","sourceCategory":"Computer Use / 工程","author":{"name":"dotey","url":"https://x.com/dotey"},"demoUrl":"https://x.com/dotey/status/2096051842174087386","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":45},{"id":"work-113f2069615c4244","name":"iOS 参考做安卓","description":"一次对齐现有 iOS 应用。jonaswrks · original · 09-05","category":"app","sourceCategory":"Computer Use / 工程","author":{"name":"jonaswrks","url":"https://x.com/jonaswrks"},"demoUrl":"https://x.com/jonaswrks/status/2096201967982829707","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":46},{"id":"work-4f39d7ff1be591ea","name":"Three.js 30 分钟可交互场景","description":"作者说从几小时压到 30 分钟。lepadphone · original · 09-05","category":"other","sourceCategory":"Computer Use / 工程","author":{"name":"lepadphone","url":"https://x.com/lepadphone"},"demoUrl":"https://x.com/lepadphone/status/2096147245775331419","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":47},{"id":"work-bfb906fc1df55d29","name":"3D pipeline 工作室测试","description":"工作室级管线试跑。badxstudio · original · 09-04","category":"other","sourceCategory":"Computer Use / 工程","author":{"name":"badxstudio","url":"https://x.com/badxstudio"},"demoUrl":"https://x.com/badxstudio/status/2095982983379653113","sourceUrl":"https://x.com/3three_AI/status/2096483458612944976","repoUrl":null,"imageUrl":"/previews/x-thread-15.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":48},{"id":"work-2653deaaa9de785e","name":"UI 生成质量","description":"短视频观点，但被广泛收藏。MSchwaibold · original · 09-05","category":"other","sourceCategory":"Computer Use / 工程","author":{"name":"MSchwaibold","url":"https://x.com/MSchwaibold"},"demoUrl":"https://x.com/MSchwaibold/status/2096059496812716307","sourceUrl":"https://x.com/3three_AI/status/2096483449397985496","repoUrl":null,"imageUrl":"/previews/x-thread-12.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":49},{"id":"work-c23d4b96d93e9022","name":"ZX Spectrum 48K 复刻","description":"橡胶键盘、磅带加载、可玩 Gridrunner。DeryaTR_ · original · 09-05","category":"other","sourceCategory":"音乐 / 科学 / Prompt","author":{"name":"DeryaTR_","url":"https://x.com/DeryaTR_"},"demoUrl":"https://x.com/DeryaTR_/status/2096062355692048605","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-163.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":50},{"id":"work-bec5dd071ce85ae7","name":"Ableton 从零做一轨","description":"Pietro + Ableton MCP。skirano · original · 09-03","category":"other","sourceCategory":"音乐 / 科学 / Prompt","author":{"name":"skirano","url":"https://x.com/skirano"},"demoUrl":"https://x.com/skirano/status/2095595942544089525","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":51},{"id":"work-ce318ba4e91342aa","name":"个人风格 MIDI","description":"Astra 出稿，作者改 MIDI 再进 Suno。super_bonochin · original · 09-05","category":"other","sourceCategory":"音乐 / 科学 / Prompt","author":{"name":"super_bonochin","url":"https://x.com/super_bonochin"},"demoUrl":"https://x.com/super_bonochin/status/2096183825433084181","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":52},{"id":"work-29515da76d06c559","name":"9 条能上班的 Agent prompt","description":"账单、二手市场、夜间 QA、竞品。gregisenberg · original · 09-04","category":"other","sourceCategory":"音乐 / 科学 / Prompt","author":{"name":"gregisenberg","url":"https://x.com/gregisenberg"},"demoUrl":"https://x.com/gregisenberg/status/2095854071580156338","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":53},{"id":"work-f8ba75cbd771096d","name":"第一性原理盘问代码库","description":"先删再简。georgepickett · original · 09-04","category":"other","sourceCategory":"音乐 / 科学 / Prompt","author":{"name":"georgepickett","url":"https://x.com/georgepickett"},"demoUrl":"https://x.com/georgepickett/status/2095979879137460640","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":54},{"id":"work-02afd2c889a276f4","name":"Mosswing","description":"3D 单键飞行，控制小翼穿越障碍间隙得分。作者：Ayi1337。One Shot Prompt 与记录 · 源码 · 单文件 HTML。","category":"game","sourceCategory":"动作与街机","author":{"name":"","url":null},"demoUrl":"https://mosswing-quiet-flight.jack-514.chatgpt.site/","sourceUrl":"https://x.com/i/status/2096263516181123300","repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":55},{"id":"work-ea7ac6ce81db2b36","name":"Magic Carpet Wizard — A Thousand Skies","description":"驾驶魔毯探索球形世界，穿环、施法并挑战 Boss。作者：threapchills。桌面浏览器，需要 WebGL 2；Three.js/Vite 源码。","category":"game","sourceCategory":"动作与街机","author":{"name":"","url":null},"demoUrl":"https://threapchills.github.io/MagicCarpetWizard/","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":56},{"id":"work-9414e523f86ec556","name":"瓜体实验室","description":"半流体水果形变与碰撞的西瓜合成玩法。作者：Ayi1337。源码 · 单文件 HTML。","category":"game","sourceCategory":"解谜与益智","author":{"name":"","url":null},"demoUrl":"https://melon-game.jack-514.chatgpt.site/","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":57},{"id":"work-9c7ec2875e8b7ddb","name":"ORBITAL GARDEN · 轨道花园","description":"48,000 颗光点在花、引力环和星系之间变形的粒子艺术沙盒。作者：jackroc。支持 WebGL 的现代浏览器，免费、无需登录或 API Key；创作记录 · 源码与运行说明 · 离线 HTML · Prompt。","category":"experiment","sourceCategory":"实验玩法","author":{"name":"","url":null},"demoUrl":"https://orbital-garden.hp20230404.chatgpt.site/","sourceUrl":null,"repoUrl":null,"imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":58},{"id":"work-4708c9bf953c7d14","name":"DannyMac180/astra-advisor","description":"动态 Sol/Terra/Luna 子 Agent 编排","category":"other","sourceCategory":"社区项目","author":{"name":"","url":null},"demoUrl":null,"sourceUrl":"https://github.com/DannyMac180/astra-advisor","repoUrl":"https://github.com/DannyMac180/astra-advisor","imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":59},{"id":"work-57cacc734ddc43d0","name":"Ayi1337/gpt6-astra-one-shot-games","description":"原始 Prompt 与可运行单文件 HTML","category":"other","sourceCategory":"社区项目","author":{"name":"","url":null},"demoUrl":null,"sourceUrl":"https://github.com/Ayi1337/gpt6-astra-one-shot-games","repoUrl":"https://github.com/Ayi1337/gpt6-astra-one-shot-games","imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":60},{"id":"work-8d49162b51503c1c","name":"tadamcz/koethe","description":"mean-value-problem — Lean 4 数学反例探索","category":"other","sourceCategory":"社区项目","author":{"name":"","url":null},"demoUrl":null,"sourceUrl":"https://github.com/tadamcz/koethe","repoUrl":"https://github.com/tadamcz/koethe","imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":61},{"id":"work-9e8d9df493264dae","name":"Firnschnee/dual-model-mcp","description":"Fable 5.1 与 Astra 双模型 MCP","category":"experiment","sourceCategory":"社区项目","author":{"name":"","url":null},"demoUrl":null,"sourceUrl":"https://github.com/Firnschnee/dual-model-mcp","repoUrl":"https://github.com/Firnschnee/dual-model-mcp","imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":62},{"id":"work-64ffe9e804b852d5","name":"LunarXuan/task-model-router","description":"按返工成本路由 Codex 任务","category":"other","sourceCategory":"社区项目","author":{"name":"","url":null},"demoUrl":null,"sourceUrl":"https://github.com/LunarXuan/task-model-router","repoUrl":"https://github.com/LunarXuan/task-model-router","imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":63},{"id":"work-d76704efa605582a","name":"MiaAI-Lab/GPT-6-Astra-100-HTML-Files","description":"100 个独立 HTML 视觉实验","category":"experiment","sourceCategory":"社区项目","author":{"name":"","url":null},"demoUrl":null,"sourceUrl":"https://github.com/MiaAI-Lab/GPT-6-Astra-100-HTML-Files","repoUrl":"https://github.com/MiaAI-Lab/GPT-6-Astra-100-HTML-Files","imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":64},{"id":"work-c003ef22d863004e","name":"gih10012/astra-parabox-benchmark","description":"Patrick's Parabox 364 关屏幕基准","category":"other","sourceCategory":"社区项目","author":{"name":"","url":null},"demoUrl":null,"sourceUrl":"https://github.com/gih10012/astra-parabox-benchmark","repoUrl":"https://github.com/gih10012/astra-parabox-benchmark","imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":65},{"id":"work-c77aaeb31d06b9cf","name":"coreprocess/openai-relay-for-cursor","description":"在 Cursor 中接入 Responses API 模型","category":"experiment","sourceCategory":"社区项目","author":{"name":"","url":null},"demoUrl":null,"sourceUrl":"https://github.com/coreprocess/openai-relay-for-cursor","repoUrl":"https://github.com/coreprocess/openai-relay-for-cursor","imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":66},{"id":"work-8a31ebd9378a8396","name":"sjh9714/astra-tandem","description":"ShunsukeHayashi/gpt6-task-spawner — 构建/审阅与任务分发工作流","category":"other","sourceCategory":"社区项目","author":{"name":"","url":null},"demoUrl":null,"sourceUrl":"https://github.com/sjh9714/astra-tandem","repoUrl":"https://github.com/sjh9714/astra-tandem","imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":67},{"id":"work-dc81dce77bca9260","name":"marius4lui/NULLSPACE","description":"生存恐怖 FPS","category":"other","sourceCategory":"社区项目","author":{"name":"","url":null},"demoUrl":null,"sourceUrl":"https://github.com/marius4lui/NULLSPACE","repoUrl":"https://github.com/marius4lui/NULLSPACE","imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":68},{"id":"work-7e42ba1b0b9fa540","name":"Rising1234Sun/qingmingshanghetu","description":"清明上河图实时 3D 场景","category":"experiment","sourceCategory":"社区项目","author":{"name":"","url":null},"demoUrl":null,"sourceUrl":"https://github.com/Rising1234Sun/qingmingshanghetu","repoUrl":"https://github.com/Rising1234Sun/qingmingshanghetu","imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":69},{"id":"work-56d2c02b94b7bac8","name":"da03/astra-plays-gta","description":"Astra 操作 GTA Vice City","category":"other","sourceCategory":"社区项目","author":{"name":"","url":null},"demoUrl":null,"sourceUrl":"https://github.com/da03/astra-plays-gta","repoUrl":"https://github.com/da03/astra-plays-gta","imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":70},{"id":"work-eff74cbc4c3f16e9","name":"xinbenlv/ra2-gpt-6-astra-2026-09-04","description":"红警 2 one-shot 重建","category":"other","sourceCategory":"社区项目","author":{"name":"","url":null},"demoUrl":null,"sourceUrl":"https://github.com/xinbenlv/ra2-gpt-6-astra-2026-09-04","repoUrl":"https://github.com/xinbenlv/ra2-gpt-6-astra-2026-09-04","imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":71},{"id":"work-04f3eeac4963586e","name":"paveljor/agent-bluff","description":"多模型欺骗能力对赛","category":"experiment","sourceCategory":"社区项目","author":{"name":"","url":null},"demoUrl":null,"sourceUrl":"https://github.com/paveljor/agent-bluff","repoUrl":"https://github.com/paveljor/agent-bluff","imageUrl":null,"posterUrl":null,"videoUrl":null,"sourceOrder":72},{"id":"work-13437626d2614973","name":"Zork 文字冒险改为 3D 动作冒险","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/emollick/status/2096047660662722620","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-001.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-01-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-01.mp4","sourceOrder":73},{"id":"work-4ddddd7991f91259","name":"浏览器第三人称动作游戏","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/superalesha/status/2095988972879335792","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-004.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-04-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-04.mp4","sourceOrder":74},{"id":"work-e072428bf4e9a66d","name":"反重力竞速游戏","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/superalesha/status/2095967568825582044","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-005.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-05-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-05.mp4","sourceOrder":75},{"id":"work-113936e041b40d68","name":"Mario Kart 风格赛车","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/DeryaTR_/status/2095945186643710171","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-006.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-06-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-06.mp4","sourceOrder":76},{"id":"work-4539d57dce6c7bfd","name":"Gogh Strike 艺术风格射击游戏","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/petergostev/status/2096013280519016608","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-007.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-07-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-07.mp4","sourceOrder":77},{"id":"work-2cee9e15bfcb4cb0","name":"Cut the Rope 风格解谜游戏","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/mirochill/status/2095968487994732974","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-008.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-08-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-08.mp4","sourceOrder":78},{"id":"work-f484d21389c91dc9","name":"可漫游且可编辑的房间","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/onofumi_AI/status/2096020860121596003","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-009.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-09-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-09.mp4","sourceOrder":79},{"id":"work-c7f702273bc5fc6b","name":"从零制作 3D 角色","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/posi_posi8/status/2096017956325224851","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-010.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-10-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-10.mp4","sourceOrder":80},{"id":"work-a2b3e32a3bfc8840","name":"户型图与 3D 漫游同步","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/onofumi_AI/status/2095999282088378520","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-011.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-11-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-11.mp4","sourceOrder":81},{"id":"work-c2cfe1b8ac05793c","name":"办公室复刻","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/bridgemindai/status/2095993644389982294","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-012.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-12-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-12.mp4","sourceOrder":82},{"id":"work-3369db0b059aadfb","name":"房源照片转模型和宣传视频","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/Freyabuilds/status/2095833957447434523","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-013.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-13-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-13.mp4","sourceOrder":83},{"id":"work-ec2b5297b79042ba","name":"批量尝试网站视觉设计","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/nateherk/status/2096018636079026498","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-015.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-15-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-15.mp4","sourceOrder":84},{"id":"work-e303c73121faead6","name":"漫剧产品导演台调研与开发","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/nicknam92226032/status/2096018367937450343","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-016.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-16-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-16.mp4","sourceOrder":85},{"id":"work-915811aa1507a24b","name":"改造抽奖流程界面","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/nabu_lines/status/2096001136566141055","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-017.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-17-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-17.mp4","sourceOrder":86},{"id":"work-c0bedca7ad3f55a0","name":"重做现有网站 onboarding","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/coelhoxyz/status/2096000135184400863","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-018.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-18-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-18.mp4","sourceOrder":87},{"id":"work-cc0d8da9c847d8b1","name":"可操作的笔记界面","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/daradoescode/status/2095978271384990084","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-019.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-19-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-19.mp4","sourceOrder":88},{"id":"work-882d0b980a18b798","name":"Gameboy 风格个人作品集","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/Angaisb_/status/2095964361105789424","sourceUrl":"https://x.com/3three_AI/status/2096483451843330333","repoUrl":null,"imageUrl":"/previews/x-thread-13.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-20-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-20.mp4","sourceOrder":89},{"id":"work-1af1c117ec6ee018","name":"macOS App onboarding","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/lucas_montano/status/2095959478411698295","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-021.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-21-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-21.mp4","sourceOrder":90},{"id":"work-700d6279a79923b0","name":"Astra 主题欢迎界面","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/jaimintf/status/2095863849635422679","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-022.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-22-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-22.mp4","sourceOrder":91},{"id":"work-3f0d3bf82f0cb295","name":"品牌 Remotion 营销视频","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/bridgemindai/status/2095963477542056143","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-024.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-24-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-24.mp4","sourceOrder":92},{"id":"work-9346160506b7817b","name":"布列塔尼街景短片","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/thomas_guilcher/status/2095845691373351276","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-025.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-25-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-25.mp4","sourceOrder":93},{"id":"work-204c7fc3afd63124","name":"为 Seedance 视频撰写提示词","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/eachlabs/status/2095911062499381467","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-026.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-26-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-26.mp4","sourceOrder":94},{"id":"work-dc8b657140672a49","name":"Blender 灰模到电影感视频","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/Deevid_AI/status/2095919830423498910","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-027.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-27-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-27.mp4","sourceOrder":95},{"id":"work-f66f1c8810b137f3","name":"不完整扫描网格转 CAD","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/Alpha10six/status/2096042985775386739","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-028.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-28-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-28.mp4","sourceOrder":96},{"id":"work-f00994e006560ebf","name":"C++ 光线追踪器迁移到 Swift 与 GPU","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/PaulSolt/status/2095879835088293931","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-029.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-29-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-29.mp4","sourceOrder":97},{"id":"work-28041fe41b42fd5d","name":"低清人像转可打印模型","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/vi4m/status/2096007521437663706","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-031.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-31-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-31.mp4","sourceOrder":98},{"id":"work-92ed718fbed3d617","name":"实时海岸模拟","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/hajimetwi3/status/2096033088178671755","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-032.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-32-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-32.mp4","sourceOrder":99},{"id":"work-e482d91a16545e18","name":"双摆数值模拟与交互画布","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/AlicanKiraz0/status/2095970338043789323","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-033.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-33-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-33.mp4","sourceOrder":100},{"id":"work-25ebe9b21530d5e0","name":"程序化水面效果","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/PaulSolt/status/2095902741092606154","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-034.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-34-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-34.mp4","sourceOrder":101},{"id":"work-4dfe49c71fab5178","name":"果蝇神经连接组驱动 Minecraft 运动","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/evnsnclr/status/2095975490708291948","sourceUrl":"https://x.com/3three_AI/status/2096483461041381633","repoUrl":null,"imageUrl":"/previews/x-thread-16.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-35-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-35.mp4","sourceOrder":102},{"id":"work-c9f1227930823113","name":"化学分析 macOS 应用原型","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/DeryaTR_/status/2095907471042675179","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-036.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-36-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-36.mp4","sourceOrder":103},{"id":"work-34d4ccb1ba4e1db1","name":"已知 CVE 重发现评测","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/pilvar222/status/2095980204912955679","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-037.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-37-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-37.mp4","sourceOrder":104},{"id":"work-674a0eba484a96df","name":"一次生成 PowerPoint","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/gota_bara/status/2096004521143201858","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-038.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-38-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-38.mp4","sourceOrder":105},{"id":"work-bcd16cd0b59f3d3f","name":"Bach 风格四声部乐谱","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/aug5thmusic/status/2096030719156089029","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-039.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-39-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-39.mp4","sourceOrder":106},{"id":"work-bf0f0a499c33b193","name":"为 Suno 准备歌曲材料","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/super_bonochin/status/2096023836747763926","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-040.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-40-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-40.mp4","sourceOrder":107},{"id":"work-235c6c99d676cd2f","name":"Blender 别墅场景对照","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/karankendre/status/2095636679264780481","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-041.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-41-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-41.mp4","sourceOrder":108},{"id":"work-cbb5e37e6106e5b4","name":"旧金山 Palace of Fine Arts 重建","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/sharifshameem/status/2095653641164329143","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-043.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-43-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-43.mp4","sourceOrder":109},{"id":"work-6acb12aaaf9905f9","name":"14 分钟动效视频","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/chddaniel/status/2095775049475313943","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-045.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-45-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-45.mp4","sourceOrder":110},{"id":"work-ee80f4a851b651a7","name":"Panzer Dragoon Episode 1 风格游戏","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/yasei_no_otoko/status/2095975195312029889","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-046.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-46-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-46.mp4","sourceOrder":111},{"id":"work-f8b9ad16e1a786fb","name":"BridgeBench 熔岩灯","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/bridgemindai/status/2095962388503679133","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-048.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-48-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-48.mp4","sourceOrder":112},{"id":"work-4b25443bba5e6c39","name":"Blender Dax Raad 人物","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/kitlangton/status/2095959455238164566","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-049.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-49-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-49.mp4","sourceOrder":113},{"id":"work-2c9722eb8052b3fa","name":"鹈鹕 SVG 转 3D","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/anion_ex/status/2095963142010581098","sourceUrl":"https://x.com/3three_AI/status/2096483463671238867","repoUrl":null,"imageUrl":"/previews/x-thread-17.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-50-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-50.mp4","sourceOrder":114},{"id":"work-742787bb6344a461","name":"Street Heat 浏览器街机赛车","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/higgsfield_ai/status/2095916820431827408","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-051.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-51-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-51.mp4","sourceOrder":115},{"id":"work-58e6ebb9c677bac2","name":"Three.js 海上战争场景","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/synthwavedd/status/2095840435319001278","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-052.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-52-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-52.mp4","sourceOrder":116},{"id":"work-b5bc968a9dd01d1c","name":"Blender 香蕉雕塑复测","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/D3VAUX/status/2095989462878560702","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-053.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-53-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-53.mp4","sourceOrder":117},{"id":"work-0ef1a40c3e0b2b63","name":"3D mockup 生成工具","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/joshmillgate/status/2095619319690400253","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-054.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-54-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-54.mp4","sourceOrder":118},{"id":"work-5ab0d29f4f7f1d0e","name":"Three.js PS5 手柄","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/blueemi99/status/2095967131573649552","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-055.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-55-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-55.mp4","sourceOrder":119},{"id":"work-e059c4e5330acca6","name":"单 prompt 游戏展示","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/Ludoowic/status/2095840011501380039","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-056.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-56-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-56.mp4","sourceOrder":120},{"id":"work-3039280ca33e1836","name":"Blender 城堡与视频","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/nemumusitocha/status/2095989696094720158","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-057.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-57-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-57.mp4","sourceOrder":121},{"id":"work-7a081d157b90639e","name":"BridgeMind 火箭发射视频","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/bridgemindai/status/2095968262043349373","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-058.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-58-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-58.mp4","sourceOrder":122},{"id":"work-eca91e837b0f4d85","name":"Roblox 动漫大乱斗","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/WoahWurdz/status/2095999578419929412","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-059.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-59-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-59.mp4","sourceOrder":123},{"id":"work-a48440f070c10ce4","name":"Web to App 转原生移动 App","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/chhddavid/status/2095790622066307451","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-060.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-60-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-60.mp4","sourceOrder":124},{"id":"work-eefabe71d89f49af","name":"20 星球探索游戏","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/hakmgpt/status/2095985014378778986","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-061.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-61-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-61.mp4","sourceOrder":125},{"id":"work-7bbede601e8c86b5","name":"Star Destroyer 室内外场景","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/ChrisGPT/status/2095991474714222782","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-062.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-62-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-62.mp4","sourceOrder":126},{"id":"work-a00752a4532529dc","name":"纽博格林赛道飞行展示","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/reach_vb/status/2095973112097747199","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-063.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-63-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-63.mp4","sourceOrder":127},{"id":"work-48704dd166549a23","name":"单张图转 VRM 角色","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/nemumusitocha/status/2095974763772719484","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-064.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-64-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-64.mp4","sourceOrder":128},{"id":"work-41fe6de6010c6bc3","name":"HELIOS 红石音乐装置","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/Angaisb_/status/2096007325005832642","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-065.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-65-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-65.mp4","sourceOrder":129},{"id":"work-1d9529682f9da340","name":"2D / 3D Chain Reaction Machine","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/KinasRemek/status/2095973918775382487","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-066.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-66-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-66.mp4","sourceOrder":130},{"id":"work-877dafd9bb67b1d6","name":"Pokemon 风格游戏重建","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/MozeTech/status/2096023838102536341","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-067.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-67-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-67.mp4","sourceOrder":131},{"id":"work-8549faac0f37b81f","name":"WoW / RuneScape 风格 RPG","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/DeryaTR_/status/2095952101000016076","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-068.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-68-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-68.mp4","sourceOrder":132},{"id":"work-45006dd2b999a32d","name":"鹈鹕 SVG 动画","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/DeryaTR_/status/2096000334418038940","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-069.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-69-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-69.mp4","sourceOrder":133},{"id":"work-ef460b460e9a8dc8","name":"Astra 自我介绍视频","description":"CheerSelfAI 公开使用案例。","category":"other","sourceCategory":"CheerSelfAI 使用案例","author":{"name":"","url":null},"demoUrl":"https://x.com/nemumusitocha/status/2095967527755305130","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-070.jpg","posterUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-70-poster.jpg","videoUrl":"https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-70.mp4","sourceOrder":134},{"id":"work-378bdf401b2d545a","name":"2. 3D 人体解剖网站","description":"3D 网页把男性解剖结构拆成 2,234 个可观察模型部件。","category":"website","sourceCategory":"X 线程新增案例 · 02","author":{"name":"ashe / @ashebytes","url":"https://x.com/ashebytes"},"demoUrl":"https://x.com/ashebytes/status/2096221988763173186","sourceUrl":"https://x.com/3three_AI/status/2096483421585600687","repoUrl":null,"imageUrl":"/previews/x-thread-02.jpg","sourceOrder":135,"posterUrl":null,"videoUrl":null},{"id":"work-e731cd44c1d01c3a","name":"3. 生成超逼真的产品广告","description":"一次生成产品宣传视频，完整提示词见原帖评论。","category":"other","sourceCategory":"X 线程新增案例 · 03","author":{"name":"leo / @leomeethewoo","url":"https://x.com/leomeethewoo"},"demoUrl":"https://x.com/leomeethewoo/status/2096207831695564833","sourceUrl":"https://x.com/3three_AI/status/2096483424492195995","repoUrl":null,"imageUrl":"/previews/x-thread-03.jpg","sourceOrder":136,"posterUrl":null,"videoUrl":null},{"id":"work-b320abd91ce0328b","name":"6. 26 分钟生成的完整作品","description":"作者记录 Astra Ultra 生成作品的过程与 token 用量。","category":"other","sourceCategory":"X 线程新增案例 · 06","author":{"name":"Adam Lyttle / @adamlyttleapps","url":"https://x.com/adamlyttleapps"},"demoUrl":"https://x.com/adamlyttleapps/status/2095991822623654124","sourceUrl":"https://x.com/3three_AI/status/2096483431953887523","repoUrl":null,"imageUrl":"/previews/x-thread-06.jpg","sourceOrder":137,"posterUrl":null,"videoUrl":null},{"id":"work-ae91774ab8aa558a","name":"7. 在画板里用鼠标给素描上色","description":"Astra 自动创建图层、放大画布、选择画笔并给手绘线稿上色。","category":"other","sourceCategory":"X 线程新增案例 · 07","author":{"name":"taiyaki_sun","url":"https://x.com/taiyaki_sun"},"demoUrl":"https://x.com/taiyaki_sun/status/2096149368193839455","sourceUrl":"https://x.com/3three_AI/status/2096483434621476991","repoUrl":null,"imageUrl":"/previews/x-thread-07.jpg","sourceOrder":138,"posterUrl":null,"videoUrl":null},{"id":"work-22ff739867ccffe8","name":"10. Minecraft 屏幕展示 OpenAI 标志变成 GPT-6 Astra","description":"在 Minecraft 中制作屏幕动画，让 OpenAI 标志变成 “6 Astra”。","category":"other","sourceCategory":"X 线程新增案例 · 10","author":{"name":"Angel / @Angaisb_","url":"https://x.com/Angaisb_"},"demoUrl":"https://x.com/Angaisb_/status/2096199660687745134","sourceUrl":"https://x.com/3three_AI/status/2096483442804588758","repoUrl":null,"imageUrl":"/previews/x-thread-10.jpg","sourceOrder":139,"posterUrl":null,"videoUrl":null},{"id":"work-2a33f9a6e675b74d","name":"11. 没有拍摄，没有剪辑，只用一个 prompt","description":"公开案例声称用一个提示词生成 30 秒 AI 视频。","category":"tool","sourceCategory":"X 线程新增案例 · 11","author":{"name":"NΞKO_SHΛRK / @cat_shark_L1011","url":"https://x.com/cat_shark_L1011"},"demoUrl":"https://x.com/cat_shark_L1011/status/2096215847438291002","sourceUrl":"https://x.com/3three_AI/status/2096483445820269033","repoUrl":null,"imageUrl":"/previews/x-thread-11.jpg","sourceOrder":140,"posterUrl":null,"videoUrl":null},{"id":"work-fd985aaa8039a25b","name":"14. 在 Aseprite 里画初音未来像素画","description":"在 Aseprite 中制作真正的点阵图，而非像素风插画。","category":"tool","sourceCategory":"X 线程新增案例 · 14","author":{"name":"すえまる / @suemaruuuuuuX","url":"https://x.com/suemaruuuuuuX"},"demoUrl":"https://x.com/suemaruuuuuuX/status/2096212351502721361","sourceUrl":"https://x.com/3three_AI/status/2096483456100585762","repoUrl":null,"imageUrl":"/previews/x-thread-14.jpg","sourceOrder":141,"posterUrl":null,"videoUrl":null},{"id":"work-6df22c87815603cb","name":"18. 完整可玩的卡牌游戏","description":"从抽卡动画需求扩展成可上线的完整卡牌游戏。","category":"tool","sourceCategory":"X 线程新增案例 · 18","author":{"name":"ギガビット@ゲームつくるひと / @gigabit_million","url":"https://x.com/gigabit_million"},"demoUrl":"https://x.com/gigabit_million/status/2096094717989867681","sourceUrl":"https://x.com/3three_AI/status/2096483466057801819","repoUrl":null,"imageUrl":"/previews/x-thread-18.jpg","sourceOrder":142,"posterUrl":null,"videoUrl":null},{"id":"work-fe85e86986201154","name":"19. 完整的 Final Cut 项目","description":"自动导入片段、调色、同步剪辑，为后续视频编辑准备工程。","category":"tool","sourceCategory":"X 线程新增案例 · 19","author":{"name":"Ben Davis / @davis7","url":"https://x.com/davis7"},"demoUrl":"https://x.com/davis7/status/2095742249275699415","sourceUrl":"https://x.com/3three_AI/status/2096483468549226939","repoUrl":null,"imageUrl":"/previews/x-thread-19.jpg","sourceOrder":143,"posterUrl":null,"videoUrl":null},{"id":"work-a112776f77c5a2cc","name":"20. GPT-6 Astra 与其他模型的视觉对比","description":"让多个模型根据同一张扑克牌绘制真实感眼睛并对比结果。","category":"tool","sourceCategory":"X 线程新增案例 · 20","author":{"name":"Ann Nguyen / @ann_nnng","url":"https://x.com/ann_nnng"},"demoUrl":"https://x.com/ann_nnng/status/2096060924998348918","sourceUrl":"https://x.com/3three_AI/status/2096483471032238491","repoUrl":null,"imageUrl":"/previews/x-thread-20.jpg","sourceOrder":144,"posterUrl":null,"videoUrl":null},{"id":"work-4949fef340ffe507","name":"22. 8 分钟生成动效设计视频","description":"作者记录只修改 3 次、约 8 分钟完成动效视频。","category":"other","sourceCategory":"X 线程新增案例 · 22","author":{"name":"Titouan Gillet / @titouangillet_","url":"https://x.com/titouangillet_"},"demoUrl":"https://x.com/titouangillet_/status/2096176174032359469","sourceUrl":"https://x.com/3three_AI/status/2096483475968958492","repoUrl":null,"imageUrl":"/previews/x-thread-22.jpg","sourceOrder":145,"posterUrl":null,"videoUrl":null},{"id":"work-531476ed78c7c585","name":"24. 完整的 BMX 赛车游戏","description":"一次生成包含下坡物理、特技、碰撞、降雨和电影镜头的 3D BMX 游戏。","category":"game","sourceCategory":"X 线程新增案例 · 24","author":{"name":"Irushi / @Im_IrushiK","url":"https://x.com/Im_IrushiK"},"demoUrl":"https://x.com/Im_IrushiK/status/2096280064019353891","sourceUrl":"https://x.com/3three_AI/status/2096483481178218886","repoUrl":null,"imageUrl":"/previews/x-thread-24.jpg","sourceOrder":146,"posterUrl":null,"videoUrl":null},{"id":"work-a53f63a8578c3292","name":"26. 在 Photoshop 里为自己画肖像","description":"Astra 在 Photoshop 中完成肖像绘制，作者记录了不同于人类的操作方式。","category":"other","sourceCategory":"X 线程新增案例 · 26","author":{"name":"Kris Kashtanova / @icreatelife","url":"https://x.com/icreatelife"},"demoUrl":"https://x.com/icreatelife/status/2096243539411697678","sourceUrl":"https://x.com/3three_AI/status/2096483751236939920","repoUrl":null,"imageUrl":"/previews/x-thread-26.jpg","sourceOrder":147,"posterUrl":null,"videoUrl":null},{"id":"work-4e83100d51b4b7ba","name":"30. 地铁跑酷小游戏","description":"使用 GPT-6 Astra 制作的可玩地铁跑酷小游戏。","category":"game","sourceCategory":"X 线程新增案例 · 30","author":{"name":"Furqan / @Furqanware","url":"https://x.com/Furqanware"},"demoUrl":"https://x.com/Furqanware/status/2094954714345677052","sourceUrl":"https://x.com/3three_AI/status/2096484191240421378","repoUrl":null,"imageUrl":"/previews/x-thread-30.jpg","sourceOrder":148,"posterUrl":null,"videoUrl":null},{"id":"work-ff1f44e327b9cb73","name":"从街道到赌场桌的连续镜头预演与生成","description":"Astra 规划全局空间，低多边形预演固定调度，Medeo 上的 Seedance 2.5 渲染。 Astra 的角色是空间规划；最终画面来自 Seedance，不能归作 Astra 原生视频。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@Medeo_AI","url":"https://x.com/Medeo_AI"},"demoUrl":"https://x.com/Medeo_AI/status/2095931387966640231","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-071.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":149},{"id":"work-6ebc1e63c5bf943b","name":"将 Opus 跑车结果与 Pietro 的 Astra 输出对照","description":"作者认为 Opus 更流畅，去除 Astra 的镜头光晕后两者相近。 Astra 输出来自 Pietro 的已有作品，不能说发帖者重新运行 Astra。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@TimJayas","url":"https://x.com/TimJayas"},"demoUrl":"https://x.com/TimJayas/status/2095937263104667824","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-072.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":150},{"id":"work-0683106f933529ae","name":"在 Blender 中构建城市","description":"城市三维场景演示 作者未说明城市名称和具体规模；影视行业预测不属于该成果。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@Loofyb0i","url":"https://x.com/Loofyb0i"},"demoUrl":"https://x.com/Loofyb0i/status/2095941061390573621","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-073.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":151},{"id":"work-67563f80cbce990a","name":"实时流体网站的双模型同提示对照","description":"Astra 与 Fable 使用相同提示，全流程在 Higgsfield Supercomputer。 平台自营演示，未验证数值流体物理或逐模型运行。","category":"experiment","sourceCategory":"CheerSelfAI · 模拟与科学可视化","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2095943653198119309","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-074.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":152},{"id":"work-4b861e6c9fd7d388","name":"把现有 tile map demo 改为巨龙俯视射击游戏","description":"作者称 38 分钟完成。 建立在已有 demo 上，不能描述为完全从零生成。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@PaulSolt","url":"https://x.com/PaulSolt"},"demoUrl":"https://x.com/PaulSolt/status/2095945953412882695","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-075.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":153},{"id":"work-f84bef2242965847","name":"KiCad 中从原理图到 PCB 布局的官方演示解读","description":"由电子原理图转成的 PCB 布局演示 15 秒片段为压缩播放，不代表完成用时。","category":"tool","sourceCategory":"CheerSelfAI · 工程文件与代码迁移","author":{"name":"@lagerskoy","url":"https://x.com/lagerskoy"},"demoUrl":"https://x.com/lagerskoy/status/2095954273498796282","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-076.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":154},{"id":"work-7d5de28f1ac95d7c","name":"火车场景视频及声音克隆误用反馈","description":"作者称 Astra 自行使用了自己的声音克隆。 作者对声音克隆使用提出意外反馈，不能描述为已获专门授权的流程。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@AdamHoltererer","url":"https://x.com/AdamHoltererer"},"demoUrl":"https://x.com/AdamHoltererer/status/2095957170491732276","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-077.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":155},{"id":"work-44d6f4e45566c85c","name":"Call of Duty 风格游戏的首次单轮测试","description":"作者称 Astra 三十分钟，Fable 近五小时，Astra token 更少。 未附账单或统一计时日志，不能推广为整体最快模型。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@WoahWurdz","url":"https://x.com/WoahWurdz"},"demoUrl":"https://x.com/WoahWurdz/status/2095958882732355908","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-078.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":156},{"id":"work-24b1ff07c2bd84f2","name":"Unreal Engine 曼哈顿街区重建的报道","description":"发帖者称 Astra 逐街区迭代约一周。 原始执行者未明确，持续一周及全城规模未核实。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@hitu_monke","url":"https://x.com/hitu_monke"},"demoUrl":"https://x.com/hitu_monke/status/2095961973435314195","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-079.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":157},{"id":"work-860056d898134d87","name":"中途停止后的游戏生成与 UI 比较","description":"作者认为 Astra 的 UI、机制与完整感领先，Kimi 性价比较高。 游戏名称与完整提示未在正文说明。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@adxtyahq","url":"https://x.com/adxtyahq"},"demoUrl":"https://x.com/adxtyahq/status/2095962504543527295","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-080.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":158},{"id":"work-060af4d4bd14c611","name":"纽约场景细节与相机运动的模型比较","description":"在 Codex 运行；完成后追加指令要求相机运动。 作者称初版不到二十分钟、较 Sol 进步，但缺少部分桥梁车辆细节。 时间、细节和与 Opus/Fable 的比较是作者观察。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@aipulseda1ly","url":"https://x.com/aipulseda1ly"},"demoUrl":"https://x.com/aipulseda1ly/status/2095962962808746380","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-081.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":159},{"id":"work-a98fd158dfb78f30","name":"十分钟在 Blender 构建火箭飞船","description":"作者称约十分钟完成。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@SafaElmali","url":"https://x.com/SafaElmali"},"demoUrl":"https://x.com/SafaElmali/status/2095965848066294220","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-082.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":160},{"id":"work-96f2708c08376280","name":"将《远岬夜航》文字转为 Three.js 三维演出","description":"不看渲染画面盲写，不加载外部模型或贴图；作者报告 48 分钟。 时间、盲写和资产约束来自作者描述，未复现。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@cxjwin","url":"https://x.com/cxjwin"},"demoUrl":"https://x.com/cxjwin/status/2095968856682750102","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-083.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":161},{"id":"work-9062557a14776900","name":"前端生成中有无 skills 的对照","description":"两组前端输出对照 未给出 skills 名称、统一提示或量化评价；仅记录明确的条件对照。","category":"other","sourceCategory":"CheerSelfAI · 专业研究与安全评测","author":{"name":"@AdamHoltererer","url":"https://x.com/AdamHoltererer"},"demoUrl":"https://x.com/AdamHoltererer/status/2095970281479180536","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-084.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":162},{"id":"work-d80cb0cdd01c71f7","name":"Unreal Engine 中的多代理生存世界报道","description":"二手转述 Matt Shumer 让 Astra 创建世界，并以 Astra 代理控制角色。 多小时或隔夜运行、自治程度和声音故事为转述，未验证。","category":"experiment","sourceCategory":"CheerSelfAI · 模拟与科学可视化","author":{"name":"@precisox","url":"https://x.com/precisox"},"demoUrl":"https://x.com/precisox/status/2095970738112974973","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-085.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":163},{"id":"work-9db93168aa273a2b","name":"从照片重建 Geisel Library 的三模型对照","description":"根帖补上引用预告中留待 Astra 的建筑重建实验。 平台认为 Astra 在整体结构与细节上表现好。 引用明确 Geisel Library 任务，保留对应来源。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@EnactraAI","url":"https://x.com/EnactraAI"},"demoUrl":"https://x.com/EnactraAI/status/2095971556128399464","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-086.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":164},{"id":"work-429aed92c36ced23","name":"包含可控内饰的汽车驾驶模拟","description":"作者称首次在其测试中没有出现移动控制错误。 GTA 终极版是后续目标，当前只完成驾驶模拟前期任务。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@mirochill","url":"https://x.com/mirochill"},"demoUrl":"https://x.com/mirochill/status/2095971781165076645","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-087.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":165},{"id":"work-6262b071493bcda0","name":"四种灾难场景的 HTML 生成成本对照","description":"每个场景一个自包含 HTML；单轮且不修改。 平台报告 Astra 25159 token、1.67 美元，Fable 37767 token、2.51 美元。 平台自营同题评测，成本与无修改声明未独立复现。","category":"other","sourceCategory":"CheerSelfAI · 专业研究与安全评测","author":{"name":"@aimlapi","url":"https://x.com/aimlapi"},"demoUrl":"https://x.com/aimlapi/status/2095971826656817194","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-088.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":166},{"id":"work-064c1ce3dd910988","name":"Subway Surfers 风格跑酷的单轮测试","description":"作者报告 Astra 二十分钟，Fable 超过一小时且效果较差。 时间、质量和单轮状态均为作者自述，未独立试玩。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@_MaxBlade","url":"https://x.com/_MaxBlade"},"demoUrl":"https://x.com/_MaxBlade/status/2095972303037198821","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-089.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":167},{"id":"work-e979a8d2dd9d41e1","name":"海洋模拟的同提示模型比较","description":"作者认为 Astra 明显优于 Sol，Fable 仍有竞争力。 同提示和质量判断来自作者，未核验模拟物理正确性。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@TimJayas","url":"https://x.com/TimJayas"},"demoUrl":"https://x.com/TimJayas/status/2095972421195141247","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-090.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":168},{"id":"work-4bcf25d8b514437f","name":"单轮生成 BMW M4 CS 模型","description":"Max effort，一次生成。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@HarshithLucky3","url":"https://x.com/HarshithLucky3"},"demoUrl":"https://x.com/HarshithLucky3/status/2095973405111849025","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-091.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":169},{"id":"work-bce9cd3097bc4e9b","name":"使用 ProGPU 的跨平台 2.5D 冒险游戏","description":"使用作者的 ProGPU 渲染库，基于 WebGPU 与 .NET C#。 跨端运行是作者自述，未逐平台测试。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@wieslawsoltes","url":"https://x.com/wieslawsoltes"},"demoUrl":"https://x.com/wieslawsoltes/status/2095973549118804080","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-092.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":170},{"id":"work-3e9cbf0850773aca","name":"使用 Devin 与两项设计 skill 一次生成网站","description":"一次生成的网站设计演示 skill 名称和网站业务未具体公开；原帖有工具步骤，不能描述为无外部指导。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@JustinGorya","url":"https://x.com/JustinGorya"},"demoUrl":"https://x.com/JustinGorya/status/2095977339893039308","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-093.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":171},{"id":"work-115917a682c5fe75","name":"让 Astra 在 Paint 绘制本人肖像","description":"带随帖视频的人像绘画演示 帖子以建议任务形式呈现，原始执行者与绘画准确性未核实。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@vision_ia","url":"https://x.com/vision_ia"},"demoUrl":"https://x.com/vision_ia/status/2095979231444345279","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-094.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":172},{"id":"work-19ed0bc7b5813447","name":"鲁布·戈德堡连锁装置的双模型对照","description":"不用物理引擎；手写逐帧重叠碰撞；固定 1200 帧、60 fps、20 秒录制，反馈观察但不手改代码。 作者报告 Astra 1.84 美元、9 分 56 秒、约 45k token；第二轮才完成。 成本、计时和确定性来自作者测试，未独立复现。","category":"experiment","sourceCategory":"CheerSelfAI · 模拟与科学可视化","author":{"name":"@thehypedotnews","url":"https://x.com/thehypedotnews"},"demoUrl":"https://x.com/thehypedotnews/status/2095980885732704629","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-095.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":173},{"id":"work-8c07bc1aac7235fe","name":"Angry Birds 风格 3D 重建及画质不足反馈","description":"作者对 Astra 的三维画面不满意，认为 Fable 更精致，但称 Astra 价格更低。 保留画质不满意反馈，不能把标题中的 ARR 当作生成游戏收入。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@MozeTech","url":"https://x.com/MozeTech"},"demoUrl":"https://x.com/MozeTech/status/2095981655370666076","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-096.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":174},{"id":"work-ac1c014d58ac1c1c","name":"把大型交易系统代码库转为三维说明网站","description":"两模型研究现有数百万行代码库，并使用 Codex 的 Sites 插件呈现。 作者称两份方案整体相似，细节分析另在线程中。 根帖当前展示部分标为 Sol，Astra 的细节与完整对照未取齐。","category":"tool","sourceCategory":"CheerSelfAI · 工程文件与代码迁移","author":{"name":"@nishffx","url":"https://x.com/nishffx"},"demoUrl":"https://x.com/nishffx/status/2095986973525594614","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-097.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":175},{"id":"work-27b221b993da21d8","name":"从犬吠录音尝试重建空间","description":"把音频交给 Astra，要求尽可能依据声音重建。 声音到空间的推断未以真实测绘核验，不能写成获得准确地图。","category":"other","sourceCategory":"CheerSelfAI · 专业研究与安全评测","author":{"name":"@literallydenis","url":"https://x.com/literallydenis"},"demoUrl":"https://x.com/literallydenis/status/2095989219390844985","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-098.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":176},{"id":"work-083422af645cd8b8","name":"可映射真实手柄输入的交互 PS5 模型","description":"可旋转、按键、拖动摇杆并镜像真实手柄输入的 Three.js 演示 作者给出 Demo 和代码入口，未独立运行或连接手柄验证。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@SafaElmali","url":"https://x.com/SafaElmali"},"demoUrl":"https://x.com/SafaElmali/status/2095989925627789490","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-099.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":177},{"id":"work-82804a4da3ecaa3d","name":"单提示构建可检查的 A380 Blender 模型","description":"发帖者称一条提示生成，可旋转检查比例。 原帖明确不是航空工程级几何，拓扑、材料和系统未验收。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@irinatoxi","url":"https://x.com/irinatoxi"},"demoUrl":"https://x.com/irinatoxi/status/2095991176411119919","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-100.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":178},{"id":"work-924f3a913dc6cbf6","name":"在 Monocode 内生成模型庆祝效果","description":"Monocode 内的庆祝展示效果 原帖未详述视觉形式或实现方式，不能据此补写具体动画。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@nikolay_dp","url":"https://x.com/nikolay_dp"},"demoUrl":"https://x.com/nikolay_dp/status/2095992327240028179","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-101.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":179},{"id":"work-c0070ac97fe27b22","name":"Astra 与 Higgsfield 的可玩广告流程","description":"Astra 构建逻辑和机制，Higgsfield 生成三维世界、角色及资产，再迭代玩法和创意。 平台自营流程演示；未提供实际投放、转化率或批量生成验证。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2095993175659982985","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-102.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":180},{"id":"work-60c76e520618d35d","name":"含烟雾场景的四模型输出与成本复测","description":"作者记录 Astra 11 分钟、12.85 美元；并列出其他模型时间与成本。 具体场景和统一提示未在正文命名，不能进一步推断对象。","category":"other","sourceCategory":"CheerSelfAI · 专业研究与安全评测","author":{"name":"@Bhavani_00007","url":"https://x.com/Bhavani_00007"},"demoUrl":"https://x.com/Bhavani_00007/status/2095993683447611740","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-103.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":181},{"id":"work-23c192403f6f404b","name":"对 Next.js 游戏运动与物理表现的复测","description":"引用先前 Sol 的 Next.js 游戏实验；作者先前表示将用 Astra 重做同一游戏。 同任务关系由同作者前后叙述支持；未给完整提示或量化物理评分。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@b4dgerr","url":"https://x.com/b4dgerr"},"demoUrl":"https://x.com/b4dgerr/status/2095996823039078547","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-104.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":182},{"id":"work-a1ec4fb5a73f1019","name":"含 NPC、职业与巨龙的体素世界","description":"一次生成，回复中提供试玩入口。 作者考虑把测试项目发展为真实游戏。 数量、能力和可玩性为作者自述，未独立统计或试玩。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@knowixbuilds","url":"https://x.com/knowixbuilds"},"demoUrl":"https://x.com/knowixbuilds/status/2095996882678169800","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-105.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":183},{"id":"work-bc04b1a0c152205b","name":"从 SVG 到可拆解的三维硬件网站","description":"先从 SVG 开始，再持续追加要求；提供浏览器体验链接。 多轮生成，未独立打开试玩验证。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@alexprokhorov","url":"https://x.com/alexprokhorov"},"demoUrl":"https://x.com/alexprokhorov/status/2095997514940092704","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-106.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":184},{"id":"work-418ac5c405899c2d","name":"参考图绘制 Sam Altman 人像的偏差测试","description":"作者称视频按实际速度播放，但画面不像输入图。 保留作者明确指出的相似度失败，未量化图像误差或核对播放速度。","category":"experiment","sourceCategory":"CheerSelfAI · 模拟与科学可视化","author":{"name":"@1littlecoder","url":"https://x.com/1littlecoder"},"demoUrl":"https://x.com/1littlecoder/status/2095998329415205240","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-107.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":185},{"id":"work-c3d5e20317651af5","name":"电脑操作创建表格的双模型比较","description":"两个 computer-use agent 的表格创建演示 平台引流演示，未核查表格正确性或操作成功率。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@coastyai","url":"https://x.com/coastyai"},"demoUrl":"https://x.com/coastyai/status/2095999601685963081","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-108.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":186},{"id":"work-1749606705488891","name":"HTML 房屋场景与努力档位比较","description":"作者称 xHigh 约三十分钟，Low 也能得到接近结果且优于 GPT-5.6。 场景质量、时间和档位比较均为作者判断，未复现实验。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@mirochill","url":"https://x.com/mirochill"},"demoUrl":"https://x.com/mirochill/status/2095999828069163119","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-109.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":187},{"id":"work-9f92d7c45bd0c28e","name":"Astra computer use 操作 smash.fun 的失败测试","description":"操作游戏的测试，作者称速度快但尚不能玩好 这是游戏操作能力测试，不是 Astra 创建该游戏。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@kylejeong","url":"https://x.com/kylejeong"},"demoUrl":"https://x.com/kylejeong/status/2096004273876381916","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-110.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":188},{"id":"work-77220a1745fd95c3","name":"巨像题材游戏与控制机制演示","description":"作者评价控制机制理解准确。 控制准确性为作者评价，未独立试玩。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@TimJayas","url":"https://x.com/TimJayas"},"demoUrl":"https://x.com/TimJayas/status/2096005792428437708","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-111.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":189},{"id":"work-dbe2e155452c404d","name":"Crayon 上的 Naruto 题材游戏演示","description":"Naruto 标签的游戏演示 平台展示的简短原帖，具体机制、提示和可玩性未验证。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@usecrayon","url":"https://x.com/usecrayon"},"demoUrl":"https://x.com/usecrayon/status/2096007051378139282","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-112.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":190},{"id":"work-825b0d8636b62cb4","name":"十分钟制作卡通城堡模型","description":"作者称十分钟完成。 制作时间及执行过程为发帖者陈述，未核查原始模型文件。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@digitalcloudno","url":"https://x.com/digitalcloudno"},"demoUrl":"https://x.com/digitalcloudno/status/2096008984331264320","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-113.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":191},{"id":"work-f06ac946d4a99fbe","name":"为 PlayStation 1 制作 3D 格斗原型","description":"制作中的格斗游戏原型 作者明确仍在制作中；未验证可在真机运行。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@GOROman","url":"https://x.com/GOROman"},"demoUrl":"https://x.com/GOROman/status/2096009079105966164","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-114.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":192},{"id":"work-5ee19d60813999ac","name":"将美国自然历史博物馆重建为游戏","description":"Higgsfield Supercomputer 上使用单提示；平台声称 DLSS 5 改善画面。 平台自营演示；单提示、DLSS 5 参与和可玩性均未独立验证。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096009543327404491","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-115.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":193},{"id":"work-e693fb752e65fb45","name":"麦田中的浪人 Three.js 场景","description":"Max reasoning；作者报告约两小时。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@zwb44","url":"https://x.com/zwb44"},"demoUrl":"https://x.com/zwb44/status/2096013227012354507","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-116.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":194},{"id":"work-d0024dfa8e75383c","name":"简易射击游戏","description":"射击游戏演示","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@npaka123","url":"https://x.com/npaka123"},"demoUrl":"https://x.com/npaka123/status/2096013842665124246","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-117.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":195},{"id":"work-99bba54ee5eda907","name":"Sonic Dash Run 3D 游戏演示","description":"发帖者称单提示约花费 5 美元。 原始执行者与费用账单未核实；不把 5 美元视为可复现报价。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@0x0SojalSec","url":"https://x.com/0x0SojalSec"},"demoUrl":"https://x.com/0x0SojalSec/status/2096014293443760198","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-118.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":196},{"id":"work-3e15aebb81ba8296","name":"简易 3D 格斗游戏","description":"3D 格斗游戏演示","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@npaka123","url":"https://x.com/npaka123"},"demoUrl":"https://x.com/npaka123/status/2096014561652666386","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-119.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":197},{"id":"work-a1fdbe4f21f557db","name":"3D 战斗编排的 Astra 与 Fable 对照","description":"作者认为 Fable 总体逻辑略好，但 Astra 的战斗编排更贴近现实。 战斗场景名称、统一提示及完整评分未公开；结论为作者主观比较。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@OmedVibeCodes","url":"https://x.com/OmedVibeCodes"},"demoUrl":"https://x.com/OmedVibeCodes/status/2096016463458951296","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-120.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":198},{"id":"work-662781586936285d","name":"程序化悬浮古寺场景的模型对照","description":"沿用引用帖的提示：黄昏峡谷古寺、程序化 Three.js、布料、风、体积光和闪电，无外部资产。 作者认为 Astra 在细节、运镜、贴图和美感上更好。 任务细节取自同作者被引用的旧实验，根帖明确复用相同提示。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@pradeepXkapoor","url":"https://x.com/pradeepXkapoor"},"demoUrl":"https://x.com/pradeepXkapoor/status/2096016935519760581","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-121.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":199},{"id":"work-82131a163ae009df","name":"可眨眼与挤压的交互饺子宴","description":"Astra Ultra 与 Three.js；作者称 15 分钟。 未独立运行，15 分钟为作者自述。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@mech_eng_dev","url":"https://x.com/mech_eng_dev"},"demoUrl":"https://x.com/mech_eng_dev/status/2096019217698967809","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-122.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":200},{"id":"work-06cd409c615d9669","name":"原生 macOS 游戏的 Astra 与 Sol 单轮对照","description":"无跟进与修正，对照 Astra Ultra 和 Sol Ultra。 作者报告 Astra 32 分 32 秒、Sol 33 分 58 秒，两次合计约占 20x 套餐 5%。 时间与额度为作者自述；套餐百分比不等于 API 成本。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@arthurdisper","url":"https://x.com/arthurdisper"},"demoUrl":"https://x.com/arthurdisper/status/2096019292433404400","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-123.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":201},{"id":"work-61b4b9b45306e91c","name":"单张图片生成弹珠台的局限测试","description":"作者认为视觉处理有效，但隐含机械行为知识仍不足。 保留失败与局部成功；未把可见墙体当完整可玩证明。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@Maoku","url":"https://x.com/Maoku"},"demoUrl":"https://x.com/Maoku/status/2096019402550583440","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-124.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":202},{"id":"work-247a84fb5878acc0","name":"为 ScaleBot 构建热门短视频研究库","description":"作者称使用 Astra 一次生成。 产品方自述演示，功能和真实数据效果未独立验证。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@mikefutia","url":"https://x.com/mikefutia"},"demoUrl":"https://x.com/mikefutia/status/2096019572365181428","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-125.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":203},{"id":"work-13b4d17a65dc9bf7","name":"在现有机甲项目上构建战斗游戏","description":"一次主提示，部分 Three.js 工作使用作者的 Crayon harness。 使用已有机甲项目，不能描述为完全从零。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@aniketjart","url":"https://x.com/aniketjart"},"demoUrl":"https://x.com/aniketjart/status/2096019868713984080","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-126.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":204},{"id":"work-9120d42638daaa50","name":"游戏机风格的个人作品集网站","description":"作者称一轮完成。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@shotatykr","url":"https://x.com/shotatykr"},"demoUrl":"https://x.com/shotatykr/status/2096020111014670364","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-127.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":205},{"id":"work-466526181e067f3a","name":"日经 225 期权交易数据视频化","description":"向 Astra 输入交易数据并一次生成。 仅记录数据呈现任务，未验证数据、计算或交易结论。","category":"experiment","sourceCategory":"CheerSelfAI · 模拟与科学可视化","author":{"name":"@_map_universe_","url":"https://x.com/_map_universe_"},"demoUrl":"https://x.com/_map_universe_/status/2096020997887664450","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-128.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":206},{"id":"work-9fea672e587d95bf","name":"单轮复刻苹果 107 秒宣传视频的测试","description":"沿用作者对各模型使用的固定视频重建任务，一次生成。 作者称 Astra 首次达到其预期。 属于作者自设基准和主观验收，未独立比对原片。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@pallavmac","url":"https://x.com/pallavmac"},"demoUrl":"https://x.com/pallavmac/status/2096022283642949797","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-129.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":207},{"id":"work-4fe0fc2905dcb75c","name":"为町田 SEO 酒场制作网站","description":"作者表示该版本可用。 原帖仅展示网站，未验证线上功能与部署状态。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@shotatykr","url":"https://x.com/shotatykr"},"demoUrl":"https://x.com/shotatykr/status/2096022409359003965","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-130.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":208},{"id":"work-d7028c8bad713f50","name":"照片转角色并集成演讲轨道作品集","description":"在网页搜索、Blender computer use 与代码间切换，生成资产后集成并反复检查调整。 作者的个人演示，未独立运行网站或检查三维资产。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@HowDevelop","url":"https://x.com/HowDevelop"},"demoUrl":"https://x.com/HowDevelop/status/2096023793772998704","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-131.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":209},{"id":"work-25ebcb5814f1beb8","name":"在手机 ChatGPT Work 给视频添加注释","description":"作者在手机应用的 Work 中切换到 Astra 后执行。 原帖也讨论账户开放状态；这里只收录实际视频注释操作。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@taya_mama_AI","url":"https://x.com/taya_mama_AI"},"demoUrl":"https://x.com/taya_mama_AI/status/2096025522203762947","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-132.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":210},{"id":"work-ae401bde86655d9d","name":"统筹虚构咖啡配送服务的宣传视频","description":"手机发出指令，由 Astra 统筹，Remotion 制作信息图，Higgsfield MCP 接入 Seedance 等视频模型。 Astra 承担设计与流程管理，视频画面包含其他模型生成。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@excel_niisan","url":"https://x.com/excel_niisan"},"demoUrl":"https://x.com/excel_niisan/status/2096025670388449650","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-133.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":211},{"id":"work-a02882a8af938a14","name":"Lego Racers 1999 重建的速度与画面对照","description":"两个模型使用相同的一次性重建要求。 作者称 Astra 更快，Fable 5.1 更接近原作画面。 速度和视觉判断来自作者，无标准化计时或完整试玩验证。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@k2sbhai","url":"https://x.com/k2sbhai"},"demoUrl":"https://x.com/k2sbhai/status/2096026282094154134","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-134.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":212},{"id":"work-dcbf85715d9d3b4a","name":"单轮生成室内空间漫游","description":"作者称一次生成。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@aigeboku","url":"https://x.com/aigeboku"},"demoUrl":"https://x.com/aigeboku/status/2096026883377013082","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-135.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":213},{"id":"work-751b90525a33bd65","name":"为 YOLO 制作目标标注","description":"用于 YOLO 的标注演示 原帖未给出数据规模和标注准确率，未独立验证。","category":"tool","sourceCategory":"CheerSelfAI · 工程文件与代码迁移","author":{"name":"@he81tuki26nichi","url":"https://x.com/he81tuki26nichi"},"demoUrl":"https://x.com/he81tuki26nichi/status/2096027634337747036","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-136.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":214},{"id":"work-677b53efb2bb6951","name":"将 3D 模型的线框到贴图过程制成镜头展示","description":"在生成模型后追加指令，要求从线框逐渐添加纹理并用运镜呈现。 具体模型对象未在正文命名；记录的是有明示步骤的展示流程。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@excel_niisan","url":"https://x.com/excel_niisan"},"demoUrl":"https://x.com/excel_niisan/status/2096028906197512609","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-137.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":215},{"id":"work-7807ae1b74dea9a3","name":"Sentinel 中的 DJ 卡车与灯光控制台","description":"作者称数分钟完成。 时间与完整性为作者自述；未测试灯控功能。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@cerspense","url":"https://x.com/cerspense"},"demoUrl":"https://x.com/cerspense/status/2096031686786224173","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-138.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":216},{"id":"work-ca3c79bd44e37636","name":"乐谱视觉特效应用的首屏设计","description":"作者展示 Astra 生成的首屏并评价正面。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@ramonpiano_","url":"https://x.com/ramonpiano_"},"demoUrl":"https://x.com/ramonpiano_/status/2096032278472245437","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-139.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":217},{"id":"work-ae9cbab5a167f6e4","name":"编写 AI 女友应用的演示报道","description":"Clavicular 展示的 AI 女友应用 资讯账号转述 Clavicular 的使用情况，未取得代码或独立验证。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@ClavicularNews","url":"https://x.com/ClavicularNews"},"demoUrl":"https://x.com/ClavicularNews/status/2096032333832806840","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-140.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":218},{"id":"work-b8a4270ff6810825","name":"人形角色生成与 Fable 5.1 对照","description":"作者认为 Astra 有明显进步，并称剩余问题约需 1—2 次修正。 胜负和修正次数是作者判断。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@gimu_ai","url":"https://x.com/gimu_ai"},"demoUrl":"https://x.com/gimu_ai/status/2096032408420434415","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-141.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":219},{"id":"work-29e6537c4869e048","name":"为游戏场景生成路径、资产与空间层次","description":"作者展示场景，并计划后续接入 Crayon。 Crayon 接入仍是后续计划，不能写成已完成。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@TusharXo","url":"https://x.com/TusharXo"},"demoUrl":"https://x.com/TusharXo/status/2096037482739683574","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-142.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":220},{"id":"work-3b7f1e3bbe004be3","name":"Minecraft 红石电路制作","description":"作者测试Astra在Minecraft创建红石电路并展示结果。 未给电路功能或实际保存与运行检查。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@posi_posi8","url":"https://x.com/posi_posi8"},"demoUrl":"https://x.com/posi_posi8/status/2096039492968939702","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-143.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":221},{"id":"work-63556fe7370d21df","name":"Vtuber Live2D 角色与表情尝试","description":"作者尝试让Astra一次创建Vtuber Live2D角色，自动生成表情差分，但未实现手脚动作。 保留部分完成与限制；未验证Live2D工程和绑定。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@aiclass_g2","url":"https://x.com/aiclass_g2"},"demoUrl":"https://x.com/aiclass_g2/status/2096041288261140711","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-144.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":222},{"id":"work-ad6870eea20f9aaa","name":"在线画板绘制 Messi 致敬作品","description":"作者测试Astra寻找在线Paint并绘制致敬Messi的壁画，展示实时操作。 画面质量和操作完成度未独立验收。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@AlanDaitch","url":"https://x.com/AlanDaitch"},"demoUrl":"https://x.com/AlanDaitch/status/2096044340795641999","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-145.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":223},{"id":"work-5ab3761516a711d0","name":"量子主题解说视频","description":"作者让Astra制作量子主题解说视频并展示一次生成结果。 未独立核验科学准确性、旁白和素材来源。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@kyutaro15","url":"https://x.com/kyutaro15"},"demoUrl":"https://x.com/kyutaro15/status/2096045534440210587","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-146.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":224},{"id":"work-12c06bf2dfc45939","name":"酒店广告提示词与 MiniMax H3 成片","description":"作者让Astra编写广告prompt，经Topview MCP在Codex中调用MiniMaxH3生成酒店广告风格视频，发现文字生成不足并考虑今后用Remotion叠字。 现轮明确未用Remotion；旧Kling酒店片只作参照，不归Astra。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@Naonekozamurai","url":"https://x.com/Naonekozamurai"},"demoUrl":"https://x.com/Naonekozamurai/status/2096046087790596522","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-147.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":225},{"id":"work-2820df28062a1daa","name":"Madison 城市飞行展示","description":"作者用Codex与Astra约20分钟制作美国威斯康星Madison的无人机飞越风格展示。 不是实际无人机拍摄；地理精度未核验，物理实验可视化为未来计划。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@birdman9550","url":"https://x.com/birdman9550"},"demoUrl":"https://x.com/birdman9550/status/2096046951657812207","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-148.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":226},{"id":"work-57bb736507eef8f9","name":"进击的巨人风格游戏原型","description":"作者展示另一款用Astra制作的Attack on Titan风格游戏。 未给具体玩法和工程；不与其20星球游戏合并。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@hakmgpt","url":"https://x.com/hakmgpt"},"demoUrl":"https://x.com/hakmgpt/status/2096047406424928348","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-149.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":227},{"id":"work-43dca768fdc3fc62","name":"随歌曲变化的 3D 企鹅舞蹈","description":"作者用Astra制作分析歌曲并生成对应企鹅动画的应用，称包含自建3D模型、灯光系统和50多种动画变体，每首歌有不同表现。 曲目分析、变体数量和动画同步未独立验证。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@manandua","url":"https://x.com/manandua"},"demoUrl":"https://x.com/manandua/status/2096047454219391018","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-150.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":228},{"id":"work-03b44c982bfdea81","name":"按创作者风格生成游戏","description":"作者让Astra研究yungcontent并创建符合其风格的游戏，称一次生成。 未给具体风格判定或游戏机制，不推断实际研究来源。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@yungcontent","url":"https://x.com/yungcontent"},"demoUrl":"https://x.com/yungcontent/status/2096047904582721772","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-151.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":229},{"id":"work-82eed0ec454d2844","name":"WebGL GTA6 风格游戏原型","description":"作者粗略要求Astra Pro制作WebGL可操作GTA6风格游戏，称20分钟完成展示版本。 不代表商业原作范围；未试玩机制。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@kgsi","url":"https://x.com/kgsi"},"demoUrl":"https://x.com/kgsi/status/2096048662304666098","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-152.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":230},{"id":"work-e62bb4ecc6dee84d","name":"躲避撞人男子的交互游戏","description":"作者用Astra创建躲避撞人男子的游戏，被撞3次或反击3次即结束，含结尾演出和随机暴走角色。 仅虚构游戏机制，未独立测试难度和碰撞判定。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@AiFreak_tool","url":"https://x.com/AiFreak_tool"},"demoUrl":"https://x.com/AiFreak_tool/status/2096049700172648585","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-153.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":231},{"id":"work-ade19d00b287ae2a","name":"风暴航海场景的模型对照","description":"Topview将Astra与Fable5.1用于同一风暴航海场景，展示波浪和人群画面并比较电影感。 平台自营主观对照；不假定Astra原生生成视频，底层工作流未细分。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@TopviewAIJP","url":"https://x.com/TopviewAIJP"},"demoUrl":"https://x.com/TopviewAIJP/status/2096053141838160045","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-154.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":232},{"id":"work-8c02b8e9b7269c41","name":"深陵·秦宫星河交互地下世界","description":"作者把先前单个3D兵马俑项目升级为深陵·秦宫星河，用Astra、Blender和Three.js约30分钟生成120兵俑、自由漫游与星盘机关，称模型源码可编辑且本地可玩。 数量、工程和交互均未独立检查；初模与本次升级归同项目。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@servasyy_ai","url":"https://x.com/servasyy_ai"},"demoUrl":"https://x.com/servasyy_ai/status/2096055030675906575","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-155.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":233},{"id":"work-1a1a6b65f931125f","name":"3D 汽车建模的 Astra 与 Fable 对照","description":"TypingMind展示让Astra与Fable5.1构建3D汽车的比较。 平台自营；具体prompt、工具、时间与评分未给。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@TypingMindApp","url":"https://x.com/TypingMindApp"},"demoUrl":"https://x.com/TypingMindApp/status/2096057056340177302","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-156.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":234},{"id":"work-8d46417ba0a9fa48","name":"Krita 照片重绘与金门大桥添加","description":"转述官方示范：把照片交给Astra，经computer use在Krita画成梵高风格并添加金门大桥。 二手官方演示，不验证图像准确性；其余能力介绍不另算案例。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@xiaohu","url":"https://x.com/xiaohu"},"demoUrl":"https://x.com/xiaohu/status/2096057117061136838","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-157.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":235},{"id":"work-d227f466c8bd0deb","name":"电脑操作钢琴演奏测试","description":"作者测试Astra computer use演奏一首钢琴曲并附录屏。 曲名、软件和完成质量未说明；不与其他作者同题合并。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@yanhua1010","url":"https://x.com/yanhua1010"},"demoUrl":"https://x.com/yanhua1010/status/2096057156202353027","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-158.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":236},{"id":"work-3e1d2b98e18c362d","name":"办公室视频转可探索 3D 空间","description":"GMI Cloud称向Astra提供办公室视频，不到1小时得到接近原貌的可探索3D空间。 平台自营自述；未验证尺寸、还原度与可探索性。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@gmi_cloud","url":"https://x.com/gmi_cloud"},"demoUrl":"https://x.com/gmi_cloud/status/2096058488648798400","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-159.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":237},{"id":"work-7b1099e4824dfe9e","name":"温泉小镇场景","description":"作者让Astra制作自己的温泉小镇世界并展示结果。 场景工具、交互和细节未说明。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@taishik_","url":"https://x.com/taishik_"},"demoUrl":"https://x.com/taishik_/status/2096059031475359906","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-160.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":238},{"id":"work-9de2d21cf21a78fe","name":"一行提示生成 3D 游戏","description":"作者称用约一行提示让Astra制作精细3D游戏，主观认为超过Fable。 无游戏题材和玩法；不把主观优劣当基准。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@masahirochaen","url":"https://x.com/masahirochaen"},"demoUrl":"https://x.com/masahirochaen/status/2096061462032826495","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-162.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":239},{"id":"work-3b279d23022dea0f","name":"经需求访谈生成视频编辑应用","description":"作者以先询问功能和规格的要求启动Astra，约30分钟生成视频编辑应用并认为达到实用水平。 实用性是作者主观判断；具体编辑功能和文件处理未验收。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@old_pgmrs_will","url":"https://x.com/old_pgmrs_will"},"demoUrl":"https://x.com/old_pgmrs_will/status/2096063127125434701","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-164.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":240},{"id":"work-eebba4c09c50ea72","name":"双 PCB 穿戴设备外壳设计","description":"作者把PCB模型交给Astra，在Fusion360设计容纳两块板、电池、外部电源键和衣物磁吸结构的穿戴设备外壳。 3D打印、PCBA和通电均为下一步，未制造验证。","category":"tool","sourceCategory":"CheerSelfAI · 工程文件与代码迁移","author":{"name":"@Peter05704721","url":"https://x.com/Peter05704721"},"demoUrl":"https://x.com/Peter05704721/status/2096064163831513165","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-165.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":241},{"id":"work-fdd0220c616d46eb","name":"合唱音轨补掌声与乐谱跟随练习视频","description":"作者给Astra已购男高音2音轨、八声部乐谱PDF和参考视频，约20分钟按谱补合成掌声到mp3；再约20分钟制作乐谱随播放按小节高亮的练习视频。 未独立检查乐谱对齐和音频；产品化为未来设想，Fable5.1对照尚未执行。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@Gonnector","url":"https://x.com/Gonnector"},"demoUrl":"https://x.com/Gonnector/status/2096064375870333249","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-167.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":242},{"id":"work-27a42fae59ad0734","name":"俯视角多人撤离射击游戏","description":"作者称Astra一次生成俯视角多人撤离射击游戏，图形、声音与玩法通过Blender和Unity完成。 多人、质量、速度与费用优于旧模型为作者主张；未实际测试。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@AlexFinn","url":"https://x.com/AlexFinn"},"demoUrl":"https://x.com/AlexFinn/status/2096065384290128372","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-168.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":243},{"id":"work-f95cd7ae27b1cbca","name":"八款浏览器游戏的同题模型对照","description":"作者让Astra和Fable各生成8款浏览器游戏，主题包括躲避球、卡丁车、GTA、Mario、ARPG、网球、Flappy Bird及跑酷；报告Astra平均15分钟对47分钟，画面更好但游戏性较弱。 本视频只展示GTA、卡丁车与躲避球；整组自述作为1次比较实验，不拆8条。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@chenchengpro","url":"https://x.com/chenchengpro"},"demoUrl":"https://x.com/chenchengpro/status/2096066915504652776","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-169.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":244},{"id":"work-046ef57b794d525c","name":"24 秒宇宙主题发布庆祝短片","description":"作者围绕Astra上线和额度重置制作24秒宇宙庆祝视频，列Astra、HyperFrames与ElevenLabs为制作工具。 音频与画面依赖工具；具体Astra执行步骤未详述。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@takamasa045","url":"https://x.com/takamasa045"},"demoUrl":"https://x.com/takamasa045/status/2096068927415849406","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-170.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":245},{"id":"work-d5b33c158387fc02","name":"Apple Park 照片重建","description":"转述Astra依据数张照片在Blender重建Apple Park，包含环形建筑、内室、桌椅、景观与Steve Jobs Theater。 完全还原为宣传说法；未取原执行者工程和建筑精度。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@masahirochaen","url":"https://x.com/masahirochaen"},"demoUrl":"https://x.com/masahirochaen/status/2096071849079865785","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-171.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":246},{"id":"work-3928a7173298aef6","name":"Blender iMac 与鼠标模型","description":"作者用Astra High要求在Blender创建iMac和鼠标并展示结果。 没有具体流程、尺寸或结构验收。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@diegocabezas01","url":"https://x.com/diegocabezas01"},"demoUrl":"https://x.com/diegocabezas01/status/2096072775865643194","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-172.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":247},{"id":"work-97af573d7124b67a","name":"F1 赛车照片转可旋转 Three.js 模型","description":"作者给Astra一张Kimi Antonelli的Mercedes F1车照片，约15分钟制作可旋转的Three.js模型。 未验证几何准确性或模型工程。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@CoastalFuturist","url":"https://x.com/CoastalFuturist"},"demoUrl":"https://x.com/CoastalFuturist/status/2096073154686771380","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-173.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":248},{"id":"work-d127d52e910412e5","name":"Theme Park 游戏重建","description":"作者把Theme Park的Wiki链接与DOS版说明书给Astra，要求制作游戏并展示一次生成结果。 文档理解和玩法覆盖未核验，不等于完整原作复制。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@nodchip","url":"https://x.com/nodchip"},"demoUrl":"https://x.com/nodchip/status/2096073907031921045","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-174.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":249},{"id":"work-7b57c8f3f8788726","name":"Three.js 星月夜油画空间","description":"二手帖展示Astra将梵高星月夜转换为可进入的Three.js空间，描述立体笔触与流动漩涡。 原执行者未明确；不采信第一次听懂画家等宣传叙述。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@NFT_Chen","url":"https://x.com/NFT_Chen"},"demoUrl":"https://x.com/NFT_Chen/status/2096075112860856815","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-175.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":250},{"id":"work-e31448bdcd1aed6a","name":"两张照片参考的 Canva 肖像","description":"作者给Astra两张本人照片，让其通过浏览器在Canva中绘制本人。 提问耗时和成本但未给数值，保持未知。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@nateherk","url":"https://x.com/nateherk"},"demoUrl":"https://x.com/nateherk/status/2096075129885204811","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-176.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":251},{"id":"work-29efa8685af49ec4","name":"甜甜圈建模与糖霜落下展示动画","description":"作者先用Astra在Blender约10分钟渲染甜甜圈模型，再要求展示视频，得到糖霜落下动画和镜头运动。 两帖属于同一作品进展；未验模型及动画工程。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@op7418","url":"https://x.com/op7418"},"demoUrl":"https://x.com/op7418/status/2096077414157922681","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-177.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":252},{"id":"work-b6bf1ec746001cd6","name":"3D 鹈鹕骑车模型演示","description":"作者转述群友用Astra制作3D骑车鹈鹕。 原作者身份、流程和模型文件缺失；不与其他作者同题实验强行合并。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@zhang_baoqing","url":"https://x.com/zhang_baoqing"},"demoUrl":"https://x.com/zhang_baoqing/status/2096077580155924741","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-178.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":253},{"id":"work-53bc78361f5c1e04","name":"Astral War 浏览器多人射击游戏","description":"作者在旧Modern Claudefare项目上用Astra Ultra fast一天制作Astral War，结合Three.js、Meshy与ElevenLabs，称支持人类/亡灵、单人/多人、手柄、私房语音及最多12人权威服务器。 是现有游戏改造；网络稳定性、12人同房与声聊未独立测试。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@0xRishi","url":"https://x.com/0xRishi"},"demoUrl":"https://x.com/0xRishi/status/2096079660605997264","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-179.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":254},{"id":"work-4ec50b42cb2f65fe","name":"为已有 PowerPoint 添加动画","description":"作者让Astra通过PC操作给已有PowerPoint添加自然动画；引用说明原文稿由Fable5.1和skills制作。 只把动画修改归Astra，非从零生成PPT；未验播放和兼容性。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@taiyo_ai_gakuse","url":"https://x.com/taiyo_ai_gakuse"},"demoUrl":"https://x.com/taiyo_ai_gakuse/status/2096079684626980876","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-180.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":255},{"id":"work-e30ff1863140be67","name":"Grok Bot 数字团队配置","description":"作者把已设计的Grok Bot方案交给Astra computer use，称不到10分钟建立7个bot、2个群、5个skill和定时任务。 机器人创建开头未录到；未验证具体bot职责与运行结果。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@GeekCatX","url":"https://x.com/GeekCatX"},"demoUrl":"https://x.com/GeekCatX/status/2096081110354845903","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-181.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":256},{"id":"work-26bb38b1b6b15a07","name":"参考图重建地球仪仪表盘","description":"作者沿用一张参考图及prompt测试Astra重建Three.js地球仪仪表盘，称一次补出图中未明说的日夜模式和2D/3D视图切换。 像素级和优于前代为单作者主观比较；未复验交互。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@hqmank","url":"https://x.com/hqmank"},"demoUrl":"https://x.com/hqmank/status/2096082432197837065","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-182.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":257},{"id":"work-b3f961ce388e3c5a","name":"Hermès 巴黎生活方式广告提示词","description":"作者用Astra编写30秒巴黎生活方式Hermès时装广告提示词，再交给Seedance2.5生成视频，指定同一人物、Kelly手袋及丝巾的连续性。 为创作者品牌风格测试，不代表品牌委托或投放；视频来自Seedance。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@johnAGI168","url":"https://x.com/johnAGI168"},"demoUrl":"https://x.com/johnAGI168/status/2096082626364788752","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-184.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":258},{"id":"work-7d089f6d00aaf8eb","name":"Photoshop 照片肖像绘制","description":"作者让Astra参考本人照片在Photoshop绘画并展示结果。 未检查绘制步骤和图像质量。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@icreatelife","url":"https://x.com/icreatelife"},"demoUrl":"https://x.com/icreatelife/status/2096083750870261882","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-185.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":259},{"id":"work-ec7b10660eec288d","name":"Blender 模型到 Unity 游戏流程","description":"作者经Astra和Blender MCP自然语言建模，再由Unity CLI将模型做成游戏并报告运行成功。 未给具体游戏主题和工程；不推断玩法完整性。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@keitowebai","url":"https://x.com/keitowebai"},"demoUrl":"https://x.com/keitowebai/status/2096085354529144842","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-186.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":260},{"id":"work-dfc11c8622a0e234","name":"七套穿搭连续展示的提示词","description":"作者用Astra编写同角色同场景连续展示7套Look的视频prompt，再以MiniMax H3生成视频，评价切换顺序、节点和动作更准确。 此前5套用Seedance2.0，不归Astra；效果自述且复杂prompt几乎耗尽一轮额度。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@Chengzilhy","url":"https://x.com/Chengzilhy"},"demoUrl":"https://x.com/Chengzilhy/status/2096086827467932140","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-187.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":261},{"id":"work-b75497ab05284231","name":"吉萨大金字塔几何到影片","description":"平台用Astra创建吉萨大金字塔几何，再经Seedance2.5生成最终画面。 平台自营多工具展示；未验证历史或工程准确性。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096088339548115037","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-188.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":262},{"id":"work-1202e063cd2b3428","name":"Hogwarts 场景整体生成测试","description":"作者让Astra High制作Hogwarts，认为空间和持续操作较强，但一次要求全部制作仍粗糙，建议按房间或资产拆解。 建议属于作者经验；未验证拆解后是否更好。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@YuYoshimuta","url":"https://x.com/YuYoshimuta"},"demoUrl":"https://x.com/YuYoshimuta/status/2096091847366242740","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-190.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":263},{"id":"work-3f7a7fd744dbf502","name":"旧客厅扫描转 Blender 重建","description":"作者给Astra父母客厅的旧3D扫描，要求从头在Blender建模，称纹理来自自己的摄影测量扫描并生成程序化shaders，无下载资产。 有扫描输入，不是无素材从零；还原与资产来源未独立验收。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@bilawalsidhu","url":"https://x.com/bilawalsidhu"},"demoUrl":"https://x.com/bilawalsidhu/status/2096092080397246707","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-191.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":264},{"id":"work-2de50d5b3fa5a7e4","name":"iPod 3D 模型与 Mac 对话展示 App","description":"作者首次安装Blender，让Astra建模iPod并做成Mac App，支持物理交互及Codex对话记录展示。 未验证App构建、交互和数据持久化。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@BystAnd3rs","url":"https://x.com/BystAnd3rs"},"demoUrl":"https://x.com/BystAnd3rs/status/2096092297381531713","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-192.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":265},{"id":"work-10df98cfc5f78f64","name":"Pokepia 场景搭建与迭代","description":"作者连接Blender用Astra约10分钟搭好Pokepia基础场景，再调整两轮提示，总计约1小时和12%周额度。 额度及耗时为自述；未检查具体场景细节和工程。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@LerSentAI","url":"https://x.com/LerSentAI"},"demoUrl":"https://x.com/LerSentAI/status/2096092845962637622","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-193.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":266},{"id":"work-a91052841da04e11","name":"已有个人网站的界面更新","description":"作者用6 Astra更新自己的站点，展示效果并反映token消耗快。 具体改动和token数未披露；不写成整站从零构建。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@KeKeYa88","url":"https://x.com/KeKeYa88"},"demoUrl":"https://x.com/KeKeYa88/status/2096092871208440314","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-194.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":267},{"id":"work-95d76da624cbe183","name":"六复音减法合成器","description":"作者展示Astra一次生成的6-poly减法合成器。 未检查声部、振荡器和音频输出行为。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@yskmsd","url":"https://x.com/yskmsd"},"demoUrl":"https://x.com/yskmsd/status/2096092961780228228","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-195.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":268},{"id":"work-ebbbd445c6348c7f","name":"黑洞诞生的 WebGL 演示内容","description":"作者让Astra用WebGL制作黑洞诞生主题的幻灯或演示内容，约20分钟产出。 科学表述和视觉物理精度未核验。","category":"experiment","sourceCategory":"CheerSelfAI · 模拟与科学可视化","author":{"name":"@zeeeeeen","url":"https://x.com/zeeeeeen"},"demoUrl":"https://x.com/zeeeeeen/status/2096093614397170104","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-196.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":269},{"id":"work-5631717b23d01996","name":"Product Design 插件制作 AI 科普个人网站","description":"作者在Codex安装Product Design插件，用一句需求生成G哥太空漫步站点，含Hero、AI主题卡片、学习路径、介绍和CTA。 结果依赖插件；未验证上线、移动端和用户效果。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@goan999999","url":"https://x.com/goan999999"},"demoUrl":"https://x.com/goan999999/status/2096093868118708666","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-197.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":270},{"id":"work-ed12fe6a61e81c22","name":"悉尼歌剧院代码建模与渲染","description":"Higgsfield用Astra输出悉尼歌剧院代码，Blender转成可编辑几何，Cycles进行路径追踪光照。 平台自述；没有建筑精度或工程验收。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096095994991800573","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-199.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":271},{"id":"work-01d5b6f1dcde4744","name":"游乐场高速跑酷动态分镜","description":"作者用Astra和TypeScript/Remotion在笔记本上数分钟构建游乐场跑酷动态分镜，要求WebGL共用3D坐标、不同高度设施和多机位，渲染为MP4。 prompt约束不等于每项已验收；未读取成片工程或检查镜头接触连续性。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@Kashiko_AIart","url":"https://x.com/Kashiko_AIart"},"demoUrl":"https://x.com/Kashiko_AIart/status/2096096560690209130","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-200.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":272},{"id":"work-e0d80eb328d9e38b","name":"苏州博物馆庭园重建与配乐巡游","description":"作者给Astra一个网页和prompt，在Blender重建苏州博物馆庭园并输出60秒连续漫游，称模型自行调用MiniMax Music3生成古琴、古筝、钢琴与大提琴配乐。 网页和建筑还原度未验证；配乐由MiniMax生成。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@whosamberella","url":"https://x.com/whosamberella"},"demoUrl":"https://x.com/whosamberella/status/2096096998092841449","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-201.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":273},{"id":"work-d9822c080cad9a5c","name":"最小可玩 3D 格斗游戏","description":"作者让Codex中的Astra制作最低限度能运行的3D格斗游戏并展示结果。 未试玩检验动作和碰撞。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@alfredplpl","url":"https://x.com/alfredplpl"},"demoUrl":"https://x.com/alfredplpl/status/2096098790986109047","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-202.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":274},{"id":"work-bcff9f92548d47b5","name":"3D 怪兽养成游戏原型","description":"作者使用Astra制作怪兽养成游戏，展示简单prompt生成的3D版本，仍认为继续打磨可提升。 进行中原型，不视为完整高品质游戏。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@seki_anos","url":"https://x.com/seki_anos"},"demoUrl":"https://x.com/seki_anos/status/2096099608531538303","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-203.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":275},{"id":"work-7945b3ee95d39d2e","name":"NES 烈火风格射击游戏","description":"作者让Astra创建类似Summer Carnival92烈火的NES射击游戏，采用KITAQFC编译器、KUROSAKI调试模拟器与SARAKURA观测平台，无敌模式录屏。 录屏用无敌模式；未在NES实机验收，工具还未公开发布。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@bartaro","url":"https://x.com/bartaro"},"demoUrl":"https://x.com/bartaro/status/2096099649275019512","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-204.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":276},{"id":"work-bfe337c32a2ee672","name":"星际旅行浏览器游戏","description":"作者让Astra制作以Astra星群旅行为主题的浏览器游戏。 玩法与运行情况未独立检查。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@AILogDev","url":"https://x.com/AILogDev"},"demoUrl":"https://x.com/AILogDev/status/2096101439336743159","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-205.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":277},{"id":"work-3d694a6d14e78d58","name":"巴比伦空中花园的描述重建","description":"Higgsfield让Astra建立空中花园几何，再用Seedance2.5生成最终画面。 未发现实物的历史建筑属概念重建，不是考古验证。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096101502045835527","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-206.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":278},{"id":"work-921074fa02bc407b","name":"动作捕捉到 Unity 的重定向管线","description":"作者用3个Astra Medium与1个xHigh运行goal约2小时，打通模型、绑定、动作/面部/手指捕捉重定向至Unity测试，称用约12%周额度。 建立在卡住一两个月的已有工程上；指标和完整效果为自述。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@DLKFZWilliam2","url":"https://x.com/DLKFZWilliam2"},"demoUrl":"https://x.com/DLKFZWilliam2/status/2096106328787951710","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-207.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":279},{"id":"work-ed9f0d00197d178e","name":"阿尔忒弥斯神庙的描述到几何重构","description":"Higgsfield让Astra依据古代描述生成可编辑神庙几何，Seedance2.5加入电影化画面。 不验证历史建筑尺寸与真实性；平台自营多工具流程。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096109301916205380","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-208.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":280},{"id":"work-e86ffc1f3fd760b6","name":"こけこけ角色宇宙漂浮动画","description":"作者把已生成的こけこけ3D模型交给Astra，制作角色在宇宙漂浮的视频。 现有模型创建归属未完整明确；只把本次动画任务归Astra。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@akifumi_ai","url":"https://x.com/akifumi_ai"},"demoUrl":"https://x.com/akifumi_ai/status/2096110251397562826","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-209.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":281},{"id":"work-7a80b02e881a8b57","name":"Raven 个人项目介绍视频","description":"作者用Astra的3D与网页能力制作个人项目raven的介绍视频，先提供期望风格。 未取得完整工程或验证视频对产品描述准确性。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@zhengli","url":"https://x.com/zhengli"},"demoUrl":"https://x.com/zhengli/status/2096110412320350680","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-210.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":282},{"id":"work-68b09dd470855fe4","name":"微鼠迷宫探索模拟器与算法改进","description":"作者让Astra制作微鼠探索模拟器并改进探索算法。 未给算法指标或实体机器人测试。","category":"experiment","sourceCategory":"CheerSelfAI · 模拟与科学可视化","author":{"name":"@xfa273","url":"https://x.com/xfa273"},"demoUrl":"https://x.com/xfa273/status/2096110473989197942","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-211.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":283},{"id":"work-f49ede1a423901a3","name":"手游广告转可玩浏览器游戏","description":"作者用Astra参考手机游戏广告，经Blender构建不到30分钟的小型浏览器游戏，认为与参考接近。 广告和具体游戏名未写，未验证相似度与玩法。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@buildingadlicio","url":"https://x.com/buildingadlicio"},"demoUrl":"https://x.com/buildingadlicio/status/2096111709496680842","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-212.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":284},{"id":"work-4779e2f813788fc5","name":"Clip Studio 参考角色逐笔绘制","description":"作者让Astra操作Clip Studio逐笔画附件角色，展示完成作品并讨论观察绘制过程的体验。 未声明与后续草稿上色测试为同图，暂不合并；作品质量未独立验收。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@gigabit_million","url":"https://x.com/gigabit_million"},"demoUrl":"https://x.com/gigabit_million/status/2096111940078858734","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-213.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":285},{"id":"work-f06de90cd85c67b6","name":"奥林匹亚宙斯神像的几何与成片","description":"Higgsfield依据文字描述用Astra写3D结构，再以Seedance2.5生成奥林匹亚宙斯神像影片。 历史建筑为想象重构，不是考古准确性验收；平台自营展示。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096112876360790493","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-214.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":286},{"id":"work-4659d6b771c55978","name":"AI 城市视频转可行走 3D 空间","description":"作者用Astra参考Midjourney加Kling生成的街道视频，制作可自行行走的3D空间，当前是首次产物，细腻材质仍待完善。 视频模型提供视觉参考；未检验场景拓扑与交互。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@onofumi_AI","url":"https://x.com/onofumi_AI"},"demoUrl":"https://x.com/onofumi_AI/status/2096113261204979897","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-215.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":287},{"id":"work-67f59136bf65ae01","name":"官方指南转 95 秒日语模型解说","description":"作者把OpenAI官方指南交给Codex中的Astra，生成含3D演出和日语旁白的95秒解说视频，并在途中调整指令与思考深度。 未独立核查解说事实、声音来源或完整工程。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@kawai_design","url":"https://x.com/kawai_design"},"demoUrl":"https://x.com/kawai_design/status/2096115698124865645","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-216.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":288},{"id":"work-3496698d1acefafb","name":"Three.js WebGPU 动画网站教程","description":"作者录制10分钟教程，展示使用Astra和Three.js WebGPU制作3D动画网站。 award-winning是宣传形容，未验证实际获奖；教程未完整播放。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@viktoroddy","url":"https://x.com/viktoroddy"},"demoUrl":"https://x.com/viktoroddy/status/2096115863158133107","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-217.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":289},{"id":"work-f6d9926d6dc57301","name":"照片转セラドニア与角蛙 3D 模型","description":"作者用Astra根据照片制作セラドニア与角蛙两类动物的3D模型，并与实物对比。 未确认首个动物日文名的规范中文译名，保留原文；未验几何。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@nakanokaeru","url":"https://x.com/nakanokaeru"},"demoUrl":"https://x.com/nakanokaeru/status/2096116438398615974","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-218.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":290},{"id":"work-81260287664df4c2","name":"肖像参考反推交互布光方案","description":"作者用Codex和Astra Ultra制作肖像布光工具，输入照片后生成可调主灯、轮廓灯、反光板与相机方案，改灯同步改变脸部阴影；约20分钟初版后迭代并剪辑介绍视频。 仅轻量原型，不能视为真实物理反演精确结果。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@takeborn299","url":"https://x.com/takeborn299"},"demoUrl":"https://x.com/takeborn299/status/2096116536327197129","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-219.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":291},{"id":"work-de545e9886f1c57e","name":"Blender 资产驱动的浏览器游戏","description":"作者让Astra用Blender生成游戏资产，称一次生成的游戏已在浏览器运行。 游戏题材、玩法及完整性未说明。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@chimze_art","url":"https://x.com/chimze_art"},"demoUrl":"https://x.com/chimze_art/status/2096117651911106570","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-220.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":292},{"id":"work-e20d6f1f2a070a71","name":"浏览器 FPS 的武器手感与瞄准镜","description":"作者用Astra构建浏览器FPS，再迭代更重后坐力、武器重量和冲击，并要求仅镜内放大，附试玩链接。 多轮打磨，不是一次完成；未独立试玩枪械反馈。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@superalesha","url":"https://x.com/superalesha"},"demoUrl":"https://x.com/superalesha/status/2096117875908235764","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-221.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":293},{"id":"work-ea25c2b068337430","name":"单张帆船图片转可编辑 3D","description":"作者安装Blender后把帆船图片给Astra，让其编写代码在Blender重建，不配置MCP，得到细节粗略但可编辑的3D。 未检验比例、拓扑和可编辑性。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@Kohaku_NFT","url":"https://x.com/Kohaku_NFT"},"demoUrl":"https://x.com/Kohaku_NFT/status/2096120541816205631","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-222.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":294},{"id":"work-6c93e55edb0a2a79","name":"HTML 重制 Machine Age 风格发布视频","description":"作者在自有HyperFrames harness运行Astra，仅用HTML重制a16z Machine Age视频为模型发布片。 原片为参考；完整code2video基准仍在运行，未交付基准结果。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@liu8in","url":"https://x.com/liu8in"},"demoUrl":"https://x.com/liu8in/status/2096120563156779229","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-223.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":295},{"id":"work-61868c8df139d7d8","name":"飞机工厂的实时 3D 制造模拟","description":"作者要求Astra研究飞机制造与Airsup精益生产资料，设计Texas喷气机工厂，建立实时Three.js模拟、测试并部署。 工厂设计可行性、制造数据和模拟精度未独立验收。","category":"experiment","sourceCategory":"CheerSelfAI · 模拟与科学可视化","author":{"name":"@konstantinsaifo","url":"https://x.com/konstantinsaifo"},"demoUrl":"https://x.com/konstantinsaifo/status/2096122429319852319","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-224.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":296},{"id":"work-f4539d468d473f25","name":"电子表格头像创作","description":"作者让Astra在电子表格中围绕自己的头像进行创作并展示结果。 根帖没有软件和单元格实现细节，不推断像素数量或格式。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@yungcontent","url":"https://x.com/yungcontent"},"demoUrl":"https://x.com/yungcontent/status/2096122927221805462","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-225.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":297},{"id":"work-7fe40bbf5aa287a5","name":"在线演奏录制并交付音乐文件","description":"作者让Astra通过computer use寻找能在线演奏录制的网站，交付mp3，再转成mp4；称歌曲用掉5小时额度80%，转视频耗尽剩余。 音乐质量和原创性未核验；额度不是费用。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@trxuanxw","url":"https://x.com/trxuanxw"},"demoUrl":"https://x.com/trxuanxw/status/2096123074081091753","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-226.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":298},{"id":"work-7feeb81639f811bc","name":"赛博朋克横版游戏的配色测试","description":"作者测试Astra生成赛博朋克横版游戏，观察模型持续偏向粉彩，但认为仍是该组测试中最好结果。 比较模型、prompt与评价标准未完整披露；主观测试。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@NeoAIForecast","url":"https://x.com/NeoAIForecast"},"demoUrl":"https://x.com/NeoAIForecast/status/2096123621978812526","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-227.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":299},{"id":"work-589741280007327b","name":"鼠标操作绘制自画像","description":"作者让Astra computer use绘制自己的画像，称画面全部由AI鼠标操作完成。 根帖未指明软件；其他相同媒体转载声称Canva可作为补充，当前不臆定。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@keitowebai","url":"https://x.com/keitowebai"},"demoUrl":"https://x.com/keitowebai/status/2096124169406775325","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-228.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":300},{"id":"work-cbd4589bcae2eb6e","name":"Blender 一级方程式赛车模型","description":"作者用Astra Extra High经computer use在Blender制作F1赛车模型，报告23分34秒。 未验证几何尺寸或工程模型可用性。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@Conor_D_Dart","url":"https://x.com/Conor_D_Dart"},"demoUrl":"https://x.com/Conor_D_Dart/status/2096125193580113957","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-229.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":301},{"id":"work-0fec578f2c02638e","name":"Canva 肖像绘制演示","description":"作者展示或建议让Astra在Canva绘制本人肖像。 未给原执行者或实际绘画过程说明；不与不同媒体的同题肖像强行合并。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@vision_ia","url":"https://x.com/vision_ia"},"demoUrl":"https://x.com/vision_ia/status/2096125394470506713","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-230.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":302},{"id":"work-f9d7b11155ce1d00","name":"ChatGPT Work 云端 PSP 游戏开发","description":"作者经3至4轮对话让Astra完成PSP游戏的建模、绑定、构建测试，并在云端自动设置PPSSPP环境录制视频。 不是单次指令；未在PSP实机验证。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@bunkaich","url":"https://x.com/bunkaich"},"demoUrl":"https://x.com/bunkaich/status/2096126334628139221","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-231.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":303},{"id":"work-da1cdf46ce2ee4e0","name":"Jeep 游戏的 Astra High 复测","description":"作者用Astra High复测此前Sol Ultra提示并展示Jeep游戏，提到增加鸟鸣。 Jeep主题由同媒体转载补证；未获取完整prompt或实际用量。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@SadAlbert10","url":"https://x.com/SadAlbert10"},"demoUrl":"https://x.com/SadAlbert10/status/2096126384964088230","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-232.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":304},{"id":"work-9f352242085664c3","name":"CROWNFALL 第一人称射击游戏","description":"作者称Astra在10分钟内生成带Kael角色的CROWNFALL FPS，未使用Blender MCP。 不采信AAA品质宣传；功能完整性未试玩验证。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@HexxRL","url":"https://x.com/HexxRL"},"demoUrl":"https://x.com/HexxRL/status/2096126718930997609","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-233.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":305},{"id":"work-04e9c9578018d496","name":"实时棋类游戏胶囊演出修复","description":"作者用Astra修复过去反复未修好的胶囊演出，明确产物为游戏内资产，引用同作者无回合实时棋类项目。 不是AI视频；关卡和地形机制仍是后续计划。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@ShadeLurk","url":"https://x.com/ShadeLurk"},"demoUrl":"https://x.com/ShadeLurk/status/2096127073479987638","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-234.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":306},{"id":"work-e3975988da58852c","name":"Legora 多文档错误核对测试","description":"转述Legora用Astra在数分钟内比较41份文档并找到预置4处错误的测试。 作者明确尚未亲测；仅二手基准，文档内容与错误设置未读取。","category":"other","sourceCategory":"CheerSelfAI · 专业研究与安全评测","author":{"name":"@futuristufuk","url":"https://x.com/futuristufuk"},"demoUrl":"https://x.com/futuristufuk/status/2096127426698867052","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-235.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":307},{"id":"work-9e129c0dcde9d961","name":"内容模板开头与展示结构优化","description":"作者让Astra Ultra优化两个内容模板，约5分钟将热点焦虑开头改为具体场景问题与产品展示，并认为增加了可选写作方式。 不是所有文章都适用；100%到18%额度为作者观察，不作质量或成本保证。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@aehyok","url":"https://x.com/aehyok"},"demoUrl":"https://x.com/aehyok/status/2096128961470226493","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-236.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":308},{"id":"work-c20cfac0f30858e6","name":"网页版宝可梦游戏原型","description":"作者称让Astra一次生成网页版宝可梦游戏并展示结果。 低细节自述，未核查具体玩法、范围或试玩。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@zhengli","url":"https://x.com/zhengli"},"demoUrl":"https://x.com/zhengli/status/2096130504538091525","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-237.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":309},{"id":"work-8d80c6c6a9945d9d","name":"可编辑 Blender 蒸汽机车","description":"二手帖称Astra经computer use在Blender构建可编辑蒸汽机车3D模型。 未给原执行者和工程；不验证结构精度。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@MohammadMsft","url":"https://x.com/MohammadMsft"},"demoUrl":"https://x.com/MohammadMsft/status/2096131855284056073","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-238.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":310},{"id":"work-f23bb4c678d1be17","name":"T-rex 模型绑定与动画","description":"Tripo创建的霸王龙模型由Astra进行绑定和动画，使用Three.js渲染。 不把原始模型生成归Astra；未验绑定与骨骼质量。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@majidmanzarpour","url":"https://x.com/majidmanzarpour"},"demoUrl":"https://x.com/majidmanzarpour/status/2096133339329536249","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-239.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":311},{"id":"work-897af50819633312","name":"HyperFrames 与本地旁白的发布视频","description":"作者用Astra最高档结合HyperFrames制作发布视频，使用Voicebox在本地生成自己的声音作为旁白。 音视频依赖外部工具；未独立核对工程和完整流程。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@SuguruKun_ai","url":"https://x.com/SuguruKun_ai"},"demoUrl":"https://x.com/SuguruKun_ai/status/2096133389107769703","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-240.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":312},{"id":"work-815c709e71027a68","name":"演示文稿到产品包装与交互提案网页","description":"作者用一个prompt让Astra约40分钟连续生成配图PowerPoint、logo、3D产品包装及可拖动模型和动态报价图表的Web演示并部署。 未查文件内容、部署地址和商业验收。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@excel_niisan","url":"https://x.com/excel_niisan"},"demoUrl":"https://x.com/excel_niisan/status/2096135152246329556","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-241.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":313},{"id":"work-5de0958da6ce7153","name":"Odyssey 风格关卡的构建与通关录屏","description":"AIHubMix用Astra制作8平台3月亮的关卡，包含回旋帽攻击、金币敌人、检查点与触控；报告真实键盘7跳5掷帽收集3月亮零跌落并录制720p/30fps音画。 平台自营自测；未独立复跑游戏和测试。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@AiHubMix","url":"https://x.com/AiHubMix"},"demoUrl":"https://x.com/AiHubMix/status/2096135808243876152","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-242.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":314},{"id":"work-3f5868e0d2eef1a7","name":"Contra 风格游戏重建","description":"作者称Astra在30分钟内零样本生成旧Contra风格游戏。 怀旧相似度是主观感觉，不代表完整原作机制。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@Saboo_Shubham_","url":"https://x.com/Saboo_Shubham_"},"demoUrl":"https://x.com/Saboo_Shubham_/status/2096135898425647292","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-243.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":315},{"id":"work-812186901bf239c4","name":"角色打碎浏览器画面的特效","description":"作者让Astra实现屏幕人物破坏浏览器画面的视觉交互功能。 这是画面特效描述，不推断实际破坏浏览器或系统；未验证实现。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@stella_24r","url":"https://x.com/stella_24r"},"demoUrl":"https://x.com/stella_24r/status/2096135909926416823","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-244.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":316},{"id":"work-eb07c876cd951649","name":"虚拟人物 UGC 的参考图与视频提示词流程","description":"作者在Codex中把Seedance2.5提示指南做成skill，用Astra组织GPT Images参考图与30秒虚构人物UGC视频prompt，经Seedance480p生成再由Topaz放大2K。 视频生成归Seedance，放大归Topaz；人物自然程度为主观评估。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@tanabe_fragm","url":"https://x.com/tanabe_fragm"},"demoUrl":"https://x.com/tanabe_fragm/status/2096136682055864564","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-245.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":317},{"id":"work-5d0f42471b24669d","name":"科幻工业中庭的角色交互场景","description":"作者让Astra制作科幻工业中庭，通过Blender建模和Three.js交互，采用授权底模与动作素材，再打磨装备材质光照和步行动作，录制页面实操。 依赖外部资产与动作；角色自然程度未独立验收。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@servasyy_ai","url":"https://x.com/servasyy_ai"},"demoUrl":"https://x.com/servasyy_ai/status/2096137415895494816","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-246.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":318},{"id":"work-fe7b4cf9c0342a73","name":"TradingView 图表预读与标线","description":"作者称让Astra打开TradingView图表，绘制趋势线、阻力线、Fibonacci和波浪理论标记，并给人工交易前的初步读图结论。 仅记录辅助标注流程，低相关交易策略是后续设想；没有收益或预测有效性证据。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@jesselaunz","url":"https://x.com/jesselaunz"},"demoUrl":"https://x.com/jesselaunz/status/2096141540771111103","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-247.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":319},{"id":"work-e2473cf7a4f04215","name":"Driftwake 水上战斗游戏","description":"作者发布用Astra制作的Driftwake，描述为3D roguelike水上战斗游戏并提供链接。 未独立试玩或核查机制。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@_nilni","url":"https://x.com/_nilni"},"demoUrl":"https://x.com/_nilni/status/2096141925019775334","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-249.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":320},{"id":"work-21905d28ce0d5b9e","name":"咖啡店照片转 Blender 漫游","description":"作者给Astra咖啡店照片，重建木吊顶、灯带、烘豆机、货架和植物，生成15秒竖屏漫游及可编辑Blender工程，承认还原度仍需提升。 未读取工程或衡量实际几何误差。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@harrisonitsme","url":"https://x.com/harrisonitsme"},"demoUrl":"https://x.com/harrisonitsme/status/2096143359505269079","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-251.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":321},{"id":"work-8e50c4a9276bc118","name":"限时寻找可疑包裹游戏","description":"作者用Astra Ultra约8小时构建在倒计时内寻找可疑包裹的游戏，附试玩链接。 引用早帖仅26分钟和token，后帖才确认具体任务；不相加两个阶段计时。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@adamlyttleapps","url":"https://x.com/adamlyttleapps"},"demoUrl":"https://x.com/adamlyttleapps/status/2096149581885309297","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-254.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":322},{"id":"work-8139ee9f22e03412","name":"聊天 UI 组件演示录屏","description":"作者让Astra为自己的shadcn/ui聊天组件录制演示，该组件包含模型切换、可搜索历史和文件附件。 Astra在当前证据中的角色是录屏，不能把原组件开发也归给它。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@ephraimduncan","url":"https://x.com/ephraimduncan"},"demoUrl":"https://x.com/ephraimduncan/status/2096149900417192106","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-255.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":323},{"id":"work-f78bcd91ff93cc69","name":"Clip Studio 草图上色未完成测试","description":"作者只给草稿风格参考图，让Astra在Clip Studio逐笔画线稿与上色，观察到遮住文字后撤回改色，1小时仍未完成。 保留未完成结果；不把自动操作当成交付成功。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@gigabit_million","url":"https://x.com/gigabit_million"},"demoUrl":"https://x.com/gigabit_million/status/2096150291033063514","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-256.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":324},{"id":"work-12be9eec6ba2a54b","name":"丛林寺庙与神猴守护者场景对照","description":"作者让Astra用HTML和Three.js生成丛林寺庙唤醒巨大神猴守护者场景，沿用Fable测试prompt，认为Astra清晰度强但仍偏好Fable照明。 单次主观视觉比较；未核查源码和相同条件。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@BuildFastWithAI","url":"https://x.com/BuildFastWithAI"},"demoUrl":"https://x.com/BuildFastWithAI/status/2096150942894948547","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-257.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":325},{"id":"work-7e64153ac09b4a52","name":"复古 RPG 战斗攻击特效","description":"作者让Astra制作旧勇者斗恶龙风格战斗的攻击特效，认为效果改善但招式命名很差。 画面质量为主观评价；未提供游戏工程。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@kojikagames","url":"https://x.com/kojikagames"},"demoUrl":"https://x.com/kojikagames/status/2096153821907124464","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-259.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":326},{"id":"work-6e0788f339f478d5","name":"Minecraft 风格游戏原型","description":"作者指示Astra制作Minecraft风格游戏，并展示首次生成结果。 未说明具体机制和功能覆盖；不等于完整Minecraft。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@daitenP","url":"https://x.com/daitenP"},"demoUrl":"https://x.com/daitenP/status/2096154379397247092","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-260.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":327},{"id":"work-4b4c8bdc146f712a","name":"SKYBREAK 武装飞车战斗游戏","description":"作者展示Astra Pro制作的SKYBREAK，用武装飞车进行大逃杀战斗，认为AI对手过强。 游戏平衡与可玩性未独立验证。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@gosrum","url":"https://x.com/gosrum"},"demoUrl":"https://x.com/gosrum/status/2096155638758019226","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-261.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":328},{"id":"work-86de786bdb747c66","name":"波罗蜜开放世界游戏","description":"作者用Astra制作波罗蜜世界，以佛陀为主角切换五种神通、积累波罗蜜并击败魔罗，提供试玩链接。 未独立试玩或评价宗教叙事准确性。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@naga3","url":"https://x.com/naga3"},"demoUrl":"https://x.com/naga3/status/2096156076618187111","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-262.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":329},{"id":"work-f188a8f2db949d9e","name":"Excalidraw 镜面自拍绘制","description":"作者让Astra通过浏览器在Excalidraw逐笔绘画并上色自拍，称约6分钟、5%额度，保留卷发、眼镜、手机和手表，结果仍粗糙。 额度与耗时自述；未独立评价肖像还原。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@Kappaemme1926","url":"https://x.com/Kappaemme1926"},"demoUrl":"https://x.com/Kappaemme1926/status/2096156379882951054","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-263.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":330},{"id":"work-8dc481595a6baf4a","name":"手机与电脑可玩的节奏游戏","description":"作者用Astra制作名为なんか聴いたことある音ゲー的节奏游戏，称约5分钟完成，包含HARD模式并提供评论区入口。 未检验音轨授权、节奏同步或跨设备可玩性。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@mindup_nari","url":"https://x.com/mindup_nari"},"demoUrl":"https://x.com/mindup_nari/status/2096156793902948369","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-264.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":331},{"id":"work-499bc78dcbb75d3d","name":"海上搁浅船的 Blender 动画","description":"作者在Medium档要求生成海中搁浅船，Astra经Blender MCP建模和动画，耗时约40分钟。 未独立核查模型、动画与计时。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@Ananth7e","url":"https://x.com/Ananth7e"},"demoUrl":"https://x.com/Ananth7e/status/2096159964247277835","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-265.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":332},{"id":"work-8d50b21ee714d501","name":"Clip Studio Paint 涂色尝试与额度限制","description":"作者让Astra操作Clip Studio Paint给画作上色，约10分钟耗尽Plus额度，表示实用仍有门槛但已看到操作与修改设置。 未明确最终着色完成；保留实际失败和限制，不写成成功交付。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@shimadauro","url":"https://x.com/shimadauro"},"demoUrl":"https://x.com/shimadauro/status/2096161305824751946","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-266.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":333},{"id":"work-c5ac6d77dd4650f4","name":"KiCad 原理图转 PCB 布局演示","description":"转述Astra在KiCad中将电路原理图转为PCB布局，放置元件并走铜线。 未识别本帖原执行者与具体板卡；不代表DRC、电气验证或制造通过。","category":"tool","sourceCategory":"CheerSelfAI · 工程文件与代码迁移","author":{"name":"@Alacritic_Super","url":"https://x.com/Alacritic_Super"},"demoUrl":"https://x.com/Alacritic_Super/status/2096162271517196465","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-267.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":334},{"id":"work-6c5b56257ac56cd8","name":"实时无限海洋 WebGL2 模拟","description":"作者用Astra构建浏览器实时海洋，带程序化波浪、天气、时段和五种相机模式。 实时控制为作者自述；未验证物理精度和性能。","category":"experiment","sourceCategory":"CheerSelfAI · 模拟与科学可视化","author":{"name":"@KeertiMata","url":"https://x.com/KeertiMata"},"demoUrl":"https://x.com/KeertiMata/status/2096163348786315460","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-268.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":335},{"id":"work-08f8ccc823c91156","name":"像素大战风格 3D 吃豆人游戏","description":"作者称用Astra约10分钟制作3D吃豆人游戏，参考电影像素大战的创意。 未试玩或核查关卡、碰撞和性能。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@0xEcho99","url":"https://x.com/0xEcho99"},"demoUrl":"https://x.com/0xEcho99/status/2096163667977130390","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-270.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":336},{"id":"work-b0c7494f142eac67","name":"Blender Discovery 航天飞机","description":"转述Astra在Blender重建Discovery航天飞机，描述机身、座舱、起落架、货舱、尾部与发动机等构件。 近1:1与单prompt耗时为未验证转述；未获原执行者工程。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@irinatoxi","url":"https://x.com/irinatoxi"},"demoUrl":"https://x.com/irinatoxi/status/2096164527339368809","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-271.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":337},{"id":"work-bf7f366c67cd4e93","name":"随机细胞到多细胞生物演化模拟","description":"作者要求Astra模拟随机细胞汤的演化，展示多细胞个体移动、分裂与后代生长，称模型也为生物命名并剪辑视频。 视觉模拟不等于生物学有效性；未验算法和参数。","category":"experiment","sourceCategory":"CheerSelfAI · 模拟与科学可视化","author":{"name":"@Angaisb_","url":"https://x.com/Angaisb_"},"demoUrl":"https://x.com/Angaisb_/status/2096165078877835491","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-272.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":338},{"id":"work-24dae61624753fdb","name":"参考视频转互动游戏 1.0","description":"作者用Astra参考所引情感主题短视频制作互动游戏1.0，并反映token消耗高。 机制、token数量和参考视频素材来源未核验。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@you1873118","url":"https://x.com/you1873118"},"demoUrl":"https://x.com/you1873118/status/2096165216467952065","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-273.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":339},{"id":"work-142a3a24f476a32a","name":"Town to City 风格城镇游戏","description":"作者展示Astra约2小时制作的Town to City风格游戏结果。 未给原项目8个月与本次产物的同等范围，不能据此计算效率倍数。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@TAbrodi","url":"https://x.com/TAbrodi"},"demoUrl":"https://x.com/TAbrodi/status/2096165309963206979","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-274.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":340},{"id":"work-f8f1991676695888","name":"史莱姆互动玩具","description":"作者用GPT-6 Astra制作可以玩史莱姆的交互作品。 玩法和技术细节未说明；不从视频臆造物理能力。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@halukik_0520","url":"https://x.com/halukik_0520"},"demoUrl":"https://x.com/halukik_0520/status/2096165542247940557","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-275.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":341},{"id":"work-83762c6578a56980","name":"ICE 骑车战斗网页游戏","description":"作者在ChatGPT手机端用Astra Max约33分钟制作3D骑车战斗游戏，要求8名敌人、Sky9首领与结局舞蹈，称手机和电脑均可玩。 角色、图像和音乐依赖参考素材；关卡完成度和跨设备能力均为作者自述。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@khajochi","url":"https://x.com/khajochi"},"demoUrl":"https://x.com/khajochi/status/2096166729701638393","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-277.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":342},{"id":"work-a5ee3d2dc3149ca6","name":"Blender 人形狼与奔跑动画","description":"转述Matt Wolfe评测：Astra通过computer use在Blender构建人形狼，并制作步幅、摆臂、腾空和尾部运动的奔跑循环。 未取得原作者完整评测或工程；不独立确认绑骨和游戏资产可用性。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@Arcane_Aii","url":"https://x.com/Arcane_Aii"},"demoUrl":"https://x.com/Arcane_Aii/status/2096169051747938418","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-278.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":343},{"id":"work-bf34fab1c55051d1","name":"Lego 1999 Racers 重建对照","description":"作者以重建Lego 1999 racers为prompt比较Astra和Fable，声称Astra构建速度快25倍。 未提供两次具体计时、玩法覆盖或公平比较设置；倍数仅为作者主张。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@SBnft25","url":"https://x.com/SBnft25"},"demoUrl":"https://x.com/SBnft25/status/2096169622261424261","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-279.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":344},{"id":"work-8ab56cf00be0ad8a","name":"黑神话悟空风格游戏演示","description":"作者转述他人用Astra做出黑神话悟空风格游戏，并展示视频。 未给原作者或工程；只记录二手低细节演示，不代表原作规模。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@you1873118","url":"https://x.com/you1873118"},"demoUrl":"https://x.com/you1873118/status/2096172881889931617","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-280.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":345},{"id":"work-517904b19a97ce73","name":"人偶固定与胶带缠绕游戏","description":"作者用Astra制作随机移动人偶的交互游戏，点击固定部位，再通过鼠标拖拽缠绕并补加胶带。 未独立试玩或检查物理模拟。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@Ushizaru_LAB","url":"https://x.com/Ushizaru_LAB"},"demoUrl":"https://x.com/Ushizaru_LAB/status/2096174633762607296","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-281.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":346},{"id":"work-d82e2a708cfbaedc","name":"GTA IV 风格游戏原型","description":"作者称Astra基本一次生成了GTA IV风格游戏克隆。 不能理解为完整商业游戏复制；无关卡和机制验收。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@enisco","url":"https://x.com/enisco"},"demoUrl":"https://x.com/enisco/status/2096174745624498223","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-282.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":347},{"id":"work-5c9971965a3d6d90","name":"四张照片经代码生成场景视频","description":"作者在Codex中用Astra将4张照片转为代码生成的视频，称没有此前Fable结果中的z-fighting。 具体场景与渲染工具未说明；画面问题改善为作者自述。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@ai_ai_ailover","url":"https://x.com/ai_ai_ailover"},"demoUrl":"https://x.com/ai_ai_ailover/status/2096175723614703738","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-283.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":348},{"id":"work-b960a0d400abfc7a","name":"3D 渲染参考转交互网页开关","description":"作者用几个prompt让Astra把cerpow的3D渲染参考转成可交互web toggle，实现仅使用React和WebGL shaders。 原始视觉参考来自其他创作者；未检查交互代码和可访问性。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@fabiuix","url":"https://x.com/fabiuix"},"demoUrl":"https://x.com/fabiuix/status/2096175936211194125","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-284.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":349},{"id":"work-5d2de4640b6000e0","name":"AFTERIMAGE 游戏原型","description":"作者发布GPT-6 Astra Pro制作的AFTERIMAGE，附可玩链接，并描述失败成为道路的主题。 未打开试玩验证机制、难度或完成度。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@gosrum","url":"https://x.com/gosrum"},"demoUrl":"https://x.com/gosrum/status/2096176593131741260","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-286.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":350},{"id":"work-76d83f1382821554","name":"新加坡街道的手机视角场景","description":"作者先要求以手机POV制作GTA6画面风格的新加坡街道，后帖展示Astra结果。 前帖写Three.js，后帖称Unreal Engine，实际引擎未确认。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@birdabo","url":"https://x.com/birdabo"},"demoUrl":"https://x.com/birdabo/status/2096176846408945789","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-287.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":351},{"id":"work-deb8f302b24a85fa","name":"社区项目视频的提示词编写","description":"作者称所引用Leve Poços社区供水及收获项目视频的prompt由GPT-6 Astra编写。 只证实作者对prompt角色的陈述；最终生成工具、prompt正文和素材事实未核验。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@henriqueim0veis","url":"https://x.com/henriqueim0veis"},"demoUrl":"https://x.com/henriqueim0veis/status/2096176901664518253","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-288.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":352},{"id":"work-ff2b19c86527cdbe","name":"可访问的埃菲尔铁塔展示","description":"作者展示用Astra创建的埃菲尔铁塔观看作品，并附访问链接。 未打开链接验证3D形式、交互或还原准确性。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@ayaboch","url":"https://x.com/ayaboch"},"demoUrl":"https://x.com/ayaboch/status/2096178212883587094","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-289.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":353},{"id":"work-7d09e7a04a6d2cb9","name":"整理开发中游戏的 UI","description":"作者在已有开发中游戏上让Astra反复调整界面，提升界面完成度。 不属于从零构建整款游戏；未提供具体改动清单或用户测试。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@yugiriworks","url":"https://x.com/yugiriworks"},"demoUrl":"https://x.com/yugiriworks/status/2096178313547133382","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-290.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":354},{"id":"work-b177e6751ec83108","name":"设计、配乐与旁白动效视频","description":"作者称Astra约25分钟生成设计、动作、音效、音乐及人声的视频，又进行了4到5次调整。 并非零返工；音频素材来源与工程未核验。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@TROOVY","url":"https://x.com/TROOVY"},"demoUrl":"https://x.com/TROOVY/status/2096178387207225513","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-291.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":355},{"id":"work-69c12e9315eb0570","name":"必杀技作品的 Astra 改稿与 Topview 视频化","description":"作者用Astra润色已发布的必杀技作品，再交给Topview生成视频，称镜头切分更贴合招式。 最终视频依赖Topview；未提供完整改稿或prompt。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@YaReYaRu30Life","url":"https://x.com/YaReYaRu30Life"},"demoUrl":"https://x.com/YaReYaRu30Life/status/2096179235501265279","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-292.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":356},{"id":"work-f2f151cee2e4e3ff","name":"照片转可编辑教堂 3D 巡游","description":"GPT-6 Astra和Blender参考教堂照片建柱、彩窗、长椅与钢琴，并通过相机运动输出23秒视频；保留可改家具与机位的3D数据。 几何准确性与后续编辑未独立验收。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@noel_ai_lab","url":"https://x.com/noel_ai_lab"},"demoUrl":"https://x.com/noel_ai_lab/status/2096181084405047767","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-293.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":357},{"id":"work-621d061dfb9b656f","name":"Three.js 汽车游戏与网格优化","description":"作者称不到3分钟构建Three.js游戏，随后把汽车14个mesh减到6个，并生成回归测试，报告9/9通过。 耗时、网格和测试通过均为作者自述；未读取测试源码。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@svector_eth","url":"https://x.com/svector_eth"},"demoUrl":"https://x.com/svector_eth/status/2096182841813955029","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-295.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":358},{"id":"work-2637266129779bd1","name":"照片场景的 Blender 建模与动画","description":"作者用GPT-6 Astra和Blender重建照片场景，并追加动画。 照片对应的具体地点、几何精度和模型工程未验证。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@neka_nat","url":"https://x.com/neka_nat"},"demoUrl":"https://x.com/neka_nat/status/2096184394507866425","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-296.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":359},{"id":"work-fcd98b57b0e84d5e","name":"Subway Surfers 克隆的画质与机制对照","description":"作者用相同简单指令约20分钟生成跑酷游戏并部署到ChatGPT Sites；称消耗71%额度、部署另23%，缺少道具、上车坡道和移动列车。 额度百分比不是API费用；作者写合计96%，与两分项94%不一致，原文数字不作纠正后统计。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@SahilPanhotra","url":"https://x.com/SahilPanhotra"},"demoUrl":"https://x.com/SahilPanhotra/status/2096184406734188768","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-297.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":360},{"id":"work-f7fbad6364dca101","name":"生成游戏原型时快速耗尽额度","description":"作者用粗略指令离开后让Astra运行。 报告一次尝试就达到额度，仍希望完善角色运动。 并未完成可玩性验收；额度消耗无精确数值。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@taya_mama_AI","url":"https://x.com/taya_mama_AI"},"demoUrl":"https://x.com/taya_mama_AI/status/2096186558470844755","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-298.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":361},{"id":"work-55bea006be4ed855","name":"用 Tripo 初模经 Astra 修模绑定并制作动画","description":"作者先图像生成→Tripo三维化→Astra修模→加rig→做动画，人工组织阶段。 明确分阶段与人为流程安排，不能称单次自动从零完成。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@mocchimocchi991","url":"https://x.com/mocchimocchi991"},"demoUrl":"https://x.com/mocchimocchi991/status/2096187582837293520","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-299.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":362},{"id":"work-61518ef6db17d713","name":"用 SPEC 制作 Digital Twin Data Hall 新版","description":"作者从SPEC启动Astra构建。 没有旧版本来源或改动列表，未据此制造既有案例update。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@aijoey","url":"https://x.com/aijoey"},"demoUrl":"https://x.com/aijoey/status/2096189270213956042","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-300.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":363},{"id":"work-5a2b15d236ae73b4","name":"比较并结束 snowboarder 动画基准","description":"作者将同一snowboarder任务用于两模型，认为均无需修改。 未给具体完整prompt或原始评分。","category":"other","sourceCategory":"CheerSelfAI · 专业研究与安全评测","author":{"name":"@alex_erm","url":"https://x.com/alex_erm"},"demoUrl":"https://x.com/alex_erm/status/2096190023179608548","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-301.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":364},{"id":"work-70f33e4fe24f46f1","name":"从一张插画在 Blender 重建三维场景","description":"作者无建模经验，仅给Astra插画和一句话。 原图主题和还原精度未说明。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@Chechecheur","url":"https://x.com/Chechecheur"},"demoUrl":"https://x.com/Chechecheur/status/2096191700251341189","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-302.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":365},{"id":"work-b84910adc1ef9146","name":"制作点击弹跳的 WebGPU 果冻","description":"Astra配合WebGPU和Three.js。 作者称30分钟。 引用同作者早前30分钟交互作品，是否同一果冻需root查看原内容。","category":"experiment","sourceCategory":"CheerSelfAI · 模拟与科学可视化","author":{"name":"@lepadphone","url":"https://x.com/lepadphone"},"demoUrl":"https://x.com/lepadphone/status/2096192125721551273","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-303.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":366},{"id":"work-39e3d02d88d91096","name":"一次生成 PUBG 风格游戏","description":"作者用Astra单提示词生成。 “破绽少”为作者评价，不代表完整商业产品。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@usutaku_channel","url":"https://x.com/usutaku_channel"},"demoUrl":"https://x.com/usutaku_channel/status/2096192231635845335","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-304.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":367},{"id":"work-d3059aaef18a2df4","name":"在快速启动的 Codex 沙箱中创建文件","description":"作者用Astra在agent沙箱演示创建文件，并描述秒级启动。 示例仅文件操作，完整full-stack应用与生产部署仍是计划。","category":"tool","sourceCategory":"CheerSelfAI · 工程文件与代码迁移","author":{"name":"@saugardev","url":"https://x.com/saugardev"},"demoUrl":"https://x.com/saugardev/status/2096193413838192875","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-305.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":368},{"id":"work-e6d748426d66f925","name":"比较两模型Medium骑车鹈鹕SVG动画","description":"相同prompt要求鹈鹕骑车并用H5展示。 作者认为Astra腿部运动和外观更好，Sol腿不动。 “无bug/完美”为作者主观评价。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@xueyu1125","url":"https://x.com/xueyu1125"},"demoUrl":"https://x.com/xueyu1125/status/2096193816864981444","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-306.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":369},{"id":"work-85fafb3f1aeeb892","name":"以单张建筑照片开展传统软件专业交付实验","description":"Astra持续运行8小时，生成13类技术/视觉成果。 作者给60/100、约2.1亿tokens，并分别报告完成度。 8小时时明确两部成片与高精模型未完成，后续45给13小时总结。","category":"tool","sourceCategory":"CheerSelfAI · 工程文件与代码迁移","author":{"name":"@ZHO_ZHO_ZHO","url":"https://x.com/ZHO_ZHO_ZHO"},"demoUrl":"https://x.com/ZHO_ZHO_ZHO/status/2096195128927093076","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-308.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":370},{"id":"work-b9c5a05e179cbf61","name":"约20分钟生成 Panzer Dragoon 风格游戏","description":"作者因看到话题而亲自用Astra极高档尝试。 同类任务的作者新实验，不能仅因已发布他人的Panzer案例而判重。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@tetumemo","url":"https://x.com/tetumemo"},"demoUrl":"https://x.com/tetumemo/status/2096195768726216992","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-309.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":371},{"id":"work-00b3c5e7c2b6fce8","name":"参考视频把分别录制的画面与声音自动剪辑","description":"Astra读取参考视频并处理分开录制的素材。 一稿质量为作者评价，未给完整编辑工程。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@fujiryu00","url":"https://x.com/fujiryu00"},"demoUrl":"https://x.com/fujiryu00/status/2096197109401940357","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-311.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":372},{"id":"work-32235957d5b790c6","name":"以照片为参考在 Photoshop 自动画图","description":"作者提供照片让Astra自动操作。 作者报告和演示，未独立运行验收。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@William_Wangyun","url":"https://x.com/William_Wangyun"},"demoUrl":"https://x.com/William_Wangyun/status/2096197571480056003","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-312.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":373},{"id":"work-053b5f83e744ba0a","name":"制作 PSP 自制游戏新原型","description":"作者用Astra构建受多个游戏启发的新作。 未明确实机运行和完整玩法，与旧Sol PSP项目不混同。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@bunkaich","url":"https://x.com/bunkaich"},"demoUrl":"https://x.com/bunkaich/status/2096198577546781153","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-313.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":374},{"id":"work-f2d64bf983bf52af","name":"制作征华传P2介绍片","description":"作者让Astra制作。 作者指出未抠干净和未修发型的地方更显眼。 保留素材与编辑缺陷，不能称无修成片。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@rouga_Aiart","url":"https://x.com/rouga_Aiart"},"demoUrl":"https://x.com/rouga_Aiart/status/2096200183256358955","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-315.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":375},{"id":"work-7477594b5cf719ca","name":"比较 Sol 与 Astra 的木乃伊三维模型","description":"使用Pixal3D、ComfyUI和headless Blender。 未给同prompt条件或定量评价。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@luisnomad","url":"https://x.com/luisnomad"},"demoUrl":"https://x.com/luisnomad/status/2096201196042145885","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-316.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":376},{"id":"work-84a9369938e998c8","name":"在 Fusion 360 制作并打印铰接香蕉","description":"作者让Astra建模并打印，称除此未干预。 数小时后取得演示结果。 实物打印与装配未独立核验，硬件操作过程未披露。","category":"tool","sourceCategory":"CheerSelfAI · 工程文件与代码迁移","author":{"name":"@Co_ben_","url":"https://x.com/Co_ben_"},"demoUrl":"https://x.com/Co_ben_/status/2096201932289274176","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-317.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":377},{"id":"work-f5541a59f86b209e","name":"为 HANSHACORE 制作音乐视频","description":"原帖明确MV由Astra负责，音乐为AI与DAW。 不将歌曲音乐制作归给Astra；具体视频工具未给。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@tenchodono","url":"https://x.com/tenchodono"},"demoUrl":"https://x.com/tenchodono/status/2096202751315480950","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-318.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":378},{"id":"work-0dae2bc01baf403a","name":"操作 GarageBand 作曲并母带处理","description":"Astra通过computer-use使用GarageBand。 作者报告和演示，未独立运行验收。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@aigeboku","url":"https://x.com/aigeboku"},"demoUrl":"https://x.com/aigeboku/status/2096205002960507270","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-319.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":379},{"id":"work-2b382298ad8e41af","name":"把 Blender 场景扩展为 Sites 交互网站","description":"Astra将Blender模型导入Three.js并部署ChatGPT Sites；引用说明原场景主要由bpy/MCP制作。 作者报告和演示，未独立运行验收。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@op7418","url":"https://x.com/op7418"},"demoUrl":"https://x.com/op7418/status/2096205141187956887","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-320.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":380},{"id":"work-6497d5e1baf35a35","name":"验证 Astra 与 Blender 的视频制作流程","description":"作者明确自己在测试Astra×Blender制片。 未给影片主题或完整方法，保留为单次流程试作。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@ria_aicreator","url":"https://x.com/ria_aicreator"},"demoUrl":"https://x.com/ria_aicreator/status/2096205626477338792","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-321.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":381},{"id":"work-89cdf92a4247f586","name":"在 Blender 生成 MacBook Pro 模型并制作视频","description":"作者让Astra建模后生成视频。 作者报告和演示，未独立运行验收。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@blueemi99","url":"https://x.com/blueemi99"},"demoUrl":"https://x.com/blueemi99/status/2096206007193976876","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-322.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":382},{"id":"work-6f08970ebfbe9f5d","name":"用一天测试游戏生成并观察额度消耗","description":"为测试Astra制作一天游戏。 作者不确定比Sol有优势，认为粗略指令会增加额外工作与用量。 游戏名未给，额度体验不能推广为通用成本。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@YugamiaLuna","url":"https://x.com/YugamiaLuna"},"demoUrl":"https://x.com/YugamiaLuna/status/2096206311629402253","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-323.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":383},{"id":"work-f453e18110ed6726","name":"制作手绘笔记本风格第一人称射击游戏","description":"作者用Astra构建。 作者报告和演示，未独立运行验收。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@Aish2004Gupta","url":"https://x.com/Aish2004Gupta"},"demoUrl":"https://x.com/Aish2004Gupta/status/2096207995076313162","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-325.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":384},{"id":"work-b96aac0a9c7c470c","name":"生成 Palmimo 主题30秒小游戏","description":"作者使用Astra制作。 具体玩法未充分描述，30秒难度为作者反应。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@maze_rapid","url":"https://x.com/maze_rapid"},"demoUrl":"https://x.com/maze_rapid/status/2096208743243612586","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-326.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":385},{"id":"work-07ae7bdfd5d7d083","name":"生成响应风和玩家的浏览器草地","description":"Astra单提示词构建。 作者报告26分钟、周额度6%。 作者报告和演示，未独立运行验收。","category":"experiment","sourceCategory":"CheerSelfAI · 模拟与科学可视化","author":{"name":"@PenguinWeb3","url":"https://x.com/PenguinWeb3"},"demoUrl":"https://x.com/PenguinWeb3/status/2096209358128615683","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-327.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":386},{"id":"work-c3eb48c9afd9bcc5","name":"制作 Astra 自己的发布介绍视频","description":"六行prompt加参考视频；HyperFrames制作，ElevenLabs男声与音效。 不与别的作者参考同一官方片的作品自动合并。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@athrix_codes","url":"https://x.com/athrix_codes"},"demoUrl":"https://x.com/athrix_codes/status/2096209514248958161","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-328.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":387},{"id":"work-354c20346a33e3fe","name":"生成可弹奏可交互钢琴","description":"作者称Astra一句话生成。 还原度和弹奏能力未独立验收。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@anion_ex","url":"https://x.com/anion_ex"},"demoUrl":"https://x.com/anion_ex/status/2096212906178400328","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-330.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":388},{"id":"work-4bf65b8d23b6757a","name":"制作可变速放大的三维骑车鹈鹕","description":"Astra单提示词生成，支持缩放和加速。 作者称数十分钟。 未验证踏车机构物理准确性。","category":"experiment","sourceCategory":"CheerSelfAI · 模拟与科学可视化","author":{"name":"@aibuilderclub_","url":"https://x.com/aibuilderclub_"},"demoUrl":"https://x.com/aibuilderclub_/status/2096213850383331489","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-331.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":389},{"id":"work-4beaa2997bc96713","name":"用 Three.js 重建悉尼歌剧院","description":"Codex中Astra max单提示词建模，引用是作者此前计划。 形状准确性是作者说法，未实测；不将同地标不同作者合并。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@HarshithLucky3","url":"https://x.com/HarshithLucky3"},"demoUrl":"https://x.com/HarshithLucky3/status/2096214595602149857","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-332.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":390},{"id":"work-7fa354b21efc19bb","name":"开发作曲软件并生成 RPG 战斗曲","description":"作者给Astra“制作作曲软件与RPG战斗曲”的任务。 未打开软件验证，音乐编曲质量为作者观察。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@gigabit_million","url":"https://x.com/gigabit_million"},"demoUrl":"https://x.com/gigabit_million/status/2096214882630983961","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-333.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":391},{"id":"work-cb51d0f952d7272c","name":"依据工房网页制作18秒12镜招募视频","description":"Codex Astra与HyperFrames读取网页设计，多轮调整镜头与文本；ElevenLabs配乐音效，Tsugite管理制作。 明确多轮修改；引用为同一招募宣传，当前补充竖版与完整流程。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@takamasa045","url":"https://x.com/takamasa045"},"demoUrl":"https://x.com/takamasa045/status/2096214997785616775","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-334.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":392},{"id":"work-7c6e16d2f708b835","name":"在 Replit 制作熊猫冒险游戏","description":"作者用Replit与Astra制作。 作者报告和演示，未独立运行验收。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@Noni_Shehnoor","url":"https://x.com/Noni_Shehnoor"},"demoUrl":"https://x.com/Noni_Shehnoor/status/2096215589190566035","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-335.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":393},{"id":"work-101435a30d19cbcc","name":"自动制作全量字幕并剪掉口头停顿","description":"作者用Astra做full captions与filler cuts。 “完美”为作者评价，未量化错误率。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@shupeiman","url":"https://x.com/shupeiman"},"demoUrl":"https://x.com/shupeiman/status/2096218468442124672","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-336.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":394},{"id":"work-5e8c8b1cb396a022","name":"为全盲儿童开发声音寻宝游戏","description":"作者让Astra为自己的孩子制作。 作者称20分钟完成。 未独立评估无障碍交互与可玩性。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@sawadayuru","url":"https://x.com/sawadayuru"},"demoUrl":"https://x.com/sawadayuru/status/2096218784864653636","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-337.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":395},{"id":"work-944b50d18cc47cc9","name":"在 Roblox Studio 制作卡丁车竞速游戏","description":"作者描述Astra单提示词约30分钟完成。 未独立验证全部玩法，属于Mario Kart风格原型。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@givros","url":"https://x.com/givros"},"demoUrl":"https://x.com/givros/status/2096219700879331665","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-338.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":396},{"id":"work-eeec902ef2e23d08","name":"制作现实画面转 GTA 风格视频","description":"Halai平台使用Halai MCP与ChatGPT Astra。 最终渲染模型未拆清，平台自营展示。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@Halaiapp","url":"https://x.com/Halaiapp"},"demoUrl":"https://x.com/Halaiapp/status/2096221074157412559","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-339.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":397},{"id":"work-460c50a97fa54e93","name":"在画图中重绘作者头像","description":"作者指示Astra在Paint绘制其头像。 作者以“对不起”表达戏谑反应。 未推定具体绘画错误，质量反应来自作者。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@hmmmmmm1458","url":"https://x.com/hmmmmmm1458"},"demoUrl":"https://x.com/hmmmmmm1458/status/2096223601552965960","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-341.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":398},{"id":"work-9129f9cd780a8dca","name":"开展六自由度轨道交会对接工程基准","description":"作者要求双体ECI传播、HCW引导、四元数动力学、燃料和力矩约束，并分项审核。 作者给Astra92.6、Fable81.4；Astra43分钟，Fable74分钟。 分数是作者engineering-quality评分；其说明严格hard-fail下Fable应为0，未独立复核实现。","category":"experiment","sourceCategory":"CheerSelfAI · 模拟与科学可视化","author":{"name":"@AlicanKiraz0","url":"https://x.com/AlicanKiraz0"},"demoUrl":"https://x.com/AlicanKiraz0/status/2096225621303042258","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-342.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":399},{"id":"work-3d0b9221b3730865","name":"修复 Fable 构建的 Three.js 哥特教堂","description":"Fable/Opus完成约95%初始场景；Astra一小时处理渲染缺陷。 Astra负责修复，不能把整体教堂创作归给它；40%额度属于Claude部分。","category":"tool","sourceCategory":"CheerSelfAI · 工程文件与代码迁移","author":{"name":"@Big14teru","url":"https://x.com/Big14teru"},"demoUrl":"https://x.com/Big14teru/status/2096225907224485992","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-343.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":400},{"id":"work-82b3e1e13fc867c7","name":"生成超级马里奥风格游戏","description":"作者让Astra做Super Mario游戏。 “真的本物”为作者夸张，不代表官方游戏或完整复刻。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@Aivy___X","url":"https://x.com/Aivy___X"},"demoUrl":"https://x.com/Aivy___X/status/2096227063636369410","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-344.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":401},{"id":"work-8ae469b77d16e935","name":"用简短指令测试浏览器游戏生成","description":"泰文根帖说明以ChatGPT Astra指令生成游戏。 游戏名称与完整功能未写，保留为单次游戏试作。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@iaumreview","url":"https://x.com/iaumreview"},"demoUrl":"https://x.com/iaumreview/status/2096228169464557924","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-345.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":402},{"id":"work-2ba46eef89dcb443","name":"把浏览器游戏扩为带移动镜头和大地图的三维版","description":"先由概念生成UI玩法，再第二条指令改为3D并扩图。 作者称全程约45分钟。 明确两步流程，未独立试玩。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@philippsieben","url":"https://x.com/philippsieben"},"demoUrl":"https://x.com/philippsieben/status/2096230927085060515","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-346.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":403},{"id":"work-2df218ff09b07757","name":"改进既有竞速游戏的可变翼视觉","description":"Astra在作者外出期间修改旧whitebox项目。 作者仍认为翼运动不理想；旧引用未说明用Astra，所以只把本次改进归因Astra。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@ShadeLurk","url":"https://x.com/ShadeLurk"},"demoUrl":"https://x.com/ShadeLurk/status/2096231227946864782","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-347.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":404},{"id":"work-26890bf34ec911fc","name":"测试从图片制作角色的 computer-use 并中止","description":"Astra使用computer-use从图制作角色。 作者称存文件约5分钟，等待1小时后认为过慢而终止。 单次负面体验，未给全部设备和工具配置。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@Stefan_3D_AI","url":"https://x.com/Stefan_3D_AI"},"demoUrl":"https://x.com/Stefan_3D_AI/status/2096232061585731874","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-348.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":405},{"id":"work-8cd2a697f8bd24c9","name":"生成弹珠店店长模拟游戏","description":"作者让Astra创建店长模拟器。 为游戏机制演示，不作为实际经营数据。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@X64zzotSKCGtYmt","url":"https://x.com/X64zzotSKCGtYmt"},"demoUrl":"https://x.com/X64zzotSKCGtYmt/status/2096232182515933567","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-349.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":406},{"id":"work-847bfea55505c482","name":"为海岸屋舍场景增加材质、三时段光照与交互","description":"Blender扫描纹理和Cycles烘焙日光/落日/蓝调，Three.js处理波浪反射和行走。 作者报告和演示，未独立运行验收。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@LufzzLiz","url":"https://x.com/LufzzLiz"},"demoUrl":"https://x.com/LufzzLiz/status/2096232605977043293","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-350.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":407},{"id":"work-64d9f3f64652d162","name":"生成22000星粒子的星系碰撞模拟","description":"Astra实现近似引力计算。 作者称约3分钟。 近似模拟非天体物理精确求解，数量和时间为作者报告。","category":"experiment","sourceCategory":"CheerSelfAI · 模拟与科学可视化","author":{"name":"@ozwxy","url":"https://x.com/ozwxy"},"demoUrl":"https://x.com/ozwxy/status/2096233290936336620","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-351.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":408},{"id":"work-f18ad0f94a9b6c46","name":"制作猫咪晚餐冒险的可编辑夜市","description":"作者用Codex和Blender构建。 报告约1小时、20x周额度4%。 作者报告和演示，未独立运行验收。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@heykumaonx","url":"https://x.com/heykumaonx"},"demoUrl":"https://x.com/heykumaonx/status/2096233696735175020","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-352.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":409},{"id":"work-7e6171ac1b8d32fd","name":"制作1905年日俄海战模拟器","description":"Astra按单条指令建立模拟并自行查舰名航线。 史实准确性为作者转述，未核对资料或物理模拟。","category":"experiment","sourceCategory":"CheerSelfAI · 模拟与科学可视化","author":{"name":"@Genzoh1","url":"https://x.com/Genzoh1"},"demoUrl":"https://x.com/Genzoh1/status/2096234089124946307","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-353.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":410},{"id":"work-ae5bed461c2bf23c","name":"为 Elliot Hewitt 制作并两轮修改视频","description":"Astra生成后作者给两次反馈。 原帖虽称one-shot，实际明确两次修改；未给工具。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@_StainVfx","url":"https://x.com/_StainVfx"},"demoUrl":"https://x.com/_StainVfx/status/2096234895076913289","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-354.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":411},{"id":"work-998643471c13d1b4","name":"制作可改信号灯观察拥堵的交通模拟城市","description":"Astra构建道路、建筑和交通逻辑，车辆对红灯与前车作反应。 未验证模型交通学准确性或车辆数。","category":"experiment","sourceCategory":"CheerSelfAI · 模拟与科学可视化","author":{"name":"@ozwxy","url":"https://x.com/ozwxy"},"demoUrl":"https://x.com/ozwxy/status/2096235880528961572","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-355.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":412},{"id":"work-718706140bc105a4","name":"比较四模型飞行模拟器的体验与成本","description":"给四模型相同prompt。 作者认为Astra总体第一但卡顿抖动；Kimi/Fable更平滑，Gemini速度价格占优。 排名与费用为作者评估，未取得统一测试日志。","category":"other","sourceCategory":"CheerSelfAI · 专业研究与安全评测","author":{"name":"@adxtyahq","url":"https://x.com/adxtyahq"},"demoUrl":"https://x.com/adxtyahq/status/2096236137266512181","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-356.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":413},{"id":"work-427a537c5a83a271","name":"为女儿制作有动物声音与行走交互的小动物世界","description":"作者使用Astra把图像转成三维并加入音效和互动。 同时推广中转平台，应保留推广关系，未验证v1全部功能。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@LufzzLiz","url":"https://x.com/LufzzLiz"},"demoUrl":"https://x.com/LufzzLiz/status/2096236975623946589","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-357.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":414},{"id":"work-7c9452ba59d0f426","name":"将单张背景插画制作成可自由漫游的 Unreal 街景","description":"Codex agent-alliance分工分析、建模、UE导入验证，修复启动问题。 作者承认结构未完全复现原图。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@Toshi_nyaruo_AI","url":"https://x.com/Toshi_nyaruo_AI"},"demoUrl":"https://x.com/Toshi_nyaruo_AI/status/2096237124815384822","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-358.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":415},{"id":"work-04758fdbd38a2a72","name":"用 Codex 与 Remotion 复刻 DJ 主题动画","description":"Astra结合Codex和Remotion，引用其他作者Apple产品动画作为方法参考。 作者报告5分钟。 引用Apple作品是参考，不将其全部实现细节归给本次DJ视频。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@369Serena","url":"https://x.com/369Serena"},"demoUrl":"https://x.com/369Serena/status/2096238284351447502","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-359.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":416},{"id":"work-bb50b4c646fdc429","name":"基于原 CAD 制作 Microduck 机器人70部件拆解工具","description":"Astra采用原CAD几何和装配。 70部件为作者报告，未验证实体装配适用性。","category":"tool","sourceCategory":"CheerSelfAI · 工程文件与代码迁移","author":{"name":"@tspy","url":"https://x.com/tspy"},"demoUrl":"https://x.com/tspy/status/2096238855519453662","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-360.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":417},{"id":"work-4a37faf2b664799a","name":"从 Blender 粗布局推进为电影镜头","description":"Topview平台称Astra处理全流程。 未命名场景，与同平台其他片段是否同项目需后续证据。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@TopviewAIhq","url":"https://x.com/TopviewAIhq"},"demoUrl":"https://x.com/TopviewAIhq/status/2096239357586010498","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-361.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":418},{"id":"work-484cad6bafa94e67","name":"在 HyperFrames 中重建 Astra 发布视频","description":"Astra结合HyperFrames重做官方发布片，灵感来自vedu_boi。 为另一作者自己的复刻，不因相同官方参考片合并其他作者项目。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@WaterrrMiao","url":"https://x.com/WaterrrMiao"},"demoUrl":"https://x.com/WaterrrMiao/status/2096240164138004729","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-362.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":419},{"id":"work-5d590f23e012f8ff","name":"把 GunZ C++ 客户端迁移到 WebAssembly 并加键鼠覆盖层","description":"Astra将C++客户端迁移到WebAssembly和WebGL，并增加键鼠显示。 作者报告和演示，未独立运行验收。","category":"tool","sourceCategory":"CheerSelfAI · 工程文件与代码迁移","author":{"name":"@toeknee_kim","url":"https://x.com/toeknee_kim"},"demoUrl":"https://x.com/toeknee_kim/status/2096240184358556110","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-363.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":420},{"id":"work-64e6dec5dbc4cf8b","name":"为待发布 Quest 游戏制作宣传片","description":"作者让Astra制作宣传片。 Quest审核通过为作者陈述，游戏公开发布尚未完成。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@3DVR3","url":"https://x.com/3DVR3"},"demoUrl":"https://x.com/3DVR3/status/2096240577545449795","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-364.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":421},{"id":"work-d6b954de9cce2262","name":"制作地形可移动旋转的 PatchworkTactics","description":"作者用Astra制作并上线。 作者报告和演示，未独立运行验收。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@8co28","url":"https://x.com/8co28"},"demoUrl":"https://x.com/8co28/status/2096241280208810156","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-365.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":422},{"id":"work-f4a5844ef1b6f3a8","name":"自动制作 Finn Explains 风格广告视频","description":"作者称全自动使用Astra制作。 广告预算放量与用户吸引力无具体数据，不作商业效果结论。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@0xROAS","url":"https://x.com/0xROAS"},"demoUrl":"https://x.com/0xROAS/status/2096243418426937576","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-366.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":423},{"id":"work-c83f09f368480694","name":"生成 Komorebi River Run 皮划艇游戏","description":"Three.js运行，场景、音乐和音效由代码生成。 作者喜欢观感和音乐，但认为水流湍急度不足。 作者报告和演示，未独立运行验收。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@ItsmeAjayKV","url":"https://x.com/ItsmeAjayKV"},"demoUrl":"https://x.com/ItsmeAjayKV/status/2096244208533455049","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-367.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":424},{"id":"work-bae544c7dc313f21","name":"用 Unreal Engine 与 Blender 制作反恐精英风格游戏","description":"作者使用Astra、UE5与Blender。 报告30分钟、50美元API额度。 费用与完成范围为作者报告，不视为完整商业游戏复刻。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@DeonMen","url":"https://x.com/DeonMen"},"demoUrl":"https://x.com/DeonMen/status/2096244460866707559","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-368.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":425},{"id":"work-83d956788d81e399","name":"为新版 Denaria 制作两分钟介绍视频","description":"Astra从单条prompt自行理解上下文并总结。 准确性为作者评价，未核对产品信息。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@TizianoTridico","url":"https://x.com/TizianoTridico"},"demoUrl":"https://x.com/TizianoTridico/status/2096244876518072591","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-369.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":426},{"id":"work-a01b1d1a496ad262","name":"将参考图做成滚动驱动的三维工作室网站","description":"输入参考图与prompt，Astra用Three.js转为三维。 作者报告和演示，未独立运行验收。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@mx_debbiee","url":"https://x.com/mx_debbiee"},"demoUrl":"https://x.com/mx_debbiee/status/2096245759121277132","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-370.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":427},{"id":"work-d4f176e2718c32a9","name":"构建黑魂风格教堂骑士与Boss游戏","description":"给图像生成做概念、Blender制作资产；Astra连接移动、攻击、闪避和Boss登场。 依赖生成概念图和建模工具；未验证全部玩法。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@filicroval","url":"https://x.com/filicroval"},"demoUrl":"https://x.com/filicroval/status/2096246680895078470","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-371.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":428},{"id":"work-c7832a9ba5122dda","name":"介绍 Arena AI 的33分钟三维世界生成对照","description":"二手汇总多推理档位和单提示词生成演示。 未完整观看评测，课程价值与最强模型宣传不作结论。","category":"other","sourceCategory":"CheerSelfAI · 专业研究与安全评测","author":{"name":"@sheemamoto","url":"https://x.com/sheemamoto"},"demoUrl":"https://x.com/sheemamoto/status/2096246789804347521","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-372.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":429},{"id":"work-26c14c9c31af4e41","name":"根据网页图片在 Blender 重建 Winfield 城市","description":"Astra自行从互联网取参考图并建模。 作者明确不完美、非现实一比一重建。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@TheVRNerd","url":"https://x.com/TheVRNerd"},"demoUrl":"https://x.com/TheVRNerd/status/2096247120000893382","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-373.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":430},{"id":"work-2061f4357ee5b51f","name":"通过多轮对话制作苍穹红莲队风格射击游戏","description":"作者给粗略主题后与Astra多轮沟通。 未独立试玩；介绍视频所用具体模型未拆清。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@SSSS_CRYPTOMAN","url":"https://x.com/SSSS_CRYPTOMAN"},"demoUrl":"https://x.com/SSSS_CRYPTOMAN/status/2096248797873762805","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-374.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":431},{"id":"work-696fb81891684348","name":"生成咖啡馆手机点单系统","description":"作者称Astra一条prompt约5分钟生成。 未验证支付、订单后台或实际餐饮部署。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@sns_ryuto05","url":"https://x.com/sns_ryuto05"},"demoUrl":"https://x.com/sns_ryuto05/status/2096248925422505992","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-375.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":432},{"id":"work-57fca0681830a3be","name":"重建可探索 Mysuru Palace 并配原创音轨","description":"Codex中的Astra使用Blender与Three.js，另作曲后由作者合成。 视频合成由作者完成，不归因模型全程自动。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@mvkaran","url":"https://x.com/mvkaran"},"demoUrl":"https://x.com/mvkaran/status/2096249702937460876","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-376.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":433},{"id":"work-205e33429e868569","name":"在 Remotion 中制作 Tender Scout 广告","description":"Astra分场景、制作motion、检查帧并修正后渲染。 作者只给创意和一条prompt，模型内部有检查修正。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@Abdullah_Ops1","url":"https://x.com/Abdullah_Ops1"},"demoUrl":"https://x.com/Abdullah_Ops1/status/2096249736349024682","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-377.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":434},{"id":"work-8d2efcd78787a8ec","name":"把个人积木世界构想做成 Little Wonderhood","description":"作者给Astra模糊想法。 报告不到10分钟。 作者报告和演示，未独立运行验收。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@ClaireBei","url":"https://x.com/ClaireBei"},"demoUrl":"https://x.com/ClaireBei/status/2096250058807349755","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-378.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":435},{"id":"work-71a1de035e477e02","name":"设计饮水机与智能镜面体测仪外观","description":"给Astra中档概念图或旧效果图，要求实用化与还原，背景流程为Rhino。 作者称相较Sol多轮本次一轮完成。 原帖强调交付为效果图，不当成完整工程建模；3000元是报价设想。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@yhslgg","url":"https://x.com/yhslgg"},"demoUrl":"https://x.com/yhslgg/status/2096250228315914691","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-379.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":436},{"id":"work-3cb719081111b670","name":"用 Three.js skill 包制作怪兽主题游戏","description":"Astra搭配作者游戏skill，Tripo生成模型、ElevenLabs音效。 依赖额外模型/声音工具，未试玩验证。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@majidmanzarpour","url":"https://x.com/majidmanzarpour"},"demoUrl":"https://x.com/majidmanzarpour/status/2096251574918013135","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-380.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":437},{"id":"work-e2c87bbb61911190","name":"控制 Mac 建造微型新古典宫殿","description":"Astra Ultra fast控制Mac，使用两条提示词。 作者报告不到45分钟。 作者报告和演示，未独立运行验收。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@leploutos","url":"https://x.com/leploutos"},"demoUrl":"https://x.com/leploutos/status/2096251791591510290","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-381.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":438},{"id":"work-fbb2fc7de248ff2c","name":"把西部场景 Blender 几何做成电影片段","description":"Topview中让Astra重构经典Western场景。 平台演示，未给具体影片或完整工程。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@TopviewAIhq","url":"https://x.com/TopviewAIhq"},"demoUrl":"https://x.com/TopviewAIhq/status/2096252019329716464","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-382.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":439},{"id":"work-e1f380f6fe0f742f","name":"以三维电影重演 OpenAI 与 Hugging Face 事件","description":"作者让Astra max解释该事件。 报告44分钟、673万tokens、周额度15%。 属于创意重演，不证明事件细节；计时与用量为作者报告。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@haider1","url":"https://x.com/haider1"},"demoUrl":"https://x.com/haider1/status/2096252283168456958","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-383.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":440},{"id":"work-679509678d10f7ec","name":"制作右上肢人体结构爆炸视图","description":"作者用Astra进一步探索解剖展示。 未验证解剖准确性；昨天腕管手术演示是另一任务，不自动合并。","category":"experiment","sourceCategory":"CheerSelfAI · 模拟与科学可视化","author":{"name":"@HandEManAI","url":"https://x.com/HandEManAI"},"demoUrl":"https://x.com/HandEManAI/status/2096253408009486619","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-384.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":441},{"id":"work-603a88f3617642fd","name":"修复 Tripo 机器人网格并在 Substance Painter 纹理化","description":"先用Grok参考图直接让Astra做出147K三角形模型未达需求，再用Tripo P2初网格交Astra在Blender和Substance Painter处理。 原模型质量不佳与后续改进均保留；作者强调token和混合人工流程。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@insaneUEFN","url":"https://x.com/insaneUEFN"},"demoUrl":"https://x.com/insaneUEFN/status/2096255563273314618","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-385.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":442},{"id":"work-a9050e64d61b54df","name":"构建含冲刺追踪与激光剑的机器人对战游戏","description":"作者用自然语言反复描述希望的动作。 多次调整，不写成一条prompt完成。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@hayashimon1","url":"https://x.com/hayashimon1"},"demoUrl":"https://x.com/hayashimon1/status/2096255665778069957","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-386.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":443},{"id":"work-27faa07b5f46a442","name":"生成游戏及其演示画面","description":"作者称游戏和演示画面均由Astra生成。 游戏任务细节未给，保留为作者单次游戏制作观察。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@budou_umibudou","url":"https://x.com/budou_umibudou"},"demoUrl":"https://x.com/budou_umibudou/status/2096256827931697488","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-387.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":444},{"id":"work-8797c162654e1b7a","name":"比较 Astra 与 Sol 中档的直升机建模","description":"两模型均Medium。 作者评价Astra更精细且能自由翻转，Sol视角受限。 未给正文完整prompt，个人比较不外推模型排名。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@xueyu1125","url":"https://x.com/xueyu1125"},"demoUrl":"https://x.com/xueyu1125/status/2096258146318880989","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-388.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":445},{"id":"work-fd115711c64a84ac","name":"生成 Tesla Model S 十六装配体拆解工作台","description":"作者让Astra从一条提示词建参考模型。 原帖明确reference study，非Tesla工程数据；与Model X334件不同任务。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@Acoramaa","url":"https://x.com/Acoramaa"},"demoUrl":"https://x.com/Acoramaa/status/2096258222134870370","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-389.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":446},{"id":"work-c59dd054d608c714","name":"为 AdCar TV 制作30至60秒介绍视频","description":"在既有代码/3D viewer仓库使用Astra、Remotion、ffmpeg和本地Qwen3TTS。 one-shot依赖已有汽车模型、音乐与声音资产。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@d4m1n","url":"https://x.com/d4m1n"},"demoUrl":"https://x.com/d4m1n/status/2096258259459964963","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-390.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":447},{"id":"work-0a8a3f8b843a025c","name":"展示 Matthew Berman 的七区域可探索星球","description":"二手明确归于Matthew Berman以Astra制作。 未给原作者链接，功能为转述；与同作者传播可由root合并。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@0xJokker","url":"https://x.com/0xJokker"},"demoUrl":"https://x.com/0xJokker/status/2096258495469277202","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-391.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":448},{"id":"work-f086bf1ae7b9000a","name":"比较 Astra 与 Fable 的 GTA 风格游戏生成","description":"作者自述实测Astra与Fable。 认为Fable更符合需求。 GTA6是风格/目标表述，不是完整商业游戏；未给prompt与客观评分。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@Tasihi_89","url":"https://x.com/Tasihi_89"},"demoUrl":"https://x.com/Tasihi_89/status/2096259499443245153","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-392.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":449},{"id":"work-79c32c196184c76f","name":"从文字描述生成完整房屋 Blender 场景","description":"二手称一条prompt完成Blender建模。 未给原作者或房屋输入，基准夸大不作结论。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@noahxops","url":"https://x.com/noahxops"},"demoUrl":"https://x.com/noahxops/status/2096260976274460998","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-393.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":450},{"id":"work-7cd5040c2007837e","name":"用 goal 指令构建移动游戏","description":"Astra与/goal运行。 作者报告约3小时、7300万tokens。 未给游戏名称与完整功能，tokens为报告值。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@jaimintf","url":"https://x.com/jaimintf"},"demoUrl":"https://x.com/jaimintf/status/2096261065659371822","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-394.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":451},{"id":"work-730662d08a041556","name":"在 After Effects 中生成特效与动态图形","description":"作者直接让Astra操作After Effects制作。 作者报告和演示，未独立运行验收。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@icreatelife","url":"https://x.com/icreatelife"},"demoUrl":"https://x.com/icreatelife/status/2096261585249370516","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-395.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":452},{"id":"work-ca419da268679414","name":"17分钟生成 Wipeout 风格竞速原型","description":"Astra构建。 未给作者原流程或与已有反重力竞速的同源证据。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@promptowy","url":"https://x.com/promptowy"},"demoUrl":"https://x.com/promptowy/status/2096261604195139712","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-396.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":453},{"id":"work-658c913e5e0997e5","name":"在 Onshape 中按选定传感器迭代机器人设计","description":"Astra构建connector从后端操作Onshape；作者自己控制鼠标和视角。 不能把鼠标视角操作归给模型；与同作者后续rover项目是否相同待root核查。","category":"tool","sourceCategory":"CheerSelfAI · 工程文件与代码迁移","author":{"name":"@Alpha10six","url":"https://x.com/Alpha10six"},"demoUrl":"https://x.com/Alpha10six/status/2096261751389978640","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-397.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":454},{"id":"work-cfad65b05d11137e","name":"开发开源遥控飞机飞行模拟器","description":"作者因经常摔飞机而用Astra构建。 报告不到24小时。 开源和飞行物理未独立核验。","category":"experiment","sourceCategory":"CheerSelfAI · 模拟与科学可视化","author":{"name":"@adithya_s_k","url":"https://x.com/adithya_s_k"},"demoUrl":"https://x.com/adithya_s_k/status/2096261827961463280","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-398.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":455},{"id":"work-9ed13ccf8ab00f96","name":"生成 SO-101 机械臂参数化 CAD","description":"作者让Astra创建参数化CAD。 未验证尺寸、装配或实机运动。","category":"tool","sourceCategory":"CheerSelfAI · 工程文件与代码迁移","author":{"name":"@MakerMatters","url":"https://x.com/MakerMatters"},"demoUrl":"https://x.com/MakerMatters/status/2096262183281692918","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-399.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":456},{"id":"work-3a15823d5d4b411a","name":"比较 Muse Spark Max 与 Astra 的 RocketLeagueBench","description":"在RocketLeagueBench比较Muse Spark1.3 Max与Astra。 未给定量成绩或测试配置，“差距大”为作者观点。","category":"other","sourceCategory":"CheerSelfAI · 专业研究与安全评测","author":{"name":"@LLMJunky","url":"https://x.com/LLMJunky"},"demoUrl":"https://x.com/LLMJunky/status/2096262579815342093","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-400.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":457},{"id":"work-4a7259cfe8ffdcde","name":"用五小时生成高密度可探索森林","description":"Astra使用Three.js与自定义shader。 植被数量与五小时为作者报告，未独立统计或测帧率。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@LexnLin","url":"https://x.com/LexnLin"},"demoUrl":"https://x.com/LexnLin/status/2096263046918197609","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-401.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":458},{"id":"work-b1ba569543c1c24c","name":"将模糊房间参考图重建为 Blender 场景","description":"Astra中档通过Blender CLI建模并渲染。 作者报告团队计划5小时额度约40%、月额度约10%。 还有细部待修改；额度和多边形数量为作者报告。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@afrop_afr","url":"https://x.com/afrop_afr"},"demoUrl":"https://x.com/afrop_afr/status/2096263142829695246","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-402.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":459},{"id":"work-4befd98587146056","name":"用30分钟构建 Fortnite 风格大逃杀","description":"作者称Astra从零构建。 30分钟和可玩性为作者报告，未来AAA预测不是已实现结果。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@luckeyfaraday","url":"https://x.com/luckeyfaraday"},"demoUrl":"https://x.com/luckeyfaraday/status/2096263629905571896","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-403.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":460},{"id":"work-4eb383189875cc7b","name":"生成轻松简洁的个人博客首页","description":"作者用Astra生成并提供网站与开源代码线索。 作者报告和演示，未独立运行验收。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@Justin1024go","url":"https://x.com/Justin1024go"},"demoUrl":"https://x.com/Justin1024go/status/2096263641968611528","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-404.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":461},{"id":"work-78cd3597ec788fdb","name":"将机器人模型扩成展示与荒野战斗两模式游戏","description":"参考卡兹克机器人建模，使用Astra、Blender和computer-use并自行迭代材质特效。 已有模型与人工迭代参与，未实际开源或验证完整功能。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@berryxia","url":"https://x.com/berryxia"},"demoUrl":"https://x.com/berryxia/status/2096264995151704418","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-405.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":462},{"id":"work-821fa7252d1d1db7","name":"生成可运行的板式网球游戏","description":"作者持续测试Astra。 报告数小时得到可运行结果并计划继续改善。 作者报告和演示，未独立运行验收。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@AlanDaitch","url":"https://x.com/AlanDaitch"},"demoUrl":"https://x.com/AlanDaitch/status/2096265072817422369","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-406.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":463},{"id":"work-978aa7cf4a34bf8b","name":"制作30秒鲨鱼短片","description":"Astra最高档、Seedance2.5与Topview协作。 模型贡献未拆清，不能将最终画面单独归给Astra。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@AiWithYou1","url":"https://x.com/AiWithYou1"},"demoUrl":"https://x.com/AiWithYou1/status/2096265891969384690","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-407.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":464},{"id":"work-1c738f88b9b15725","name":"制作 Apple Intention 风格自我视频","description":"作者称一次生成。 未给工具或完整prompt，不推断与其他Apple风格演示同源。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@pallavmac","url":"https://x.com/pallavmac"},"demoUrl":"https://x.com/pallavmac/status/2096266857439539354","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-408.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":465},{"id":"work-b66f471ccfc7ad22","name":"运行 MineBench 建模基准并比较有效率与成本","description":"MineBench平台在现有harness运行Astra Pro对照旧Sol。 报告所有构建首轮有效，平均25分54秒、估计总34.71美元。 费用仍待provider更新；未核验全套prompt及历史700美元对照。","category":"other","sourceCategory":"CheerSelfAI · 专业研究与安全评测","author":{"name":"@minebench_ai","url":"https://x.com/minebench_ai"},"demoUrl":"https://x.com/minebench_ai/status/2096267157965275144","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-409.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":466},{"id":"work-9a1889885b7e3a8a","name":"用单提示词制作产品宣传视频","description":"Topview平台展示Astra单条prompt流程。 未给产品名与完整过程，属于平台自营演示。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@TopviewAIhq","url":"https://x.com/TopviewAIhq"},"demoUrl":"https://x.com/TopviewAIhq/status/2096267361162797118","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-410.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":467},{"id":"work-a70bd862752390a6","name":"把虚假手游广告视频做成可玩原型","description":"输入广告视频给Astra，按其中玩法开发。 作者称约20分钟。 未给广告具体游戏名或完整试玩，原型不代表成熟产品。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@givros","url":"https://x.com/givros"},"demoUrl":"https://x.com/givros/status/2096267413385875592","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-411.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":468},{"id":"work-18c6ca060c94dec9","name":"展示 Astra 自动剪辑视频","description":"二手分享并指向原视频公开prompt的评论。 未取得完整prompt或素材，引用仅短链。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@yama_threads","url":"https://x.com/yama_threads"},"demoUrl":"https://x.com/yama_threads/status/2096267848104743260","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-412.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":469},{"id":"work-badc5a44bc5d05df","name":"制作 Grand Theft Galaxy Neon Horizon 浏览器原型","description":"作者用Astra约20分钟制作。 作者明确prototype，未独立验收；引用CROWNFALL是不同游戏。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@HexxRL","url":"https://x.com/HexxRL"},"demoUrl":"https://x.com/HexxRL/status/2096268813016646029","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-413.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":470},{"id":"work-5b736bcad2134b5d","name":"生成时空之轮风格浏览器游戏","description":"作者给Astra一句浏览器游戏指令。 作者报告和演示，未独立运行验收。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@hideki_climax","url":"https://x.com/hideki_climax"},"demoUrl":"https://x.com/hideki_climax/status/2096269008505053683","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-414.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":471},{"id":"work-6b3b0efae1565226","name":"开发深海生物荧光交互落地页","description":"串联Astra与Claude Code，使用React/Next、Three.js、Tailwind和Framer Motion。 15000美元是宣传定位，非实际成交或可验证成本。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@himanshubuildss","url":"https://x.com/himanshubuildss"},"demoUrl":"https://x.com/himanshubuildss/status/2096269057544831175","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-415.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":472},{"id":"work-c169e9772c6777f1","name":"根据黑白草图重建布雷未建成的牛顿纪念堂","description":"给Astra少量1784年黑白草图和描述。 从未建成建筑的想象重建，未验证与设计方案所有细节对应。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@emollick","url":"https://x.com/emollick"},"demoUrl":"https://x.com/emollick/status/2096270461122347131","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-416.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":473},{"id":"work-9e7524d658e0549c","name":"制作 Pudgy Penguins 主题三维网页作品","description":"Astra与Three.js单提示词生成。 作者称不到30分钟。 作者报告和演示，未独立运行验收。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@FoxyPenguinApe","url":"https://x.com/FoxyPenguinApe"},"demoUrl":"https://x.com/FoxyPenguinApe/status/2096273197083808029","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-417.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":474},{"id":"work-9a707eeb3ed91d87","name":"用 PixelFork 和 Three.js 制作赛车游戏","description":"作者使用PixelFork、Astra和Three.js。 称不到10分钟。 作者报告和演示，未独立运行验收。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@zaur_ibra","url":"https://x.com/zaur_ibra"},"demoUrl":"https://x.com/zaur_ibra/status/2096273776996426055","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-418.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":475},{"id":"work-424ec6c522d802b3","name":"构建真新镇与盗梦空间交叉三维场景","description":"作者直接给Astra该主题创意。 作者报告和演示，未独立运行验收。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@yungcontent","url":"https://x.com/yungcontent"},"demoUrl":"https://x.com/yungcontent/status/2096275376125436214","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-419.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":476},{"id":"work-1c327ffd574005af","name":"制作 A Room Made of Replies 并改进视频工具","description":"Astra在eidoverse-video中边制片边改善工具。 物理精确性为作者说法，不证明控制真实机器人能力。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@SkyeSharkie","url":"https://x.com/SkyeSharkie"},"demoUrl":"https://x.com/SkyeSharkie/status/2096276401204936939","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-420.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":477},{"id":"work-3e96dc7a3979b436","name":"比较 Astra 与 Sol 的植物生长动画","description":"Astra在左、Sol5.6在右。 作者主观评价，未给prompt和运行成本。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@developedbyed","url":"https://x.com/developedbyed"},"demoUrl":"https://x.com/developedbyed/status/2096276420804657257","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-421.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":478},{"id":"work-7634d2a7ff0dc044","name":"汇总 Peter Gostev 的63组三维世界生成测试","description":"二手描述无挑选的一次生成实验，引用Arena AI评测介绍。 未打开63条仓库或完整评测，课程价值宣传不作事实；全部样本计一组评测。","category":"other","sourceCategory":"CheerSelfAI · 专业研究与安全评测","author":{"name":"@sopersone","url":"https://x.com/sopersone"},"demoUrl":"https://x.com/sopersone/status/2096276504368017826","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-422.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":479},{"id":"work-de83622bb60398a5","name":"测试作曲与演奏肖邦风格夜曲","description":"作者以引用中的肖邦夜曲标准进行单次测试。 作者评价不佳。 主观音乐测试，未披露演奏工具或乐谱。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@uncledoomer","url":"https://x.com/uncledoomer"},"demoUrl":"https://x.com/uncledoomer/status/2096276626560503843","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-423.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":480},{"id":"work-54f20b4a9271b738","name":"比较 Three.js WebGPU 弹性果冻生成","description":"Astra与Fable5.1均制作美味外观、可弹跳果冻。 作者报告Fable35分钟约15美元，Astra80分钟约20美元。 费用与计时为作者报告，评价主观。","category":"experiment","sourceCategory":"CheerSelfAI · 模拟与科学可视化","author":{"name":"@vikktorrrre","url":"https://x.com/vikktorrrre"},"demoUrl":"https://x.com/vikktorrrre/status/2096278239773700351","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-424.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":481},{"id":"work-ac5889c636fc1bcd","name":"把科研框架图重建为可编辑 PowerPoint","description":"将PaperBanana以Nano Banana Pro生成的原图交给Astra重建。 对照为作者展示，未下载文件验证可编辑性。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@dwzhu128","url":"https://x.com/dwzhu128"},"demoUrl":"https://x.com/dwzhu128/status/2096279239255576852","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-425.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":482},{"id":"work-a487e8e23bfc06e5","name":"生成高细节可交互 V8 发动机","description":"作者向Astra提出交互发动机任务。 未验证工程精度；与其他作者同题不直接合并。","category":"experiment","sourceCategory":"CheerSelfAI · 模拟与科学可视化","author":{"name":"@DilumSanjaya","url":"https://x.com/DilumSanjaya"},"demoUrl":"https://x.com/DilumSanjaya/status/2096280244663775423","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-427.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":483},{"id":"work-9fd7249119148cfa","name":"建模蟠桃园并在剪映完成30秒短片","description":"Astra medium fast做6轮建模、调用MiniMax配乐，并操作剪映重排镜头、变速、加字幕封面。 全流程约110分钟含沟通渲染检查。 耗时来自作者实际记录，非无人单次生成。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@nicekate8888","url":"https://x.com/nicekate8888"},"demoUrl":"https://x.com/nicekate8888/status/2096280438717448531","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-428.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":484},{"id":"work-99b508afb7d9c607","name":"把8分钟口播剪成7分钟并自动加字幕","description":"Astra直接操作电脑，删除重复、停顿和说错段落。 作者称初稿连贯，专业术语字幕错误少。 仍为初剪；准确率未量化。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@tiabitcoin","url":"https://x.com/tiabitcoin"},"demoUrl":"https://x.com/tiabitcoin/status/2096280487262409177","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-429.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":485},{"id":"work-2eed2aab836249ba","name":"用 JavaScript 绘制蒙娜丽莎","description":"作者让Astra用JavaScript作画。 作者报告和演示，未独立运行验收。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@NovaXCode","url":"https://x.com/NovaXCode"},"demoUrl":"https://x.com/NovaXCode/status/2096280576361898483","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-430.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":486},{"id":"work-7e53463655a25e9f","name":"为 Unity 卡牌实现背景与角色分开的闪卡效果","description":"Astra配合Unity制作，并按要求区分背景与角色效果。 作者报告和演示，未独立运行验收。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@ShadeLurk","url":"https://x.com/ShadeLurk"},"demoUrl":"https://x.com/ShadeLurk/status/2096281715958554784","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-431.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":487},{"id":"work-3986d244c21ca572","name":"制作 One More Vine 藤蔓冒险游戏","description":"作者用Astra开发并给出在线试玩。 作者报告和演示，未独立运行验收。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@bennash","url":"https://x.com/bennash"},"demoUrl":"https://x.com/bennash/status/2096282758930645170","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-432.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":488},{"id":"work-5106b2e6cff76176","name":"一次生成 motion design 短片","description":"作者称Astra一次生成。 没有给具体主题、底层工具或完整prompt。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@Kirako_ai","url":"https://x.com/Kirako_ai"},"demoUrl":"https://x.com/Kirako_ai/status/2096283314046767369","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-433.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":489},{"id":"work-2c6d3011eb5f841e","name":"构建链上新发行扫描与模拟交易终端","description":"作者用Astra构建bot，以四项合约门槛控制模拟交易。 演示0.3ETH、30K市值和66x是模拟曲线，原帖明确非真实成交。 不证明实盘收益或风控有效，仅模拟逻辑展示。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@0xBackwood","url":"https://x.com/0xBackwood"},"demoUrl":"https://x.com/0xBackwood/status/2096283642314006583","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-434.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":490},{"id":"work-250d4bb2890affe5","name":"从一张平面图生成建筑场景与渲染","description":"Astra生成场景代码，Higgsfield在Blender建模并用Cycles渲染。 平台演示，未核查户型尺寸准确性。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096284092593758631","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-435.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":491},{"id":"work-d1a7fe58a5cead58","name":"构建糟糕营销创意博物馆","description":"作者用Astra把营销反例做成主题博物馆。 作者报告和演示，未独立运行验收。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@ecomchasedimond","url":"https://x.com/ecomchasedimond"},"demoUrl":"https://x.com/ecomchasedimond/status/2096285235961045307","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-436.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":492},{"id":"work-c2f185fa21442a70","name":"单提示词生成三维火山","description":"作者首次测试Astra三维能力。 作者称使用周额度3%。 额度为个人计划消耗，未披露建模配置。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@0xRemakw","url":"https://x.com/0xRemakw"},"demoUrl":"https://x.com/0xRemakw/status/2096285870768668943","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-437.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":493},{"id":"work-bbb313f62192a46f","name":"重建 Konrad Zuse Z3 计算机","description":"Astra与Higgsfield重建。 未验证机械或计算功能的真实复刻。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096286544286175611","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-438.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":494},{"id":"work-2901353fccab9a03","name":"在 CPU 环境运行 DOOM 并比较帧率","description":"作者对比旧Sol约1FPS与Astra结果。 作者报告Astra达到20+FPS。 原帖称在其CPU上运行，未说明CPU实现或架构；帧率未经独立测量。","category":"tool","sourceCategory":"CheerSelfAI · 工程文件与代码迁移","author":{"name":"@Angaisb_","url":"https://x.com/Angaisb_"},"demoUrl":"https://x.com/Angaisb_/status/2096287643654840561","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-439.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":495},{"id":"work-d4e19794f16d76cf","name":"生成 Codex Micro 的 Grok Bot 风格三维版本","description":"原帖给出单条生成指令。 作者报告和演示，未独立运行验收。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@omarsar0","url":"https://x.com/omarsar0"},"demoUrl":"https://x.com/omarsar0/status/2096288397811679718","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-440.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":496},{"id":"work-52735c35bc7c6769","name":"对照 cozy Japan 2.0 场景生成","description":"作者在同一prompt上运行Astra，引用自己Fable旧作。 作者不确定Astra是否更优，认为可能是审美偏好。 作者报告和演示，未独立运行验收。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@0xPaulius","url":"https://x.com/0xPaulius"},"demoUrl":"https://x.com/0xPaulius/status/2096288936565817668","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-441.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":497},{"id":"work-635d3da3ce5d91a6","name":"在 Roblox 重建 Higgsfield 办公室","description":"平台让Astra在Roblox重建自家办公室。 作者报告和演示，未独立运行验收。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096290616271577239","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-442.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":498},{"id":"work-43168960ed881a35","name":"展示单提示词生成的浏览器三维游戏","description":"二手声称一条提示词生成整个游戏。 14000对象、120FPS、5分钟及盲测85%等均无原始证据，不作验证结论；引用索尼克可能是另一演示。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@shmidtqq","url":"https://x.com/shmidtqq"},"demoUrl":"https://x.com/shmidtqq/status/2096290771288961169","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-443.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":499},{"id":"work-e71798194536df98","name":"开发截图转可探索三维世界网站","description":"作者用Astra构建截图转三维体验。 未独立验证任意截图的泛化效果。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@yungcontent","url":"https://x.com/yungcontent"},"demoUrl":"https://x.com/yungcontent/status/2096291179843440952","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-444.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":500},{"id":"work-c113d6572bd1bd8d","name":"根据原视频与素材制作线框教程视频","description":"输入视频与素材，让Astra处理并在Flova制作。 各工具具体分工未拆清。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@Cupang1997","url":"https://x.com/Cupang1997"},"demoUrl":"https://x.com/Cupang1997/status/2096291647927792037","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-445.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":501},{"id":"work-812b60c115e76740","name":"创作钢琴圆舞曲并让三维钢琴家按音符演奏","description":"Astra与Higgsfield组合音乐、代码和动画。 手指逐音对应为平台主张，未核验音画同步。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096292350180163648","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-446.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":502},{"id":"work-5f8c4ca5cfd31393","name":"生成圣家堂三维导览","description":"Astra建模，Unreal Engine渲染，运行于Higgsfield Supercomputer。 作者报告和演示，未独立运行验收。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@adilinthewild","url":"https://x.com/adilinthewild"},"demoUrl":"https://x.com/adilinthewild/status/2096292643101904985","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-447.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":503},{"id":"work-cddd2832c197ece9","name":"对照20次抓积木放入碗中的操作任务","description":"各给20次抓放任务。 报告Astra95%、2.5分钟、每次0.94美元，Fable40%、6.8分钟、2.12美元。 运行环境与原始记录未给，指标为帖子报告。","category":"other","sourceCategory":"CheerSelfAI · 专业研究与安全评测","author":{"name":"@alexgetmancom","url":"https://x.com/alexgetmancom"},"demoUrl":"https://x.com/alexgetmancom/status/2096293480075002060","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-448.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":504},{"id":"work-76477f89969db2cb","name":"生成可拉伸的橙片软糖网页","description":"作者让Astra生成gummy orange slice。 作者报告和演示，未独立运行验收。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@vib3coded","url":"https://x.com/vib3coded"},"demoUrl":"https://x.com/vib3coded/status/2096293644298784949","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-449.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":505},{"id":"work-8c7f76a5a7085c84","name":"在 MineBench 测试地球大陆建模","description":"平台用Astra Pro运行社区提示词并展出结果。 平台称首次准确表现所有大陆。 大陆准确性为平台评价，未验证全部样本。","category":"other","sourceCategory":"CheerSelfAI · 专业研究与安全评测","author":{"name":"@minebench_ai","url":"https://x.com/minebench_ai"},"demoUrl":"https://x.com/minebench_ai/status/2096294038357913797","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-450.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":506},{"id":"work-f2bbede9eb562665","name":"用 Bricklink Studio 设计积木并渲染4K视频","description":"Astra操作Bricklink Studio设计，再用Blender渲染。 未下载零件表或验证实体可装配。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@dkundel","url":"https://x.com/dkundel"},"demoUrl":"https://x.com/dkundel/status/2096297005924729240","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-451.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":507},{"id":"work-edfe867c34ca3a47","name":"重建火影忍者木叶村","description":"Higgsfield与Astra协作。 作者称10–15分钟。 作者报告和演示，未独立运行验收。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@adilinthewild","url":"https://x.com/adilinthewild"},"demoUrl":"https://x.com/adilinthewild/status/2096297824053063957","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-452.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":508},{"id":"work-2c3ec48e6fd7ceb2","name":"在 Blender 重建里斯本商业广场","description":"作者用Astra High一条提示词重做其大学图形学课程题目。 作者一次测试，未核查与原建筑一致性。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@goncalo_canhoto","url":"https://x.com/goncalo_canhoto"},"demoUrl":"https://x.com/goncalo_canhoto/status/2096298425914450021","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-453.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":509},{"id":"work-2fcf7d303d43e4e3","name":"重建温哥华 Credit Foncier Building","description":"二手描述Astra建模、编辑引擎场景并测试修正。 转述约30分钟。 二手帖子未给原作者；测试和耗时未独立确认。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@Lummox_eth","url":"https://x.com/Lummox_eth"},"demoUrl":"https://x.com/Lummox_eth/status/2096298583431467093","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-454.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":510},{"id":"work-9bc1da21770050b1","name":"液态玻璃三维渲染","description":"液态玻璃效果的三维渲染","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@stevibe","url":"https://x.com/stevibe"},"demoUrl":"https://x.com/stevibe/status/2096300155477934368","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-455.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":511},{"id":"work-12cab97fd52cbf86","name":"代理群代码审核与研究分工","description":"观察九天使用情况后移除四个不常用代理，并调整审批。 效率收益未给出独立量化；不把去审批推广为通用建议。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@Roxx_0x","url":"https://x.com/Roxx_0x"},"demoUrl":"https://x.com/Roxx_0x/status/2096300416799801435","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-456.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":512},{"id":"work-eedd3a9ce83add1e","name":"组件参考驱动的个人作品集","description":"参考 Rare UI 组件制作的个人作品集页面 参考组件参与设计，不称完全从零独立设计。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@code_kartik","url":"https://x.com/code_kartik"},"demoUrl":"https://x.com/code_kartik/status/2096300833583624261","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-457.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":513},{"id":"work-7a8d332440c16445","name":"直播制作并打印可运转齿轮","description":"经 3D 打印并展示运动的齿轮设计 八小时直播和运转情况为作者证据，未独立做机械测试。","category":"tool","sourceCategory":"CheerSelfAI · 工程文件与代码迁移","author":{"name":"@_MaxBlade","url":"https://x.com/_MaxBlade"},"demoUrl":"https://x.com/_MaxBlade/status/2096302486277480532","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-458.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":514},{"id":"work-b6fcd2232c87bfc3","name":"纽约五百年城市变迁展示","description":"覆盖五百年的纽约历史与未来三维变化 历史部分未核验，未来部分属于想象。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096303855806058934","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-459.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":515},{"id":"work-7f8e0f960665636d","name":"吉祥物动画生成","description":"单次生成的吉祥物动画片段","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@tenseidesign","url":"https://x.com/tenseidesign"},"demoUrl":"https://x.com/tenseidesign/status/2096305008748965921","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-460.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":516},{"id":"work-890c2bbb7b418cdd","name":"After Effects 参考动效重建","description":"分析视频动作与时序，然后逐元素建立合成。 二十分钟为平台记录。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096306588978196786","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-461.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":517},{"id":"work-1c706b04c57ff3f0","name":"产品图到 UGC 鞋广告","description":"Astra 组织产品图和分镜，结合图像视频工具生成广告。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@jerrod_lew","url":"https://x.com/jerrod_lew"},"demoUrl":"https://x.com/jerrod_lew/status/2096307244921164232","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-462.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":518},{"id":"work-3bc97702c10bc6ca","name":"摄像头控制的无接触簧风琴","description":"先让模型观察硬件并建议项目，再据此构建演奏交互。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@shydev69","url":"https://x.com/shydev69"},"demoUrl":"https://x.com/shydev69/status/2096308047186719077","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-463.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":519},{"id":"work-6d5d391333e55450","name":"反乌托邦城市第一人称游戏","description":"包含蜘蛛、僵尸、战争机器与守卫的城市 FPS 原型","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@techartist_","url":"https://x.com/techartist_"},"demoUrl":"https://x.com/techartist_/status/2096308761535394034","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-464.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":520},{"id":"work-d672c315480285b9","name":"户型设计到 Unreal 房屋漫游","description":"模型设计平面布局、用命令行 Blender 建模，建立导出流程并启动画面检查和修改。 60 FPS 为原作者陈述；尚未验证客户改动能否自动贯穿两工具。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@lagerskoy","url":"https://x.com/lagerskoy"},"demoUrl":"https://x.com/lagerskoy/status/2096308799942595052","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-465.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":521},{"id":"work-697a6359041acaa6","name":"五关 2D 射击游戏与预告片","description":"五个关卡的 2D 射击游戏及预告视频 三次提示、两次修订和六十分钟为作者记录。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@kiyoshi_shin","url":"https://x.com/kiyoshi_shin"},"demoUrl":"https://x.com/kiyoshi_shin/status/2096312253918421028","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-466.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":522},{"id":"work-a0ec27e84a9da1ae","name":"行情驱动的大逃杀可视化","description":"将成交量和流动性映射到大逃杀角色血条的动态界面 实时数据接入为作者陈述，不作为投资效果证明。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@explosss1ve","url":"https://x.com/explosss1ve"},"demoUrl":"https://x.com/explosss1ve/status/2096313084692337025","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-467.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":523},{"id":"work-6a07b148471e4e24","name":"Xunantunich 玛雅遗址三维场景","description":"Xunantunich 遗址三维模型 两小时用时与历史准确性未独立验证。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@omarsar0","url":"https://x.com/omarsar0"},"demoUrl":"https://x.com/omarsar0/status/2096314593182171545","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-468.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":524},{"id":"work-1d821b15c8a69a46","name":"38 页木屋图纸转三维模型","description":"由 PDF 图纸与效果图生成内外部木屋三维模型 十分钟及按比例重建为作者自述，未做尺寸复测。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@LukeW","url":"https://x.com/LukeW"},"demoUrl":"https://x.com/LukeW/status/2096318130507436073","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-469.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":525},{"id":"work-3be5f0d17a1fffe3","name":"CapCut 剪辑结合本机转写","description":"Astra 负责电脑剪辑操作，Gemma 负责设备端转写。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@ivanleomk","url":"https://x.com/ivanleomk"},"demoUrl":"https://x.com/ivanleomk/status/2096318169497620699","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-470.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":526},{"id":"work-62377b1321acff1b","name":"Python 随机车流与单向红绿灯测试","description":"随机车流、单向道路及交通灯的可视化对照 以帖文为准记录 Astra High 的尝试，未独立测算法正确性。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@diegocabezas01","url":"https://x.com/diegocabezas01"},"demoUrl":"https://x.com/diegocabezas01/status/2096319081280401640","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-471.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":527},{"id":"work-0ccbe36da61e137f","name":"温哥华 Science World 三维重建","description":"Science World 建筑的三维模型","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@tokifyi","url":"https://x.com/tokifyi"},"demoUrl":"https://x.com/tokifyi/status/2096319441072255363","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-472.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":528},{"id":"work-9b2dab9d907f0b2f","name":"Blender 新闻节目开场动画","description":"含地球、轨道元素及动态标题的新闻开场片","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096320620862841139","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-473.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":529},{"id":"work-396b38cfc8ab33db","name":"制造车间 ERP 生产追踪","description":"跟踪单位、阶段、员工、工序和材料问题的 ERP 界面 面向客户的交互追踪为后续计划。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@dfwstrategy","url":"https://x.com/dfwstrategy"},"demoUrl":"https://x.com/dfwstrategy/status/2096322330977095881","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-474.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":530},{"id":"work-15b9e327a4693d60","name":"单提示词产品发布视频","description":"使用 Astra 制作的产品发布视频 具体剪辑或渲染工具未说明。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@dchernyshuk","url":"https://x.com/dchernyshuk"},"demoUrl":"https://x.com/dchernyshuk/status/2096325356294910456","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-475.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":531},{"id":"work-636a8e84754cbad2","name":"Cinema 4D 卡丁车竞速动画","description":"Cinema 4D 卡丁车竞速片段","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096325376809341069","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-476.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":532},{"id":"work-7bd447f4fa4ad775","name":"蜘蛛侠蛛丝移动游戏","description":"带蛛丝摆荡、道路和界面的 Spider-Man 风格游戏 单提示词完成是发布者转述。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@Mr_Salio","url":"https://x.com/Mr_Salio"},"demoUrl":"https://x.com/Mr_Salio/status/2096326748979765268","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-477.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":533},{"id":"work-425fd1e764f21612","name":"机器人进入新房间启动洗衣机","description":"连接 Astra 的机器人识别并旋转洗衣机旋钮 实体操作成功为发布者陈述，未独立重复试验。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@ARXrobotics","url":"https://x.com/ARXrobotics"},"demoUrl":"https://x.com/ARXrobotics/status/2096328304794210604","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-478.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":534},{"id":"work-cca8d9fbcf0ebe9e","name":"Apple Log 2 视频调色","description":"对 Apple Log 2 素材的对比度、阴影和色彩调整","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096330570712400319","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-479.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":535},{"id":"work-1dcca62dbe28f2e7","name":"Higgsfield 场景搭建与视频风格处理","description":"先场景构建，再由视频模型处理风格。 具体场景内容未在正文详述。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@Kiber_Alla","url":"https://x.com/Kiber_Alla"},"demoUrl":"https://x.com/Kiber_Alla/status/2096330873427669455","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-480.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":536},{"id":"work-a99ade911369d8f5","name":"多代理行情观察与交易执行演示","description":"分配角色、共享目录，风控代理否决条件不合格的入场。 未核验账户、真实成交或收益，帖称 67 美元变 4560 美元不能视为验证结果。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@immortalhowwl","url":"https://x.com/immortalhowwl"},"demoUrl":"https://x.com/immortalhowwl/status/2096331356389232994","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-481.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":537},{"id":"work-9cc538ff9b68ffd4","name":"Figma 参考图转可编辑画面","description":"包含轮廓、人脸、徽记、纹理的 Figma 画面","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096333291943338210","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-482.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":538},{"id":"work-f08c921f794dc3d1","name":"依据参考图进行视频调色","description":"在 DaVinci Resolve 按参考图调整视频色彩 四分钟为平台陈述。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096334648016253339","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-483.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":539},{"id":"work-49ebf613d71dea02","name":"参考龙图转十秒 Blender 镜头","description":"通过无界面 Blender 的 Python 脚本持续迭代。 八小时为作者陈述；GUI 测试是后续计划。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@doomdave","url":"https://x.com/doomdave"},"demoUrl":"https://x.com/doomdave/status/2096335588727349434","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-484.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":540},{"id":"work-e81e7d006f520e85","name":"单文件 HTML 视觉页面","description":"由单个 HTML 文件构成的视觉页面 根帖没有提供足够文字命名页面主题，保留为网页演示。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@MiaAI_lab","url":"https://x.com/MiaAI_lab"},"demoUrl":"https://x.com/MiaAI_lab/status/2096336323183284675","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-485.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":541},{"id":"work-20014c626ae37cb0","name":"体素城堡村庄与风车麦田","description":"包含城堡、村庄、风车及麦田的体素场景 412364 根麦秆与五分钟生成是作者自述。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@filicroval","url":"https://x.com/filicroval"},"demoUrl":"https://x.com/filicroval/status/2096337088396300507","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-486.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":542},{"id":"work-346b2be440ca40fa","name":"ORBITAL 太阳系探索模拟","description":"八颗行星、二十颗卫星与简化飞行的太阳系 物理与天体尺度采用简化设定，未独立核验。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@dzhohola","url":"https://x.com/dzhohola"},"demoUrl":"https://x.com/dzhohola/status/2096339041679442428","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-487.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":543},{"id":"work-80a82879d3904941","name":"精细 3D 相机模型","description":"含 122 组、1877 个零件的 Three.js 相机模型 零件统计未独立验证。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@omarsar0","url":"https://x.com/omarsar0"},"demoUrl":"https://x.com/omarsar0/status/2096339043919237288","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-488.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":544},{"id":"work-edc094b3d596cdd4","name":"浏览器海洋场景开发","description":"迭代五小时以上的浏览器海洋场景 开发时长和与其他模型比较为作者体验。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@LexnLin","url":"https://x.com/LexnLin"},"demoUrl":"https://x.com/LexnLin/status/2096341945979383932","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-489.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":545},{"id":"work-beeacf0a53bf0775","name":"Astra 与 Fable 胜利界面对照","description":"两模型生成游戏胜利画面的界面对照 未从视频独立判定胜负。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@developedbyed","url":"https://x.com/developedbyed"},"demoUrl":"https://x.com/developedbyed/status/2096342406991843555","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-490.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":546},{"id":"work-996c7f2a0bc20da9","name":"角色概念到绑定和动画的多工具制作","description":"概念和纹理转三维，Blender 完成拓扑、UV、绑定并检查返工，再进入视频生成。 30 分钟及可用于生产的判断是平台自述。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096342420543660277","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-491.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":547},{"id":"work-b90d22ee76a043bb","name":"浏览器 Factorio 风格游戏","description":"在浏览器运行的 Factorio 风格克隆游戏","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@ephraimduncan","url":"https://x.com/ephraimduncan"},"demoUrl":"https://x.com/ephraimduncan/status/2096342660214649245","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-492.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":548},{"id":"work-846199659cebb5ef","name":"旋律生成与音乐可视化分工","description":"不同模型分别负责音乐与可视化。 可视化不归因为 Astra 独立产物。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@R2Cdev_","url":"https://x.com/R2Cdev_"},"demoUrl":"https://x.com/R2Cdev_/status/2096343375339303253","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-493.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":549},{"id":"work-a464f0bef876f880","name":"单提示词 Object Show 短片","description":"Astra Pro 生成的 Object Show 视频 未披露具体视频生成工具。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@AiCanvas88957","url":"https://x.com/AiCanvas88957"},"demoUrl":"https://x.com/AiCanvas88957/status/2096344373415862616","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-494.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":550},{"id":"work-7125dfab2ee807ee","name":"Blender 动画到 Magnific 视频","description":"Astra 建模与关键帧导出，再交给视频工具。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@jerrod_lew","url":"https://x.com/jerrod_lew"},"demoUrl":"https://x.com/jerrod_lew/status/2096344802371703116","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-495.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":551},{"id":"work-7b1bec7bf07da0c0","name":"Vice City 直升机任务操作测试","description":"以 GTA Vice City 直升机任务测试模型操作能力 帖子未给出任务完成率或最终成功结论。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@yuntiandeng","url":"https://x.com/yuntiandeng"},"demoUrl":"https://x.com/yuntiandeng/status/2096346317479870830","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-496.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":552},{"id":"work-1ca0475228b056e1","name":"趋势选题到 YouTube Shorts 发布","description":"研究趋势并生成、配标题标签和发布十支 Shorts 的工作流 十支视频及观看效果为平台陈述，未访问频道验证。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096346331623358796","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-497.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":553},{"id":"work-4aeb151113b5767c","name":"SwiftUI 活动监视器界面","description":"Pro 提供设计、Astra Light 负责实现。 44 分钟为作者记录；不把设计全归给 Astra。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@wieslawsoltes","url":"https://x.com/wieslawsoltes"},"demoUrl":"https://x.com/wieslawsoltes/status/2096346434706481274","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-498.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":554},{"id":"work-1a246caeb01c0a21","name":"Illustrator 原生插画与导出排障","description":"在文件选择器冻结后经 Finder 绕过并完成导出。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096347209512178008","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-499.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":555},{"id":"work-2407f7fdd02d5049","name":"ForgeCAD 机器狗设计","description":"ForgeCAD 中的机器狗设计模型 未证明制成实体或具备运动能力。","category":"tool","sourceCategory":"CheerSelfAI · 工程文件与代码迁移","author":{"name":"@ruben_kostard","url":"https://x.com/ruben_kostard"},"demoUrl":"https://x.com/ruben_kostard/status/2096348087425871979","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-500.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":556},{"id":"work-ef272197f8b9bc56","name":"Blender 对角巷漫游","description":"分步骤生成场景并设置漫游摄像机。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@koldo2k","url":"https://x.com/koldo2k"},"demoUrl":"https://x.com/koldo2k/status/2096348588930461731","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-501.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":557},{"id":"work-3f0311e08594e072","name":"儿童制作 3D 火箭游戏","description":"作者称其十岁孩子制作的 3D 火箭游戏 作者转述孩子的制作过程。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@AIStockSavvy","url":"https://x.com/AIStockSavvy"},"demoUrl":"https://x.com/AIStockSavvy/status/2096350330661335365","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-502.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":558},{"id":"work-7f9a0c06063c8522","name":"动画剑斗从分镜到剪辑","description":"简述转 Blender 预演，再生成镜头并剪辑。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096352124754104618","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-503.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":559},{"id":"work-ed315901660f0dc7","name":"3D 游戏截图评分迭代工作流","description":"使用截图审查反馈迭代游戏视觉，目标超过 8 分。 评分来自作者自设循环，非独立质量测评。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@aisearchio","url":"https://x.com/aisearchio"},"demoUrl":"https://x.com/aisearchio/status/2096354119368028257","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-504.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":560},{"id":"work-dca6a651f46c95bc","name":"五分钟 Three.js 外星人","description":"Three.js 外星人三维角色 五分钟为作者自述。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@CryptoVonDoom","url":"https://x.com/CryptoVonDoom"},"demoUrl":"https://x.com/CryptoVonDoom/status/2096354164301537484","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-505.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":561},{"id":"work-57515236cfec17d8","name":"以本人形象构建实时约会模拟器","description":"结合本人形象与实时对话制作约会体验。 引用同作者较早演示作为背景；未亲自试玩。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@meh_agarwal","url":"https://x.com/meh_agarwal"},"demoUrl":"https://x.com/meh_agarwal/status/2096355359334269076","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-506.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":562},{"id":"work-e7d58f9d4390a383","name":"Minecraft 方块光照修改与额度消耗","description":"单个方块光照修改耗尽两份 Plus 额度的测试 六分钟和订阅额度消耗为作者自述，不换算成 API 成本。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@pigeon__s","url":"https://x.com/pigeon__s"},"demoUrl":"https://x.com/pigeon__s/status/2096355632031089029","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-507.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":563},{"id":"work-c171e65a5c7d0558","name":"Minecraft 风格游戏制作展示","description":"Minecraft 风格游戏演示 根帖未明确说明其本人是执行者。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@Aivy___X","url":"https://x.com/Aivy___X"},"demoUrl":"https://x.com/Aivy___X/status/2096357713076781101","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-508.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":564},{"id":"work-1e2119b9f873401a","name":"迈阿密 Brickell 城市模型","description":"迈阿密 Brickell 区的三维城市展示 作者指出不准确；8 分钟 Medium 与地图输入方式未经验证。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@growingmiami","url":"https://x.com/growingmiami"},"demoUrl":"https://x.com/growingmiami/status/2096357964718428167","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-509.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":565},{"id":"work-71cc078326ba72d2","name":"警车追逐驾驶游戏","description":"含车物理、警察、交通、检查点和计分的驾驶追逐游戏 在线运行与单提示词生成是平台自述。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096358632309071966","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-510.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":566},{"id":"work-cab7dae1a2f2a884","name":"可调节台灯机构概念","description":"台灯调整机构的设计原型 作者表达后续制造愿望，未作为实体成品收录。","category":"tool","sourceCategory":"CheerSelfAI · 工程文件与代码迁移","author":{"name":"@ruben_kostard","url":"https://x.com/ruben_kostard"},"demoUrl":"https://x.com/ruben_kostard/status/2096359354530238936","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-511.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":567},{"id":"work-563f5c24e34d8ffa","name":"七层动态几何构成动画","description":"448 面板、7 层持续变形的 Blender 几何艺术 面板数量、40 倍 high 和用时均为作者陈述。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@0xArtix","url":"https://x.com/0xArtix"},"demoUrl":"https://x.com/0xArtix/status/2096359972724527171","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-512.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":568},{"id":"work-1bb59873ec033cdb","name":"止损题材女孩故事短片","description":"以止损为题材的女孩故事短片 具体视频模型与制作流程未知。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@small_world_uta","url":"https://x.com/small_world_uta"},"demoUrl":"https://x.com/small_world_uta/status/2096360676466061583","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-513.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":569},{"id":"work-555b3cb29bc7c759","name":"Apple Silicon 上运行帝国时代 IV","description":"在 Apple Silicon 运行 Age of Empires IV 的移植演示 70–150 FPS、与 CrossOver 的 8 FPS 对照及在线稳定性均为作者自测。","category":"tool","sourceCategory":"CheerSelfAI · 工程文件与代码迁移","author":{"name":"@marc_ibrahim","url":"https://x.com/marc_ibrahim"},"demoUrl":"https://x.com/marc_ibrahim/status/2096365209111724235","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-514.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":570},{"id":"work-ed65079c9fa218ff","name":"Saber Descent 光剑地牢游戏","description":"使用光剑进行战斗的地牢爬行游戏 开源与可玩性为作者自述。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@CtrlAltDwayne","url":"https://x.com/CtrlAltDwayne"},"demoUrl":"https://x.com/CtrlAltDwayne/status/2096365441472209227","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-515.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":571},{"id":"work-a2ebcc491598de7e","name":"无技能辅助的故事视频失败尝试","description":"故事视频中 r2v 背景长时间不变化的失败记录 多工具角色和背景停滞原因未充分说明。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@onofumi_AI","url":"https://x.com/onofumi_AI"},"demoUrl":"https://x.com/onofumi_AI/status/2096369248138621315","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-516.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":572},{"id":"work-bdf59fe33693b073","name":"可拉伸翅膀的果冻蝴蝶","description":"WebGPU 蝴蝶抓取、拉伸交互演示 引用的橘子软糖为另一物体，未据同类任务合并。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@vib3coded","url":"https://x.com/vib3coded"},"demoUrl":"https://x.com/vib3coded/status/2096369459690680343","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-517.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":573},{"id":"work-bd42bf8c79b4998b","name":"在 Minecraft 重建纽约","description":"纽约城市的 Minecraft 场景","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@higgsfield","url":"https://x.com/higgsfield"},"demoUrl":"https://x.com/higgsfield/status/2096370002849120468","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-518.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":574},{"id":"work-cb31c3e999bd8cf1","name":"Orbital Atlas 多尺度太阳系","description":"可从银河缩放到行星内部的牛顿力学太阳系展示 力学精度和内部结构未独立验证。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096371095779901510","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-519.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":575},{"id":"work-e783e48f34f3e40d","name":"一万年前人类外观的创作演示","description":"对一万年前人类外观的视觉重建演示 属于创作性重建，未验证历史或科学准确性。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096371499930374536","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-520.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":576},{"id":"work-7aaa4f333818d972","name":"两小时复刻早期 Fortnite","description":"OG Fortnite 风格地图与游戏原型 准确地图、两小时及 100% 额度消耗为作者自述。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@vixenovaa","url":"https://x.com/vixenovaa"},"demoUrl":"https://x.com/vixenovaa/status/2096372027359686689","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-521.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":577},{"id":"work-5ab5c4705a44517b","name":"Codex 内多模型限流器开发审查","description":"开发、跨模型审查、接受有效问题并修复。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@sanchitmonga22","url":"https://x.com/sanchitmonga22"},"demoUrl":"https://x.com/sanchitmonga22/status/2096372075439235580","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-522.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":578},{"id":"work-b1eff629a3c62e0d","name":"儿童玩具车床与肥皂陀螺设计","description":"从设计概念、建模到社交短视频进行尝试。 设计概念未证明完成制造与安全测试。","category":"tool","sourceCategory":"CheerSelfAI · 工程文件与代码迁移","author":{"name":"@sibucho_labo","url":"https://x.com/sibucho_labo"},"demoUrl":"https://x.com/sibucho_labo/status/2096372808661995767","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-523.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":579},{"id":"work-7874f7087a23c693","name":"可抓取变形的黄色果冻交互体","description":"可抓取并调节硬度、阻尼的 Three.js WebGPU 果冻 转述 Scott 的演示，原作者关系待后续来源核对。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@ai_300","url":"https://x.com/ai_300"},"demoUrl":"https://x.com/ai_300/status/2096372811837100208","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-524.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":580},{"id":"work-d31f25513dddd58b","name":"带油桶运输挑战的公交游戏","description":"包含运输油桶、技巧挑战的公交游戏 合作模式是下一步计划，未计为已实现。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@artkorotkikh","url":"https://x.com/artkorotkikh"},"demoUrl":"https://x.com/artkorotkikh/status/2096373869879677250","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-525.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":581},{"id":"work-d0aef09fcc40b9f4","name":"通过 Ableton Live 制作音乐","description":"指令要求操作 Ableton Live 生成音乐的演示 帖子未说明具体编曲步骤或完整提示词上下文。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@timourxyz","url":"https://x.com/timourxyz"},"demoUrl":"https://x.com/timourxyz/status/2096374630525309206","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-526.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":582},{"id":"work-cf238be012e56745","name":"Machine-Go 射击围棋游戏","description":"在旧创意基础上多轮迭代。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@NicoSaraintaris","url":"https://x.com/NicoSaraintaris"},"demoUrl":"https://x.com/NicoSaraintaris/status/2096376258061803803","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-527.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":583},{"id":"work-b991bd9e62042f7c","name":"图像或创意转 LEGO 零件模型","description":"使用官方零件并提供 .ldr 下载的 LEGO 模型 结构优化和可搭建性为作者自述，说明书仍在计划中。","category":"tool","sourceCategory":"CheerSelfAI · 工程文件与代码迁移","author":{"name":"@emmanuel_2m","url":"https://x.com/emmanuel_2m"},"demoUrl":"https://x.com/emmanuel_2m/status/2096377028945576370","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-528.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":584},{"id":"work-4db6f39675e1ae7d","name":"比奇堡场景到影片和游戏","description":"先搭建 Blender 场景，再接图像、视频及剪辑工具。 粉丝概念作品；30 秒 1080p 为作者描述。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@groovestreetgen","url":"https://x.com/groovestreetgen"},"demoUrl":"https://x.com/groovestreetgen/status/2096377742916981247","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-529.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":585},{"id":"work-8db4aca1d42e2c38","name":"20 平方米空房的可编辑家具布局","description":"Blender 房间家具布局，物体可单独编辑 30 秒构建时长为作者陈述。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@groovestreetgen","url":"https://x.com/groovestreetgen"},"demoUrl":"https://x.com/groovestreetgen/status/2096377743701409988","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-530.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":586},{"id":"work-5b635db489533500","name":"财务文档预埋错误检出测试","description":"预先在财务数字中植入错误，再对比模型检出结果。 二手转述；41 份、4 处及 50 万英镑差异均未独立验证。","category":"other","sourceCategory":"CheerSelfAI · 专业研究与安全评测","author":{"name":"@vibecodingth","url":"https://x.com/vibecodingth"},"demoUrl":"https://x.com/vibecodingth/status/2096377980545348029","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-531.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":587},{"id":"work-3db80b71a917c4e3","name":"爱琴海多人帆船模拟器","description":"以爱琴海为场景的多人航海模拟器 多人联机能力为作者自述。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@tylercosgrove","url":"https://x.com/tylercosgrove"},"demoUrl":"https://x.com/tylercosgrove/status/2096378275170054524","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-532.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":588},{"id":"work-0857a660034e3cdc","name":"在 Photoshop 中绘制蒙娜丽莎","description":"Astra结合Higgsfield操作Photoshop。 平台演示，未验证绘画步骤和可编辑文件。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096378711444771152","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-533.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":589},{"id":"work-dc917f621215c55c","name":"通过 Runway 尝试把最终幻想6制作成动画","description":"给Astra“把Final Fantasy 6动画化”的指令，模型开始调用Runway。 作者认为结果没有超出预期。 最终视频依赖Runway；未说明是否完成完整动画，保留作者负面评价。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@masayasan201911","url":"https://x.com/masayasan201911"},"demoUrl":"https://x.com/masayasan201911/status/2096378917636719098","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-534.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":590},{"id":"work-168b87e88be0a598","name":"制作以 Edge City 活动地点为岛屿的三维任务游戏","description":"作者让Astra松散借鉴Edge City，得到多岛屿可玩世界。 原帖称已上线，未打开试玩验收。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@timourxyz","url":"https://x.com/timourxyz"},"demoUrl":"https://x.com/timourxyz/status/2096379521926840339","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-535.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":591},{"id":"work-6c917a23a769a2d0","name":"在 Krita 中绘制创造亚当","description":"Astra通过Higgsfield MCP操作Krita。 平台自营演示，未取得可编辑文件。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096379627912704049","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-536.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":592},{"id":"work-30cd78c8506f59e9","name":"以代码制作跨四个世界变换的机械梦境引擎","description":"作者说明代码由Astra负责。 未提供源码或运行环境，四世界算同一实验组。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@techartist_","url":"https://x.com/techartist_"},"demoUrl":"https://x.com/techartist_/status/2096380355121234186","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-537.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":593},{"id":"work-55daabb61b6584e8","name":"通过 Higgsfield MCP 在 Blender 中生成可开始动画制作的机器人","description":"Astra一次会话操作Blender。 未证实已绑定或完成动画，不将“可开始动画”写为成片结果。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096380489494155652","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-538.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":594},{"id":"work-39ae17c73e4fb0d4","name":"构建含 Blender 汽车资产的浏览器游戏","description":"Astra编写游戏并在Blender建模汽车。 没有给具体游戏名，不能把作者关于下一代GTA的预测写成事实。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@xikhar","url":"https://x.com/xikhar"},"demoUrl":"https://x.com/xikhar/status/2096382232403603752","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-539.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":595},{"id":"work-b8117c92757e7478","name":"在 Blender 中建立镜面厢式车辆模型","description":"作者让Astra用Blender制作车辆。 仅模型演示，内部结构未经实物验证。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@Buusk3","url":"https://x.com/Buusk3"},"demoUrl":"https://x.com/Buusk3/status/2096382949126222123","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-540.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":596},{"id":"work-403d28725de404cc","name":"将二二六事件部队行动绘制为时间动画","description":"作者让Astra绘制部队行动，用于考察青年军官与海军行动关系的假设。 动画和假设分析为作者研究演示，未核对史料或证明因果假设。","category":"experiment","sourceCategory":"CheerSelfAI · 模拟与科学可视化","author":{"name":"@noiehoie","url":"https://x.com/noiehoie"},"demoUrl":"https://x.com/noiehoie/status/2096383054461985145","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-541.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":597},{"id":"work-8a3f47ad1cba82b2","name":"在 After Effects 中重建 Higgsfield 自家发布视频","description":"Astra computer-use操作After Effects，后续同平台帖补充Higgsfield MCP参与。 “逐细节还原”为平台主张，未逐帧比对原片。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@higgsfield","url":"https://x.com/higgsfield"},"demoUrl":"https://x.com/higgsfield/status/2096383682852610051","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-542.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":598},{"id":"work-d3d5a291bc6abc1a","name":"生成咖啡杯中暴风雨的三维场景","description":"作者让Astra按该创意进行三维制作。 作者对3D和前端的总体看法不作测评结论，当前只收具体咖啡杯作品。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@CtrlAltDwayne","url":"https://x.com/CtrlAltDwayne"},"demoUrl":"https://x.com/CtrlAltDwayne/status/2096383768957538565","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-543.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":599},{"id":"work-9c07a51d5e30a011","name":"用 Crayon Pro 与 Blender MCP 制作水下吉卜力风格世界","description":"Astra与Crayon Pro构建，Blender MCP生成资产。 平台自营演示，未验试玩；与Atlantis城市仅主题类似，暂无同源证据。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@usecrayon","url":"https://x.com/usecrayon"},"demoUrl":"https://x.com/usecrayon/status/2096385137625923682","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-544.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":600},{"id":"work-29ec9c7f5aa08669","name":"从三维模型设计适合自己手部的钢铁侠护手","description":"作者让Astra依据三维模型制作。 适配为作者报告，未验证打印、佩戴或尺寸精度。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@riku720720","url":"https://x.com/riku720720"},"demoUrl":"https://x.com/riku720720/status/2096386143218802850","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-545.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":601},{"id":"work-5b07216512ea9f6e","name":"在 Blender MCP 中生成 Atlantis 城市","description":"作者称Astra一次通过Blender MCP创建。 原帖提供试玩但未验证；不能仅凭水下主题合并其他世界项目。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@aniketjart","url":"https://x.com/aniketjart"},"demoUrl":"https://x.com/aniketjart/status/2096386207639052428","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-546.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":602},{"id":"work-8c34f22957e96bca","name":"把图像转换为 SVG 再制作可编辑 PPT","description":"Astra经由图像生成→SVG化→PPT化生成资料。 作者认为SVG插画质量提高，细部颜色可调整。 未获取演示文稿并检查编辑性；图像生成模型未给。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@shin_yoshimura0","url":"https://x.com/shin_yoshimura0"},"demoUrl":"https://x.com/shin_yoshimura0/status/2096387880696602642","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-547.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":603},{"id":"work-9d09fe3d50a425ad","name":"制作 CryptoNinja 角色山村经营沙盒","description":"Astra脚本生成建筑和居民，Meshy从图像生成角色，H3 Max Turbo制作宣传片。 作者称两天完成初版，浏览器试玩已提供，Steam正式版计划10月。 最终游戏依赖多个模型和服务，费用为作者报告；Steam正式版仍是计划。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@jura_log","url":"https://x.com/jura_log"},"demoUrl":"https://x.com/jura_log/status/2096387909427589494","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-548.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":604},{"id":"work-5add9858111c79f0","name":"用 Higgsfield MCP 制作相机镜头专业器材网站","description":"平台称Astra使用Higgsfield MCP从一条提示词构建。 平台未说明全部功能和实际光学精度，不能断言软件替代真实镜头。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096387951026659630","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-549.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":605},{"id":"work-06de159a5ac9d253","name":"把日本旅行照片组织成 Remotion 视频","description":"Astra筛照片、取补充视频及免版税音乐、规划叙事写文案、绘动画地图和角色，再用Remotion动画剪辑并按反馈导出。 明确多轮反馈；素材授权与输出效果未独立验证。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@Firisis_","url":"https://x.com/Firisis_"},"demoUrl":"https://x.com/Firisis_/status/2096389164279214456","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-550.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":606},{"id":"work-89b70f08d5316721","name":"生成 MIDI 音乐并制作音视频捕获工具","description":"作者用Astra生成MIDI并演示，另称制作捕获工具。 作者估计MIDI生成约2分钟、后续约1分钟，捕获工具约2小时。 时间为估计；音乐的艺术与商品价值是作者意见，不作事实结论。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@raiteisabota","url":"https://x.com/raiteisabota"},"demoUrl":"https://x.com/raiteisabota/status/2096389478122451409","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-551.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":607},{"id":"work-19d2307747c44895","name":"生成知识解锁式横向卷轴解谜游戏","description":"向Astra直接提出该游戏类型。 原帖提供试玩入口，未打开验证玩法。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@d_d_osorezan","url":"https://x.com/d_d_osorezan"},"demoUrl":"https://x.com/d_d_osorezan/status/2096390251656933779","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-552.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":608},{"id":"work-c38910abfef59493","name":"用代码生成 ASCII 与二进制动态自画像","description":"让名为Ember的Astra生成代码自画像；字符在螺旋、隧道、花、星系等结构间数学变换。 帧数与流程为作者报告；“意识表达”为作者拟人描述，不构成模型主观体验证据。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@Skoorbkaz","url":"https://x.com/Skoorbkaz"},"demoUrl":"https://x.com/Skoorbkaz/status/2096390330597736853","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-553.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":609},{"id":"work-aaed33c77743976a","name":"为燃气轮机学习制作可交互模型","description":"作者补课后让Astra建模以测试能力和帮助理解。 模型用于个人学习，未验证工程精度。","category":"experiment","sourceCategory":"CheerSelfAI · 模拟与科学可视化","author":{"name":"@GZhan57","url":"https://x.com/GZhan57"},"demoUrl":"https://x.com/GZhan57/status/2096391170540884343","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-554.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":610},{"id":"work-4906bc8debf2294e","name":"在魔兽世界经典版中接入 agent 消息与完成通知","description":"作者在Codex要求为WoW制作Herdr插件。 作者称约3分钟后可在游戏里向agents发消息。 功能与耗时为作者报告，未安装插件验证。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@AlexFinn","url":"https://x.com/AlexFinn"},"demoUrl":"https://x.com/AlexFinn/status/2096391410048180334","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-555.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":611},{"id":"work-4d6e82d89ccb0144","name":"在 Eidoverse 中重启虚拟 Vibecamp 世界","description":"作者用 Astra 重启既有项目，计划改善PBR、建筑、草、植被和水。 初版已存在但仍需大量改进；具身AI交互和公开发布是计划，不当作完成结果。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@SkyeSharkie","url":"https://x.com/SkyeSharkie"},"demoUrl":"https://x.com/SkyeSharkie/status/2096391841885327647","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-556.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":612},{"id":"work-5c5ad2f916657715","name":"在 Onshape 中设计 rover 机器人零件","description":"Astra 使用 Onshape 及其创建的自定义插件。 作者称项目仍在工作中，未给制造与装配测试。","category":"tool","sourceCategory":"CheerSelfAI · 工程文件与代码迁移","author":{"name":"@Alpha10six","url":"https://x.com/Alpha10six"},"demoUrl":"https://x.com/Alpha10six/status/2096392271776149587","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-557.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":613},{"id":"work-2d3a682bd77ca078","name":"比较弹簧沿上行扶梯持续翻滚的物理动画","description":"要求无库 Canvas 实现弹簧在上行扶梯循环翻滚，并有 drop/reset 按钮。 作者报告 Astra 速度与额度较优但有弹簧自穿透，Fable视觉更真实且耗尽5小时窗口并报错。 单次主观对照；物理自穿透为作者观察，未复现或测量。","category":"experiment","sourceCategory":"CheerSelfAI · 模拟与科学可视化","author":{"name":"@reddmachine","url":"https://x.com/reddmachine"},"demoUrl":"https://x.com/reddmachine/status/2096392638455026150","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-558.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":614},{"id":"work-7842e9c7812e3852","name":"自动完成 Excalidraw 讲解视频并沉淀为 Skill","description":"Astra 完成调研、规划、操作 Excalidraw、录制、声音合成、剪辑和交付。 未给视频具体主题、声音模型和 Skill 文件，流程为作者报告。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@wshuyi","url":"https://x.com/wshuyi"},"demoUrl":"https://x.com/wshuyi/status/2096393490439749875","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-559.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":615},{"id":"work-2b82e85b5efcf1bf","name":"在手机上自动筛除坏镜头并安排字幕位置","description":"Astra 与 Ody 识别坏 takes 并安排不挡脸的文字，作者从手机发起并观看剪辑。 “检测100%坏镜头”为作者说法，未验证召回率或一般化效果。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@_kaitodev","url":"https://x.com/_kaitodev"},"demoUrl":"https://x.com/_kaitodev/status/2096396128627331271","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-560.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":616},{"id":"work-745d418065fe1c80","name":"两轮提示词构建 GTA 风格 WebGL 游戏","description":"首轮要求 WebGL、Blender、参考图建模并使用 RIO_MA002.fbx；二轮改善模型、碰撞破坏、物理、郊区和密度。 明确两轮与既有角色资产，AAA 只是指令目标，未证明达到商业游戏品质。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@djrio_vr","url":"https://x.com/djrio_vr"},"demoUrl":"https://x.com/djrio_vr/status/2096398839830008292","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-561.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":617},{"id":"work-130234b3e29ae9f8","name":"以参考游戏和截图构建三维游戏及资产流程","description":"提供喜爱的游戏、截图、玩法和角色目标，启用 Codex computer use，使用 Three.js、Blender MCP，并安排图像生成资产。 作者报告非 fast 模式下约2小时30分钟。 未命名游戏和发布工程；one-shot 仍依赖参考图及资产生成。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@reeder1865","url":"https://x.com/reeder1865"},"demoUrl":"https://x.com/reeder1865/status/2096399217119854794","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-562.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":618},{"id":"work-45f636ffb5658b11","name":"构建含 Stockfish 档位与经典棋局回放的三维国际象棋","description":"作者用 Astra 建造浏览器游戏并自述玩过数局。 七档难度与可玩性未独立验证；与1851棋局动画是不同作者和不同任务。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@DeryaTR_","url":"https://x.com/DeryaTR_"},"demoUrl":"https://x.com/DeryaTR_/status/2096403246512287753","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-563.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":619},{"id":"work-951fdddee9b620f9","name":"为 GRU Space 生成新闻室页面","description":"作者称 Astra 一次生成。 页面功能与上线状态未核验。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@skyler_chan_","url":"https://x.com/skyler_chan_"},"demoUrl":"https://x.com/skyler_chan_/status/2096404250607993332","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-564.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":620},{"id":"work-2814212a8192da28","name":"制作日文版可切换骨骼肌肉与内脏的三维人体图","description":"作者说明用 Astra 构建或改为日文，支持分层切换和自由视角。 未验证解剖准确性，医疗教育潜力是作者观点。","category":"experiment","sourceCategory":"CheerSelfAI · 模拟与科学可视化","author":{"name":"@hanageruge","url":"https://x.com/hanageruge"},"demoUrl":"https://x.com/hanageruge/status/2096404647154163893","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-565.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":621},{"id":"work-456964d161f9f2dd","name":"制作 Button Box 原型的交互式装配指南","description":"让 Astra 制作交互指南，并指令生成16:9演示录屏。 提供指南和 GitHub 入口但未打开；不得从交互指南推定实体已通过测试。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@danpeguine","url":"https://x.com/danpeguine"},"demoUrl":"https://x.com/danpeguine/status/2096405809387258334","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-566.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":622},{"id":"work-c92e53b6c85dbd08","name":"用既有 AviUtl2 工程与素材自动剪辑视频","description":"把旧手工 AviUtl2 工程、视频、音频和台词文件交给 Astra，模型剪辑并在缺素材时生成图像。 具体视频主题与图像模型未给，作者未公开可复验工程。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@nakanoyuusuke","url":"https://x.com/nakanoyuusuke"},"demoUrl":"https://x.com/nakanoyuusuke/status/2096408505418915914","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-567.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":623},{"id":"work-770f66e8ad97fb6e","name":"制作 HD-2D 风格游戏场景实验","description":"睡前给 Astra 详细指令，次日检查结果。 作者认为深度和光照较符合目标。 实验进行中，未给完整可玩游戏或工程。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@yugiriworks","url":"https://x.com/yugiriworks"},"demoUrl":"https://x.com/yugiriworks/status/2096408929073074410","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-568.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":624},{"id":"work-a8553e5b167acebf","name":"开发通过 CLI 与 MCP 操作的 YachiCut 视频编辑器","description":"Astra 构建在 Codex 浏览器运行的编辑器，ComfyUI 为后端；支持音视频分别管理、哈希检测与选片判断日志。 作者描述已实现与实施中的功能，未计划分发。 当前仍在实现，未逐项验收所有功能或验证外部编辑器导入。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@yachimat_manga","url":"https://x.com/yachimat_manga"},"demoUrl":"https://x.com/yachimat_manga/status/2096411125453926759","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-569.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":625},{"id":"work-1ca13d4abbcf4e7b","name":"在 Canva 中绘画新天鹅堡","description":"作者让 Astra 在 Canva 作画。 未提供可编辑文件，画作质量未经独立检查。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@Layton_Gott","url":"https://x.com/Layton_Gott"},"demoUrl":"https://x.com/Layton_Gott/status/2096414946523230215","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-570.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":626},{"id":"work-6cac813a45d0e13d","name":"仅用 JavaScript 与 Three.js 制作浏览器三维游戏","description":"作者让 Astra 用 JavaScript 与 Three.js 构建，未使用 Blender。 游戏名和玩法细节未给，保留为作者一次具体游戏试作。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@asagilf","url":"https://x.com/asagilf"},"demoUrl":"https://x.com/asagilf/status/2096418532083020027","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-571.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":627},{"id":"work-69c995e8294afe92","name":"为 Tripo 角色在 Blender 中设置模型与表情","description":"Tripo 生成角色后交给 Astra 做 Blender setup，并采用作者所称特殊方式生成表情。 特殊表情方法未披露；该帖把进一步 rigging 列为后续，和8的关联需同源证据。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@Dstudio_ai","url":"https://x.com/Dstudio_ai"},"demoUrl":"https://x.com/Dstudio_ai/status/2096420704636019105","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-572.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":628},{"id":"work-0679865267d0ec5d","name":"自动临摹星空并录制剪辑配乐","description":"自动下载原画、打开 Photopea、放参考图对照绘画，边绘画边录制并剪辑和配乐。 绘画与音视频流程为作者报告，未独立核验与原画一致性。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@gengdaJ","url":"https://x.com/gengdaJ"},"demoUrl":"https://x.com/gengdaJ/status/2096421536500683184","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-573.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":629},{"id":"work-2b3c632bffbf6a7c","name":"构建三维尤克里里练习室","description":"作者让 Astra 制作面向初学者的练习室，首曲为小星星。 原帖称提供试玩和源码，当前未打开核验。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@Peter05704721","url":"https://x.com/Peter05704721"},"demoUrl":"https://x.com/Peter05704721/status/2096425300565672317","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-574.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":630},{"id":"work-efd76c32e8a74712","name":"测试生成日本机关说明风格的复杂示意幻灯片","description":"作者测试 Astra 对这类传统复杂汇报图解的再现能力。 正文未给量化评价或完整编辑文件。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@taiyo_ai_gakuse","url":"https://x.com/taiyo_ai_gakuse"},"demoUrl":"https://x.com/taiyo_ai_gakuse/status/2096427200555917808","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-575.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":631},{"id":"work-248270922b581901","name":"生成带分层运动效果的 SVG","description":"作者称让 Astra 一次生成并处理分层关系。 引用的视频素材商店是背景推广，未证明本次实际调用该商店资产。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@ryoma_nakajima","url":"https://x.com/ryoma_nakajima"},"demoUrl":"https://x.com/ryoma_nakajima/status/2096429264241602999","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-576.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":632},{"id":"work-a229e2597eb6d359","name":"用 SVG 与 JavaScript 构建 Habbo Hotel 风格游戏","description":"二手描述 Astra Ultra 2x 用 SVG/JavaScript 绘制全部资产，以二维方式模拟光影和纵深，没有游戏引擎或素材包。 转述称两小时完成、使用 100 美元 Pro 计划周额度 42%。 原帖把周额度折算约42美元，这不是可验证 API 支出；未找到原作者工程。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@om_patel5","url":"https://x.com/om_patel5"},"demoUrl":"https://x.com/om_patel5/status/2096429334319817031","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-577.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":633},{"id":"work-c2a8b683325ebc4e","name":"不使用自动布线完成八层 PCB artwork","description":"输入部分设计规则，让 Astra 自行进行 artwork，未使用 Auto routing。 作者称八层板完成，下一步向 JLCPCB 下单与实机测试。 尚未制造与实机测试；引用只说明先前 Fable 尝试，当前 Astra 执行归属明确。","category":"tool","sourceCategory":"CheerSelfAI · 工程文件与代码迁移","author":{"name":"@gclue_akira","url":"https://x.com/gclue_akira"},"demoUrl":"https://x.com/gclue_akira/status/2096429541782942088","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-578.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":634},{"id":"work-e2a490c65176feb1","name":"操作 Clip Studio Paint 给手绘草稿分层上色","description":"二手报道插画师让 Astra 控制鼠标、建立图层、选择笔刷并填色。 报道称底色工作可完成，但阴影和最终修饰逊于作者版本，并消耗大量订阅额度。 二手报道未给原插画师帖子；额度不是精确费用，结果未独立验收。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@SomosKudasai","url":"https://x.com/SomosKudasai"},"demoUrl":"https://x.com/SomosKudasai/status/2096429707927453749","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-579.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":635},{"id":"work-83755cfc321f222d","name":"用 Astra computer-use 制作电影原型","description":"平台称电影制作全程使用 Astra computer-use，并准备公开过程。 平台自述进行中；未给片名、完整电影或工具分工，不能称已完成长片。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096430282329235694","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-580.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":636},{"id":"work-46148d4af4fb98bf","name":"生成可拆看内部叶片与气流的喷气发动机模型","description":"让 Astra 制作喷气发动机三维模型。 作者描述内部叶片转动与气流可视化。 教学示意未经工程精度验证，完整 prompt 仅预告在回复。","category":"experiment","sourceCategory":"CheerSelfAI · 模拟与科学可视化","author":{"name":"@ozwxy","url":"https://x.com/ozwxy"},"demoUrl":"https://x.com/ozwxy/status/2096431069008728440","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-581.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":637},{"id":"work-0fadb93c86884ac0","name":"用 Three.js 生成 Counter Strike 2 风格游戏","description":"二手贴给出的指令是让 Astra 在 Three.js 制作 CS2。 未提供原作者或工程，不能认为完整复刻商业游戏。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@om_patel5","url":"https://x.com/om_patel5"},"demoUrl":"https://x.com/om_patel5/status/2096431838960971880","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-582.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":638},{"id":"work-1e84be079eff156a","name":"生成 Nintendo DS 三维模型","description":"DS 游戏机三维模型 仅有模型名称和演示，未给建模工具与精度检查。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@riku720720","url":"https://x.com/riku720720"},"demoUrl":"https://x.com/riku720720/status/2096431945202971035","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-583.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":639},{"id":"work-83fa39afa7ebb1ae","name":"在 Blender 中构建 Strandbeest 风格机械步行结构","description":"向 Astra 询问能否在 Blender 制作该结构并得到演示。 作者评价结构较稳定，未验证真实连杆几何或物理可行性。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@aiclass_g2","url":"https://x.com/aiclass_g2"},"demoUrl":"https://x.com/aiclass_g2/status/2096432472695418931","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-584.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":640},{"id":"work-11ac4fd1ec26e565","name":"用 Blender 制作学校内奔跑的象形人物动画","description":"给 Astra 一条使用 Blender 制作学校内奔跑 pictogram 的指令。 作者认为图像效果比 5.6 更好。 质量比较为个人评价，未独立复现。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@Yuupapa_free","url":"https://x.com/Yuupapa_free"},"demoUrl":"https://x.com/Yuupapa_free/status/2096432585111216201","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-585.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":641},{"id":"work-3d3d44d536b47ab5","name":"从手机指令制作航班天际地图风格 Three.js 演示","description":"作者在东京至巴黎航班上从手机向 ChatGPT Astra 下指令。 未给公开工程或地理数据来源。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@clockmaker","url":"https://x.com/clockmaker"},"demoUrl":"https://x.com/clockmaker/status/2096434941336682766","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-586.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":642},{"id":"work-042f1e285fa5d9fa","name":"用 VRoid Studio 制作 VRM 角色","description":"Astra 操作 VRoid Studio。 作者报告约 8 分钟。 试作阶段，未验证导出兼容性或角色质量。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@npaka123","url":"https://x.com/npaka123"},"demoUrl":"https://x.com/npaka123/status/2096435985425010837","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-587.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":643},{"id":"work-d4a325aa3404efc8","name":"设计 F405 六层 FPV 无人机飞控板","description":"Codex 中 Astra 高强度直接操作 KiCad，完成布局布线并运行 ERC/DRC 后修改。 作者报告 3 小时 13 分 56 秒、约 5190 万 tokens，完成设计但尚未打样。 尚未制造或实机测试，不能称飞控已稳定工作；耗时/token 为作者报告。","category":"tool","sourceCategory":"CheerSelfAI · 工程文件与代码迁移","author":{"name":"@GoGoFly23","url":"https://x.com/GoGoFly23"},"demoUrl":"https://x.com/GoGoFly23/status/2096436525110309251","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-588.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":644},{"id":"work-5617b4808b7494f1","name":"生成跑酷素材供 Seedance 2.5 制作视频","description":"先让 Astra 制作跑酷素材，再以此为参考调用 Seedance 2.5。 Astra 负责参考素材，最终视频由 Seedance 生成；作者表示素材仍需改善。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@Ayu_AI_0912","url":"https://x.com/Ayu_AI_0912"},"demoUrl":"https://x.com/Ayu_AI_0912/status/2096437230172832140","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-589.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":645},{"id":"work-83f4e6d68685d3cf","name":"操作 Sibelius 编写 32 小节肖邦风格圆舞曲","description":"让 Astra 实际使用 Sibelius 创作。 作者评价操作快、软件理解和音乐效果好。 风格与质量是作者评价，未独立乐谱分析。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@yogo_escentier","url":"https://x.com/yogo_escentier"},"demoUrl":"https://x.com/yogo_escentier/status/2096437507072434658","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-590.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":646},{"id":"work-fad2fa9c88ee1faa","name":"将 1851 年经典国际象棋对局制成动画","description":"Astra 与 Higgsfield 配合。 平台未给完整棋谱或动画准确性检查，未补写具体棋手。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096437543181103449","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-591.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":647},{"id":"work-c11da8cc88b41728","name":"将乐谱转换为 MSX MGSDRV 演奏数据","description":"向 Astra 展示乐谱并要求编写可在 MSX MGSDRV 演奏的 MML。 作者称模型进一步生成了演奏数据。 未检查数据格式、乐谱准确性或设备播放。","category":"other","sourceCategory":"CheerSelfAI · 办公与音乐创作","author":{"name":"@takawo_n","url":"https://x.com/takawo_n"},"demoUrl":"https://x.com/takawo_n/status/2096438867247370318","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-592.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":648},{"id":"work-d967c6a87fefed1f","name":"用 Fable 与 Astra 制作角色坐在肩膀上的视频","description":"作者称从昨夜开始组合使用 Claude Fable 5.1 与 Astra。 作者未拆分两个模型的贡献或披露视频生成工具，不能归因 Astra 单独完成。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@Glasses_Lion","url":"https://x.com/Glasses_Lion"},"demoUrl":"https://x.com/Glasses_Lion/status/2096439080620048788","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-593.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":649},{"id":"work-7b2ffe9dfd79b862","name":"构建含 1025 个拆解部件的三维相机","description":"Astra 通过 Higgsfield 在 Blender 建模和动画。 对象数量为平台报告，不代表工程零件准确对应。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096441158465683634","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-594.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":650},{"id":"work-b3ee5c0d5a5f7035","name":"使用 Blender 为 AI 动画构建街道场景","description":"作者使用 Astra 与 Blender。 作者称分享的视频在 15 分钟内制作。 15 分钟描述视频制作，不能直接解释为完整场景建模耗时。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@MiraMusic_AI","url":"https://x.com/MiraMusic_AI"},"demoUrl":"https://x.com/MiraMusic_AI/status/2096441679847006358","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-595.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":651},{"id":"work-dd5b02b63bfcac10","name":"构建并自动测试钓鱼 iOS 应用","description":"给 Astra 一条 /goal 指令；模型开发应用、逐按钮测试，并生成持鱼图片测试提交。 作者醒来后收到完整演示录屏和功能测试报告。 完整功能通过是作者转述，未取得测试日志或独立检查后端。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@ashen_one","url":"https://x.com/ashen_one"},"demoUrl":"https://x.com/ashen_one/status/2096441749493227696","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-596.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":652},{"id":"work-6b9b02a99b55a64d","name":"为自制游戏制作预告视频","description":"作者让 Astra 为自己的游戏制作 trailer。 游戏名、剪辑工具和制作步骤未给出。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@reverinu_vtuber","url":"https://x.com/reverinu_vtuber"},"demoUrl":"https://x.com/reverinu_vtuber/status/2096444378722214015","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-597.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":653},{"id":"work-cc2b33bad0848c8a","name":"在 Blender 中生成三维别墅导览","description":"Astra 与 Higgsfield 在 Blender 中一次生成。 平台自营演示，未给原始工程、完整 prompt 或真实性验证。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@higgsfield_ai","url":"https://x.com/higgsfield_ai"},"demoUrl":"https://x.com/higgsfield_ai/status/2096449719145054373","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-598.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":654},{"id":"work-bc274ac89103d9d8","name":"操作 Clip Studio Paint 制作剑斗粗动画","description":"让 Astra 操作 Clip Studio Paint。 作者称生成成功，但步幅非常大。 动作质量缺陷来自作者反馈，未独立检查动画。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@gesoikuo3","url":"https://x.com/gesoikuo3"},"demoUrl":"https://x.com/gesoikuo3/status/2096452658399994160","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-599.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":655},{"id":"work-9ac82e64da86fab8","name":"把普通 Zillow 房源重新布置为三维模型与展示图片","description":"选择近期降价房屋，用房源图建模和布置；两轮处理，作者指出把壁橱变窗户等不合理修改。 作者称约 3 小时完成建模与调整，比先前城堡更准确。 准确性与观感为作者判断，未核对房屋实测；本文是新房屋，引用的城堡为早前不同输入。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@realYunfanYe","url":"https://x.com/realYunfanYe"},"demoUrl":"https://x.com/realYunfanYe/status/2096456060207001806","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-600.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":656},{"id":"work-321425188213a474","name":"为 X 主页角色恶作剧动画编写分镜提示词","description":"Astra 编写提示词；以角色图和 X 主页截图为参考，安排角色出框、文字纸飞机、清扫与手写结尾，再交给 MiniMax H3。 Astra 的角色是提示词与动作设计，最终视频由 MiniMax H3 生成；未逐镜核验全部约束。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@Chengzilhy","url":"https://x.com/Chengzilhy"},"demoUrl":"https://x.com/Chengzilhy/status/2096456212246364322","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-601.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":657},{"id":"work-831b364e6a45fe8f","name":"用 Astra Pro 制作 BFDI 动漫片头","description":"作者称 Astra Pro 单条提示词生成。 未披露底层视频工具、完整提示词或各工具贡献。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@AiCanvas88957","url":"https://x.com/AiCanvas88957"},"demoUrl":"https://x.com/AiCanvas88957/status/2096456960363163979","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-602.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":658},{"id":"work-e83345a57b53d958","name":"根据地图和实拍重建可交互悉尼城市","description":"输入地图和真实照片，使用 Blender 与 Three.js。 作者称一次会话完成。 “整个悉尼城”为作者表述，未验证地理覆盖或精度；与引用的宿舍房间属于不同任务。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@rionaifantasy","url":"https://x.com/rionaifantasy"},"demoUrl":"https://x.com/rionaifantasy/status/2096460180401889613","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-603.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":659},{"id":"work-0e59f1f0cf63a174","name":"在 Figma 中制作品牌视觉与页面设计","description":"让 Astra 实际操作 Figma。 设计质量是作者评价；未给完整设计规范与交付文件。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@issui_ikeda","url":"https://x.com/issui_ikeda"},"demoUrl":"https://x.com/issui_ikeda/status/2096467418575147367","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-604.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":660},{"id":"work-753b51c22af41c2c","name":"用 Three.js 构建莱特飞行器穿越日本森林游戏","description":"让 Astra 自行调研飞行器并用 Three.js 从头生成场景、模型与纹理；未连接 Blender 或外部资产。 作者称共两次会话，实际构建约 10–20 分钟，游戏流畅但部署仍待完成。 作者同时称 one-shot 和两次会话，按原述保留；未独立试玩，实际耗时为估计。","category":"game","sourceCategory":"CheerSelfAI · 游戏与玩法原型","author":{"name":"@thebuggeddev","url":"https://x.com/thebuggeddev"},"demoUrl":"https://x.com/thebuggeddev/status/2096467585785286808","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-605.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":661},{"id":"work-1f2bc01678d198b1","name":"把简短创意扩成 Seedance 视频提示词并生成对照","description":"先由 Astra 扩写简单 brief，再通过 Renoise CLI 运行 Seedance 2.5；引用同作者 Astra/Fable 对照。 视频由 Seedance 生成，Astra 负责提示词；当前引用未给具体场景和完整 prompt。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@Mayz1169","url":"https://x.com/Mayz1169"},"demoUrl":"https://x.com/Mayz1169/status/2096470693089292710","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-606.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":662},{"id":"work-1ceaf332cca9f019","name":"从分镜制作三维动画","description":"使用 Astra、Blender 与 VRoid Studio。 作者明确仍在试作，未给完片验收或制作耗时。","category":"experiment","sourceCategory":"CheerSelfAI · 动效与视频工作流","author":{"name":"@npaka123","url":"https://x.com/npaka123"},"demoUrl":"https://x.com/npaka123/status/2096471372235243750","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-607.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":663},{"id":"work-728e9c9c6a8ca6f6","name":"在应用中集成 Supabase 并改善界面","description":"ChatGPT Plus 中使用 Astra MAX；指令为 Integrate Supabase and Improve App UI。 作者报告耗尽 5 小时额度、使用周额度 16%、约 500 万 tokens 和 5 万输出 tokens，任务未完成。 耗时和额度为作者报告；未给应用与失败步骤，订阅额度不等于独立 API 费用。","category":"app","sourceCategory":"CheerSelfAI · 界面与产品流程","author":{"name":"@shownotover","url":"https://x.com/shownotover"},"demoUrl":"https://x.com/shownotover/status/2096478745494175886","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-608.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":664},{"id":"work-211602de86923f9d","name":"构建 Varanasi 三维世界","description":"Varanasi 世界构建演示 二手展示只给出场景名和 Astra 归属，未给工程或执行步骤。","category":"experiment","sourceCategory":"CheerSelfAI · 3D 空间与建模","author":{"name":"@EpicCmntsTelugu","url":"https://x.com/EpicCmntsTelugu"},"demoUrl":"https://x.com/EpicCmntsTelugu/status/2096480727366025689","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-609.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":665},{"id":"work-39b0e034eb3bb54a","name":"Astra 与 Fable 的游戏、前端和动效实测对照","description":"转述 @chaseai__ 的实测；游戏经 Codex，动效调用 Higgsfield MCP。 转述称 Astra 游戏与前端更完整、动效打平，偏好与成本判断为评测者主观结论。 二手评测总结；未取得完整测试配置或独立复现，多个输出作为同一评测组。","category":"other","sourceCategory":"CheerSelfAI · 专业研究与安全评测","author":{"name":"@neil_xbt","url":"https://x.com/neil_xbt"},"demoUrl":"https://x.com/neil_xbt/status/2096481270339604503","sourceUrl":null,"repoUrl":null,"imageUrl":"/previews/cheerself-610.jpg","posterUrl":null,"videoUrl":null,"sourceOrder":666}],"source":{"repository":"xianyu110/awesome-gpt-6-astra","url":"https://github.com/xianyu110/awesome-gpt-6-astra/blob/main/PLAYABLE.md","checkedAt":"2026-09-08T06:10:32.844Z","lastSuccessfulAt":"2026-09-08T06:10:32.844Z","revision":"playable-merge-20260908","stale":false,"status":"fresh"},"refreshAfterSeconds":300}
+{
+  "works": [
+    {
+      "id": "work-f3c567c8e4ad9261",
+      "name": "Chao Garden / Chao Party — SA2 browser multiplayer",
+      "description": "可玩 Demo · 联机 / 多人 · Sonic Adventure 2 Chao Garden Three.js 浏览器联机移植",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 联机 / 多人",
+      "author": {
+        "name": "h4nkdog",
+        "url": "https://x.com/h4nkdog"
+      },
+      "demoUrl": "https://chao.party",
+      "sourceUrl": "https://x.com/h4nkdog/status/2097308970431987857",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fcard_img%2F2097089461226000384%2FRLlVtVqI%3Fformat%3Djpg%26name%3D800x419",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fcard_img%2F2097089461226000384%2FRLlVtVqI%3Fformat%3Djpg%26name%3D800x419",
+      "videoUrl": null,
+      "sourceOrder": -1002
+    },
+    {
+      "id": "work-b0b3c24b49e80841",
+      "name": "Butterball Run — dinner-table three.js",
+      "description": "可玩 Demo · 街机 / 小游戏包 · 照片→Blender→three.js 桌面跑酷，Astra Light 11 分钟出炉",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 街机 / 小游戏包",
+      "author": {
+        "name": "SecretSeoul",
+        "url": "https://x.com/SecretSeoul"
+      },
+      "demoUrl": "https://butterball-run.jeraldine-t.chatgpt.site",
+      "sourceUrl": "https://x.com/SecretSeoul/status/2097315757931811081",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2097315709227597824%2Fimg%2FQ-MvF2J-iFPkbIQ5.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2097315709227597824%2Fimg%2FQ-MvF2J-iFPkbIQ5.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2097315709227597824/vid/avc1/720x1266/HLf18awvTA_wtidE.mp4?tag=29",
+      "sourceOrder": -1001
+    },
+    {
+      "id": "work-ecf583f0ae9d3dd7",
+      "name": "Neural Sight — Play the demo",
+      "description": "可玩 Demo · 射击 / 动作",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 射击 / 动作",
+      "author": {
+        "name": "monstercameron",
+        "url": "https://x.com/monstercameron"
+      },
+      "demoUrl": "https://monstercameron.github.io/Neural-Sight/",
+      "sourceUrl": "https://x.com/monstercameron/status/2097117275127959629",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2097116847938338816%2Fimg%2F5dg30Fk-R-cxdla3.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2097116847938338816%2Fimg%2F5dg30Fk-R-cxdla3.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2097116847938338816/vid/avc1/1496x720/Jrx90x0eKDOcvuu_.mp4?tag=14",
+      "sourceOrder": -925
+    },
+    {
+      "id": "work-fb963c122de8725a",
+      "name": "마성전설 — 메두사의 신전",
+      "description": "可玩 Demo · 射击 / 动作",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 射击 / 动作",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://knightmare-medusa-3d.robin-hwang.chatgpt.site/",
+      "sourceUrl": "https://x.com/i/status/2096984386566815920",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FHRn8LSjaIAE7X6V.jpg%3Fname%3Dorig",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -926
+    },
+    {
+      "id": "work-956b39d586362f91",
+      "name": "KLIPZI CITY",
+      "description": "可玩 Demo · 3D 场景 / 氛围探索",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 3D 场景 / 氛围探索",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://klipzi-city.deadcoolapps.chatgpt.site",
+      "sourceUrl": "https://x.com/i/status/2096951400106209628",
+      "repoUrl": null,
+      "imageUrl": "https://klipzi-city.deadcoolapps.chatgpt.site/og.png",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -927
+    },
+    {
+      "id": "work-d7cf1ece56fa1dce",
+      "name": "Geometry Dash · Fan Remix",
+      "description": "可玩 Demo · 音乐 / 表演",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 音乐 / 表演",
+      "author": {
+        "name": "17facet",
+        "url": "https://x.com/17facet"
+      },
+      "demoUrl": "https://geometry-dash-fan-nako.deif79.chatgpt.site",
+      "sourceUrl": "https://x.com/17facet/status/2096856546512982486",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-d7cf1ece56fa1dce.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -928
+    },
+    {
+      "id": "work-ac1fe0d9a1514ef4",
+      "name": "Le Bon Rayon — Épicerie de quartier",
+      "description": "可玩 Demo · 模拟经营 / 策略",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 模拟经营 / 策略",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://le-bon-rayon.alexxondre.chatgpt.site",
+      "sourceUrl": "https://x.com/i/status/2096652925527314554",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FHRjOicRbwAAN8mR.jpg%3Fname%3Dorig",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -929
+    },
+    {
+      "id": "work-dbebeceae8db26c6",
+      "name": "Peel — your new main squeezes",
+      "description": "可玩 Demo · 3D 场景 / 氛围探索",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 3D 场景 / 氛围探索",
+      "author": {
+        "name": "Cryptosphere14",
+        "url": "https://x.com/Cryptosphere14"
+      },
+      "demoUrl": "https://peel-squishies.vercel.app",
+      "sourceUrl": "https://x.com/Cryptosphere14/status/2096650466511737000",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096650421284622336%2Fimg%2FMeWgVi6MagsDyCyw.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096650421284622336%2Fimg%2FMeWgVi6MagsDyCyw.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096650421284622336/vid/avc1/1280x696/nB-YxUAF4_VG6UcT.mp4?tag=29",
+      "sourceOrder": -930
+    },
+    {
+      "id": "work-d1923b6b876a5a84",
+      "name": "CARGO LAB · 컨테이너 적재 시뮬레이터",
+      "description": "可玩 Demo · 工程 / 仿真",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 工程 / 仿真",
+      "author": {
+        "name": "nanggos",
+        "url": "https://x.com/nanggos"
+      },
+      "demoUrl": "https://cargo-lab.nanggo.chatgpt.site",
+      "sourceUrl": "https://x.com/nanggos/status/2096582509035438291",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-d1923b6b876a5a84.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -931
+    },
+    {
+      "id": "work-5b6ae5368e10b2b5",
+      "name": "Play GTA Vice City Online in Your Browser | Quenq GTA Vice City",
+      "description": "可玩 Demo · 其他可玩 Demo",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 其他可玩 Demo",
+      "author": {
+        "name": "noman23761",
+        "url": "https://x.com/noman23761"
+      },
+      "demoUrl": "https://quenq.com/apps/vice-city-online/",
+      "sourceUrl": "https://x.com/noman23761/status/2096554926965154037",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096213774130929664%2Fimg%2F67kPAD2USOad5bI5.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096213774130929664%2Fimg%2F67kPAD2USOad5bI5.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096213774130929664/vid/avc1/1108x720/A48T1ScPXKwqXNPv.mp4?tag=14",
+      "sourceOrder": -932
+    },
+    {
+      "id": "work-26a1853b26b7a5f4",
+      "name": "Lantern Cove · The Borrowed Light",
+      "description": "可玩 Demo · 竞速 / 驾驶",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 竞速 / 驾驶",
+      "author": {
+        "name": "akartit",
+        "url": "https://x.com/akartit"
+      },
+      "demoUrl": "https://lantern-cove.akartit.chatgpt.site/",
+      "sourceUrl": "https://x.com/akartit/status/2096520784449613981",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096520419826171905%2Fimg%2FCVEMco_7vn0_hUZJ.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096520419826171905%2Fimg%2FCVEMco_7vn0_hUZJ.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096520419826171905/vid/avc1/1228x720/F27bpm5EaiLR_QjA.mp4?tag=14",
+      "sourceOrder": -933
+    },
+    {
+      "id": "work-757d386b5d00cea0",
+      "name": "Astra — a dream in orbit",
+      "description": "可玩 Demo · 3D 场景 / 氛围探索",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 3D 场景 / 氛围探索",
+      "author": {
+        "name": "ReadEpoch",
+        "url": "https://x.com/ReadEpoch"
+      },
+      "demoUrl": "https://astra-dream.nxank4.chatgpt.site",
+      "sourceUrl": "https://x.com/ReadEpoch/status/2096505770204655989",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096504176373342208%2Fimg%2FBMiiejnUj45pQg9Q.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096504176373342208%2Fimg%2FBMiiejnUj45pQg9Q.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096504176373342208/vid/avc1/1920x1080/M0Yjc7R4ME3IDZ_Z.mp4?tag=29",
+      "sourceOrder": -934
+    },
+    {
+      "id": "work-d3a59b5cac45d79d",
+      "name": "DUSKLINE — Canyon Circuit",
+      "description": "可玩 Demo · 竞速 / 驾驶",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 竞速 / 驾驶",
+      "author": {
+        "name": "1banke",
+        "url": "https://x.com/1banke"
+      },
+      "demoUrl": "https://duskline-canyon-run.abdulhadi-ai.chatgpt.site",
+      "sourceUrl": "https://x.com/1banke/status/2096394721115390301",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-d3a59b5cac45d79d.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -935
+    },
+    {
+      "id": "work-f130ed7649cf4ae1",
+      "name": "One fingerprint button. Six Astra reconstructions.",
+      "description": "可玩 Demo · 3D 场景 / 氛围探索",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 3D 场景 / 氛围探索",
+      "author": {
+        "name": "magbicaleman",
+        "url": "https://x.com/magbicaleman"
+      },
+      "demoUrl": "https://magbicaleman.github.io/minis/fingerprint-study/",
+      "sourceUrl": "https://x.com/magbicaleman/status/2096393243508314176",
+      "repoUrl": null,
+      "imageUrl": "https://magbicaleman.github.io/minis/fingerprint-study/share-card.png",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -936
+    },
+    {
+      "id": "work-9437252d7ba5cfe6",
+      "name": "CYBER SUV · 互动设计展厅",
+      "description": "可玩 Demo · 竞速 / 驾驶",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 竞速 / 驾驶",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://cyber-suv-studio.banny911.chatgpt.site",
+      "sourceUrl": "https://x.com/i/status/2096384563459334256",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096384440108978176%2Fimg%2Fq0zg3za_tA_N5Fqe.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096384440108978176%2Fimg%2Fq0zg3za_tA_N5Fqe.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096384440108978176/vid/avc1/1280x632/uQgR38HU_FmDzqXc.mp4?tag=29",
+      "sourceOrder": -937
+    },
+    {
+      "id": "work-b8a54d3d86159543",
+      "name": "Flappy Bird · Click to Fly",
+      "description": "可玩 Demo · 经典复刻 / 知名玩法",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 经典复刻 / 知名玩法",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://flappy-click-arcade-sept26.wesley-blomquist96.chatgpt.site/",
+      "sourceUrl": "https://x.com/i/status/2096347522226684105",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-b8a54d3d86159543.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -938
+    },
+    {
+      "id": "work-253644bed5090c38",
+      "name": "AI Mini Racer - Astra Edition",
+      "description": "可玩 Demo · 竞速 / 驾驶",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 竞速 / 驾驶",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://ai-mini-racer.code-crunche-2353.chatgpt.site",
+      "sourceUrl": "https://x.com/i/status/2096320362736714233",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FHRegGMNWYAAMLxf.jpg%3Fname%3Dorig",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -939
+    },
+    {
+      "id": "work-4dad37a3a6287ef1",
+      "name": "无限庭院",
+      "description": "可玩 Demo · 3D 场景 / 氛围探索",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 3D 场景 / 氛围探索",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://infinite-garden.yelin8130.chatgpt.site/",
+      "sourceUrl": "https://x.com/i/status/2096317379034935342",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FHRedgffbYAArRrx.jpg%3Fname%3Dorig",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -940
+    },
+    {
+      "id": "work-d7f15f9030c7e60b",
+      "name": "Hand Replayer — PokerStars",
+      "description": "可玩 Demo · 其他可玩 Demo",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 其他可玩 Demo",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://hand-replayer.marko99999.chatgpt.site",
+      "sourceUrl": "https://x.com/i/status/2096299597689753600",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-d7f15f9030c7e60b.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -941
+    },
+    {
+      "id": "work-9b08aa629a627596",
+      "name": "Piano libre — Piano virtuel",
+      "description": "可玩 Demo · 音乐 / 表演",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 音乐 / 表演",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://piano-libre-florian.flo111.chatgpt.site",
+      "sourceUrl": "https://x.com/i/status/2096291074587197588",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-9b08aa629a627596.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -942
+    },
+    {
+      "id": "work-d9b9ad6feb69ed48",
+      "name": "Unstable Stables Online",
+      "description": "可玩 Demo · 联机 / 多人",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 联机 / 多人",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://unstable-stables-online.danielgui30.chatgpt.site/",
+      "sourceUrl": "https://x.com/i/status/2096282857400652262",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-d9b9ad6feb69ed48.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -943
+    },
+    {
+      "id": "work-1dfa79c2205bde9e",
+      "name": "Craft3D — More than a mesh.",
+      "description": "可玩 Demo · 3D 场景 / 氛围探索",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 3D 场景 / 氛围探索",
+      "author": {
+        "name": "Craft3dApp",
+        "url": "https://x.com/Craft3dApp"
+      },
+      "demoUrl": "https://craft3d.app/gallery",
+      "sourceUrl": "https://x.com/Craft3dApp/status/2096281079510659558",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FHRd7bBZbkAAhIs6.jpg%3Fname%3Dorig",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -944
+    },
+    {
+      "id": "work-7165f122f8556d68",
+      "name": "Model X Studio",
+      "description": "可玩 Demo · 3D 场景 / 氛围探索",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 3D 场景 / 氛围探索",
+      "author": {
+        "name": "grok",
+        "url": "https://x.com/grok"
+      },
+      "demoUrl": "https://model-x-studio.vercel.app",
+      "sourceUrl": "https://x.com/grok/status/2096216661011439951",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-7165f122f8556d68.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -945
+    },
+    {
+      "id": "work-e583d20731ccd5ee",
+      "name": "TOP KNOWLEDGE — 30問チャレンジ",
+      "description": "可玩 Demo · 其他可玩 Demo",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 其他可玩 Demo",
+      "author": {
+        "name": "taisyou2525",
+        "url": "https://x.com/taisyou2525"
+      },
+      "demoUrl": "https://top-call-game.taisyou2525.chatgpt.site",
+      "sourceUrl": "https://x.com/taisyou2525/status/2096206177982099727",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-e583d20731ccd5ee.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -946
+    },
+    {
+      "id": "work-77c3940254bab267",
+      "name": "Bernabéu · Visita 3D",
+      "description": "可玩 Demo · 3D 场景 / 氛围探索",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 3D 场景 / 氛围探索",
+      "author": {
+        "name": "davidcanci",
+        "url": "https://x.com/davidcanci"
+      },
+      "demoUrl": "https://bernabeu-tres-d.antihero11.chatgpt.site/",
+      "sourceUrl": "https://x.com/davidcanci/status/2096201214178308538",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-77c3940254bab267.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -947
+    },
+    {
+      "id": "work-bf1462ef10c78211",
+      "name": "Little Kingdom — 작은 왕국 체스",
+      "description": "可玩 Demo · 模拟经营 / 策略",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 模拟经营 / 策略",
+      "author": {
+        "name": "echo3042",
+        "url": "https://x.com/echo3042"
+      },
+      "demoUrl": "https://little-kingdom-chess.echo3042.chatgpt.site",
+      "sourceUrl": "https://x.com/echo3042/status/2096123409029886250",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-bf1462ef10c78211.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -948
+    },
+    {
+      "id": "work-29cd37b27d1039bb",
+      "name": "PAC-MAN: Ghost Sharks — Bite back.",
+      "description": "可玩 Demo · 经典复刻 / 知名玩法",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 经典复刻 / 知名玩法",
+      "author": {
+        "name": "awildnpc",
+        "url": "https://x.com/awildnpc"
+      },
+      "demoUrl": "https://pacman.demyx.workers.dev/",
+      "sourceUrl": "https://x.com/awildnpc/status/2096034211782099313",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FHRabu3pbIAAEKy4.jpg%3Fname%3Dorig",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -949
+    },
+    {
+      "id": "work-4fa359aa839d7e31",
+      "name": "Portal Viewer",
+      "description": "可玩 Demo · 工程 / 仿真",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 工程 / 仿真",
+      "author": {
+        "name": "SexyTechNews",
+        "url": "https://x.com/SexyTechNews"
+      },
+      "demoUrl": "https://portal-headview-3d.leo1973.chatgpt.site/",
+      "sourceUrl": "https://x.com/SexyTechNews/status/2095982479396188179",
+      "repoUrl": null,
+      "imageUrl": "https://portal-headview-3d.leo1973.chatgpt.site/og.png",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -950
+    },
+    {
+      "id": "work-11d55bcd1d526f34",
+      "name": "Gravitational Bloom",
+      "description": "可玩 Demo · 音乐 / 表演",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 音乐 / 表演",
+      "author": {
+        "name": "BuilderGuest",
+        "url": "https://x.com/BuilderGuest"
+      },
+      "demoUrl": "https://gravitational-bloom.opencrepaldi01.chatgpt.site",
+      "sourceUrl": "https://x.com/BuilderGuest/status/2095946502988288116",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FHRZMNxCWsAIMVDl.jpg%3Fname%3Dorig",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -951
+    },
+    {
+      "id": "work-46edc130b4dbbe11",
+      "name": "コヨーテの正直レビュー | ボドゲミツカル",
+      "description": "可玩 Demo · 其他可玩 Demo",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 其他可玩 Demo",
+      "author": {
+        "name": "BoardgameMt",
+        "url": "https://x.com/BoardgameMt"
+      },
+      "demoUrl": "https://bodoge-mitsukaru.t-natsu-6-17.chatgpt.site/games/coyote",
+      "sourceUrl": "https://x.com/BoardgameMt/status/2095829226650021941",
+      "repoUrl": null,
+      "imageUrl": "https://image.rakuten.co.jp/boardgame-sugorokuya/cabinet/09766721/coyote.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -952
+    },
+    {
+      "id": "work-a29273ac68e188b2",
+      "name": "スマートトレイン学習サイト｜マトレイン",
+      "description": "可玩 Demo · 工程 / 仿真",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 工程 / 仿真",
+      "author": {
+        "name": "shosuke_railfan",
+        "url": "https://x.com/shosuke_railfan"
+      },
+      "demoUrl": "https://matrain-smarttrain-learning.mato111.chatgpt.site/learn/lab/tracks",
+      "sourceUrl": "https://x.com/shosuke_railfan/status/2095825467886784550",
+      "repoUrl": null,
+      "imageUrl": "https://matrain-smarttrain-learning.mato111.chatgpt.site/og.png",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -953
+    },
+    {
+      "id": "work-80b6a38ac6ed436d",
+      "name": "Kutular – Büyük Ödül Oyunu",
+      "description": "可玩 Demo · 街机 / 小游戏包",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 街机 / 小游戏包",
+      "author": {
+        "name": "nzmdgnc",
+        "url": "https://x.com/nzmdgnc"
+      },
+      "demoUrl": "https://kutular-oyunu.tuned-lion-2154.chatgpt.site",
+      "sourceUrl": "https://x.com/nzmdgnc/status/2095803218135544027",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-80b6a38ac6ed436d.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -954
+    },
+    {
+      "id": "work-43c0770636615c0b",
+      "name": "Building Prism World ✳️ One idea, every feed.",
+      "description": "可玩 Demo · 射击 / 动作",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 射击 / 动作",
+      "author": {
+        "name": "krishnap1810",
+        "url": "https://x.com/krishnap1810"
+      },
+      "demoUrl": "https://prism-world-demo.krrish18.chatgpt.site",
+      "sourceUrl": "https://x.com/krishnap1810/status/2095633183567945941",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-43c0770636615c0b.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -955
+    },
+    {
+      "id": "work-fa8bd141aa1127bb",
+      "name": "RB19 交互仿真",
+      "description": "可玩 Demo · 工程 / 仿真",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 工程 / 仿真",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://rb19-engineering-lab.moraxc.chatgpt.site/",
+      "sourceUrl": "https://github.com/xianyu110/awesome-gpt-6-astra/blob/main/PLAYABLE.md",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-fa8bd141aa1127bb.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -956
+    },
+    {
+      "id": "work-87c25182141b18ac",
+      "name": "小丑牌 Balatro",
+      "description": "可玩 Demo · 经典复刻 / 知名玩法",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 经典复刻 / 知名玩法",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://balatro-v1-1.longyh2333521818.chatgpt.site/",
+      "sourceUrl": "https://github.com/xianyu110/awesome-gpt-6-astra/blob/main/PLAYABLE.md",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-87c25182141b18ac.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -957
+    },
+    {
+      "id": "work-1e955ed7f9b2774e",
+      "name": "植物大战僵尸",
+      "description": "可玩 Demo · 经典复刻 / 知名玩法",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 经典复刻 / 知名玩法",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://seth-xh.github.io/pvz/",
+      "sourceUrl": "https://github.com/xianyu110/awesome-gpt-6-astra/blob/main/PLAYABLE.md",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-1e955ed7f9b2774e.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -958
+    },
+    {
+      "id": "work-ced8b8f9a50c3f1e",
+      "name": "Web 三国",
+      "description": "可玩 Demo · 模拟经营 / 策略",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 模拟经营 / 策略",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://sanguo-wind-cloud.amery2010.workers.dev/",
+      "sourceUrl": "https://github.com/xianyu110/awesome-gpt-6-astra/blob/main/PLAYABLE.md",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-ced8b8f9a50c3f1e.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -959
+    },
+    {
+      "id": "work-2402bddbcc779d41",
+      "name": "COURTSIDE NBA2K",
+      "description": "可玩 Demo · 竞速 / 驾驶",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 竞速 / 驾驶",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://huhuhu.page.gd/COURTSIDE26.html",
+      "sourceUrl": "https://github.com/xianyu110/awesome-gpt-6-astra/blob/main/PLAYABLE.md",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-2402bddbcc779d41.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -960
+    },
+    {
+      "id": "work-4ed8bcd308c9e390",
+      "name": "水果忍者",
+      "description": "可玩 Demo · 经典复刻 / 知名玩法",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 经典复刻 / 知名玩法",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://fruit-ninja-dojo-20260905.yongqixue666.chatgpt.site/",
+      "sourceUrl": "https://github.com/xianyu110/awesome-gpt-6-astra/blob/main/PLAYABLE.md",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-4ed8bcd308c9e390.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -961
+    },
+    {
+      "id": "work-a6f37a0568d91d09",
+      "name": "DUSTⅡ·沙漠行动",
+      "description": "可玩 Demo · 经典复刻 / 知名玩法",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 经典复刻 / 知名玩法",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://dust-ii-map.yelin8130.chatgpt.site/",
+      "sourceUrl": "https://github.com/xianyu110/awesome-gpt-6-astra/blob/main/PLAYABLE.md",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-a6f37a0568d91d09.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -962
+    },
+    {
+      "id": "work-0c17c6584c5ee104",
+      "name": "超级马里奥·蘑菇王国",
+      "description": "可玩 Demo · 经典复刻 / 知名玩法",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 经典复刻 / 知名玩法",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://mushroom-arcade-0905.jumaomaomaoju.chatgpt.site/",
+      "sourceUrl": "https://github.com/xianyu110/awesome-gpt-6-astra/blob/main/PLAYABLE.md",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-0c17c6584c5ee104.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -963
+    },
+    {
+      "id": "work-7bbcfad4ed46e813",
+      "name": "秦王拧螺丝",
+      "description": "可玩 Demo · 模拟经营 / 策略",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 模拟经营 / 策略",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://qin-imperial-factory-221.xyjwyf123.chatgpt.site/",
+      "sourceUrl": "https://github.com/xianyu110/awesome-gpt-6-astra/blob/main/PLAYABLE.md",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-7bbcfad4ed46e813.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -964
+    },
+    {
+      "id": "work-e8981a90d32a1658",
+      "name": "Astra Games — Built with GPT-6 Astra",
+      "description": "可玩 Demo · 街机 / 小游戏包 · ❤ 1",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 街机 / 小游戏包",
+      "author": {
+        "name": "marindeloph",
+        "url": "https://x.com/marindeloph"
+      },
+      "demoUrl": "https://astragames.aigccreative.com/en",
+      "sourceUrl": "https://x.com/marindeloph/status/2096901528166793595",
+      "repoUrl": null,
+      "imageUrl": "https://astragames.aigccreative.com/en/opengraph-image?91623e0095e6cbc6",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -965
+    },
+    {
+      "id": "work-95939deaa22eeb76",
+      "name": "Zombie Escape Driver",
+      "description": "可玩 Demo · 竞速 / 驾驶 · ❤ 1",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 竞速 / 驾驶",
+      "author": {
+        "name": "MarcDagatan",
+        "url": "https://x.com/MarcDagatan"
+      },
+      "demoUrl": "https://zombiedriver.z.madsoftware.co",
+      "sourceUrl": "https://x.com/MarcDagatan/status/2096667577326190631",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096667418450178048%2Fimg%2F9CiA7EFs6BMR4M9-.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096667418450178048%2Fimg%2F9CiA7EFs6BMR4M9-.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096667418450178048/vid/avc1/1920x1080/ExYty11ZORmw9OGr.mp4?tag=29",
+      "sourceOrder": -966
+    },
+    {
+      "id": "work-0321dc254e6ff5e5",
+      "name": "THE ROAD DREAMS · 梦境之径",
+      "description": "可玩 Demo · 竞速 / 驾驶 · ❤ 1",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 竞速 / 驾驶",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://the-road-dreams.x2026283037.chatgpt.site",
+      "sourceUrl": "https://x.com/i/status/2096313256264765440",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FHReZtEXa4AAzRhC.jpg%3Fname%3Dorig",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -967
+    },
+    {
+      "id": "work-8b75f1869923ec76",
+      "name": "INFINITUM",
+      "description": "可玩 Demo · 射击 / 动作 · ❤ 2",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 射击 / 动作",
+      "author": {
+        "name": "HpMani56403",
+        "url": "https://x.com/HpMani56403"
+      },
+      "demoUrl": "https://infinitum-game.vercel.app/",
+      "sourceUrl": "https://x.com/HpMani56403/status/2097188417709002822",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2097187889839038464%2Fimg%2F0UtDGuMmz01etvXZ.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2097187889839038464%2Fimg%2F0UtDGuMmz01etvXZ.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2097187889839038464/vid/avc1/1280x720/0r3aT7HAdolRVuy0.mp4?tag=14",
+      "sourceOrder": -968
+    },
+    {
+      "id": "work-bb6ece3340e276ae",
+      "name": "Monopoly City — A board worth exploring",
+      "description": "可玩 Demo · 经典复刻 / 知名玩法 · ❤ 2",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 经典复刻 / 知名玩法",
+      "author": {
+        "name": "thomasunise",
+        "url": "https://x.com/thomasunise"
+      },
+      "demoUrl": "https://monopoly-city.eekosystems.chatgpt.site",
+      "sourceUrl": "https://x.com/thomasunise/status/2097121832159609145",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2097121658750578688%2Fimg%2FmhqTm-uIT4p0ITcm.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2097121658750578688%2Fimg%2FmhqTm-uIT4p0ITcm.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2097121658750578688/vid/avc1/1320x2868/u10kR29m5z80Tm2v.mp4?tag=29",
+      "sourceOrder": -969
+    },
+    {
+      "id": "work-ae809a5a3b804233",
+      "name": "Play Games Built with GPT-6 Astra | Astragames",
+      "description": "可玩 Demo · 街机 / 小游戏包 · ❤ 2",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 街机 / 小游戏包",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://astragames.lol",
+      "sourceUrl": "https://x.com/i/status/2096377756062027894",
+      "repoUrl": null,
+      "imageUrl": "https://astragames.lol/astragames-og.png",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -970
+    },
+    {
+      "id": "work-4360a63589232070",
+      "name": "LUMINA — Bloom of the Cosmos",
+      "description": "可玩 Demo · 音乐 / 表演 · ❤ 2",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 音乐 / 表演",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://lumina-cosmic-garden.vercel.app/",
+      "sourceUrl": "https://x.com/i/status/2096348348773028115",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-4360a63589232070.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -971
+    },
+    {
+      "id": "work-9a90a285371c742d",
+      "name": "MECHANICA — W12 Engine Lab",
+      "description": "可玩 Demo · 工程 / 仿真 · ❤ 2",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 工程 / 仿真",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://mechanica-w12-engine-lab.nm-8755.chatgpt.site/",
+      "sourceUrl": "https://x.com/i/status/2096346500364206536",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-9a90a285371c742d.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -972
+    },
+    {
+      "id": "work-3ddbcd74f6f4ab34",
+      "name": "Ember Causeway",
+      "description": "可玩 Demo · 3D 场景 / 氛围探索 · ❤ 2",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 3D 场景 / 氛围探索",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://ember-causeway.s0673468.chatgpt.site",
+      "sourceUrl": "https://x.com/i/status/2096331530951925840",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-3ddbcd74f6f4ab34.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -973
+    },
+    {
+      "id": "work-058ae9b80c886e3d",
+      "name": "TR-909 / Play it.",
+      "description": "可玩 Demo · 音乐 / 表演 · ❤ 2",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 音乐 / 表演",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://tr909play.budrose681.chatgpt.site",
+      "sourceUrl": "https://x.com/i/status/2096288426115117350",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096287504328806401%2Fimg%2Fi1HgkN_Aw8J_KmGX.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096287504328806401%2Fimg%2Fi1HgkN_Aw8J_KmGX.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096287504328806401/vid/avc1/1152x720/hy2_9SvJgplN_D0V.mp4?tag=14",
+      "sourceOrder": -974
+    },
+    {
+      "id": "work-0a0eab83c010fbb8",
+      "name": "FANG · STARLIGHT RUN",
+      "description": "可玩 Demo · 射击 / 动作 · ❤ 2",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 射击 / 动作",
+      "author": {
+        "name": "FANGsaikyou",
+        "url": "https://x.com/FANGsaikyou"
+      },
+      "demoUrl": "https://fang-starlight-run.yosshy666.chatgpt.site/",
+      "sourceUrl": "https://x.com/FANGsaikyou/status/2096192445667283326",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-0a0eab83c010fbb8.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -975
+    },
+    {
+      "id": "work-36d59fad1c131e78",
+      "name": "Komorebi — Cat World",
+      "description": "可玩 Demo · 3D 场景 / 氛围探索 · ❤ 2",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 3D 场景 / 氛围探索",
+      "author": {
+        "name": "thisjiro",
+        "url": "https://x.com/thisjiro"
+      },
+      "demoUrl": "https://komorebi-neon.vercel.app/",
+      "sourceUrl": "https://x.com/thisjiro/status/2096008437343949039",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096008338798723073%2Fimg%2FOkShGTbe1emvhg8y.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096008338798723073%2Fimg%2FOkShGTbe1emvhg8y.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096008338798723073/vid/avc1/1280x720/nELz9fYgrC0RRmQp.mp4?tag=29",
+      "sourceOrder": -976
+    },
+    {
+      "id": "work-730a5d657b6c5cdd",
+      "name": "Persepolis — An Ancient World, Rediscovered",
+      "description": "可玩 Demo · 3D 场景 / 氛围探索 · ❤ 3",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 3D 场景 / 氛围探索",
+      "author": {
+        "name": "made_by_hossein",
+        "url": "https://x.com/made_by_hossein"
+      },
+      "demoUrl": "https://persepolis-explorer.vercel.app",
+      "sourceUrl": "https://x.com/made_by_hossein/status/2096454262817534111",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096453010536751104%2Fimg%2FLeLi8P1JX8Ulsk8L.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096453010536751104%2Fimg%2FLeLi8P1JX8Ulsk8L.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096453010536751104/vid/avc1/1330x720/nChgcBIaVJTeyjBA.mp4?tag=14",
+      "sourceOrder": -977
+    },
+    {
+      "id": "work-3bd2a089eb538b6a",
+      "name": "Wildwood — A little world of your own",
+      "description": "可玩 Demo · 3D 场景 / 氛围探索 · ❤ 3",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 3D 场景 / 氛围探索",
+      "author": {
+        "name": "Krit12007",
+        "url": "https://x.com/Krit12007"
+      },
+      "demoUrl": "https://krit22.github.io/browser-minecraft/",
+      "sourceUrl": "https://x.com/Krit12007/status/2096141849841029610",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096139552549474305%2Fimg%2FUWyg2tHmMkQ3Ya0m.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096139552549474305%2Fimg%2FUWyg2tHmMkQ3Ya0m.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096139552549474305/vid/avc1/1280x720/MutZIn29IlbKPBBe.mp4?tag=14",
+      "sourceOrder": -978
+    },
+    {
+      "id": "work-aa8b54d05376d2d7",
+      "name": "ASTEROIDS · Deepfield",
+      "description": "可玩 Demo · 街机 / 小游戏包 · ❤ 3",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 街机 / 小游戏包",
+      "author": {
+        "name": "DantesClown",
+        "url": "https://x.com/DantesClown"
+      },
+      "demoUrl": "https://asteroids-deepfield-cockpit.dan200200.chatgpt.site/",
+      "sourceUrl": "https://x.com/DantesClown/status/2096085439052452064",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FHRbI_KrbYAEhUTK.jpg%3Fname%3Dorig",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -979
+    },
+    {
+      "id": "work-fc014391d199f861",
+      "name": "LAST LIGHT — A Northline Story",
+      "description": "可玩 Demo · 射击 / 动作 · ❤ 5",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 射击 / 动作",
+      "author": {
+        "name": "md_taqui_imam",
+        "url": "https://x.com/md_taqui_imam"
+      },
+      "demoUrl": "https://last-light-northline.pages.dev",
+      "sourceUrl": "https://x.com/md_taqui_imam/status/2096255279650517081",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096255107558219776%2Fimg%2Fqs62uLoxv_Wp9nE-.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096255107558219776%2Fimg%2Fqs62uLoxv_Wp9nE-.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096255107558219776/vid/avc1/1208x718/votjNT5NgOfJWh6p.mp4?tag=29",
+      "sourceOrder": -980
+    },
+    {
+      "id": "work-298cd080307f4f0e",
+      "name": "Manu.Vision — SP Edition",
+      "description": "可玩 Demo · 3D 场景 / 氛围探索 · ❤ 5",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 3D 场景 / 氛围探索",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://manu.vision/gb/",
+      "sourceUrl": "https://x.com/i/status/2095999334034690340",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2095999255907303424%2Fimg%2FXtn5tOcG1h2NsrwI.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2095999255907303424%2Fimg%2FXtn5tOcG1h2NsrwI.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2095999255907303424/vid/avc1/632x1280/a5tSr3Y8aEPhx5WN.mp4?tag=29",
+      "sourceOrder": -981
+    },
+    {
+      "id": "work-f804e082866c6e0c",
+      "name": "Topological Rubik’s Synchronizer",
+      "description": "可玩 Demo · 工程 / 仿真 · ❤ 10",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 工程 / 仿真",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://topological-rubik-synchronizer.ela-dev-27.chatgpt.site/",
+      "sourceUrl": "https://x.com/i/status/2096304797687099568",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096304637750247424%2Fimg%2Fs4iUfX1zLvZXd-9y.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096304637750247424%2Fimg%2Fs4iUfX1zLvZXd-9y.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096304637750247424/vid/avc1/1280x804/1Hs1tbSkjRtMI-VF.mp4?tag=29",
+      "sourceOrder": -982
+    },
+    {
+      "id": "work-6a7d687439bfc86c",
+      "name": "Blue Bajaj Rally 1.0.1 | Highland Loop",
+      "description": "可玩 Demo · 竞速 / 驾驶 · ❤ 12",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 竞速 / 驾驶",
+      "author": {
+        "name": "guzotech",
+        "url": "https://x.com/guzotech"
+      },
+      "demoUrl": "https://bajaj.guzo.tech/",
+      "sourceUrl": "https://x.com/guzotech/status/2096209787864088638",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096209636680486912%2Fimg%2FZPUvTKGcVliwSgk0.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096209636680486912%2Fimg%2FZPUvTKGcVliwSgk0.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096209636680486912/vid/avc1/960x720/d48z8TTwTQvoWhc3.mp4?tag=14",
+      "sourceOrder": -983
+    },
+    {
+      "id": "work-d01e6d454686c531",
+      "name": "NAVI City — A living liquidity network",
+      "description": "可玩 Demo · 3D 场景 / 氛围探索 · ❤ 16",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 3D 场景 / 氛围探索",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://navi-emerald-city.elliscopef802081.chatgpt.site/",
+      "sourceUrl": "https://x.com/i/status/2096293372071747591",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096293071260684290%2Fimg%2FpyihlSyG0FHoPmCO.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096293071260684290%2Fimg%2FpyihlSyG0FHoPmCO.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096293071260684290/vid/avc1/1320x2330/DRV_cW4NfN1ZpC_X.mp4?tag=29",
+      "sourceOrder": -984
+    },
+    {
+      "id": "work-1a24f09d60367192",
+      "name": "ASTRA Arcade — Six original games",
+      "description": "可玩 Demo · 街机 / 小游戏包 · ❤ 21",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 街机 / 小游戏包",
+      "author": {
+        "name": "antonioleivag",
+        "url": "https://x.com/antonioleivag"
+      },
+      "demoUrl": "https://astra-arcade.antonioleivag.chatgpt.site",
+      "sourceUrl": "https://x.com/antonioleivag/status/2096509898481651770",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096505353705795586%2Fimg%2FHcaXk1TLXBMsIv8e.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096505353705795586%2Fimg%2FHcaXk1TLXBMsIv8e.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096505353705795586/vid/avc1/1280x810/MYzPxqYK_hmABgoz.mp4?tag=29",
+      "sourceOrder": -985
+    },
+    {
+      "id": "work-4c139268a2a87531",
+      "name": "Tidal Rush — Paradise Grand Prix",
+      "description": "可玩 Demo · 竞速 / 驾驶 · ❤ 24",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 竞速 / 驾驶",
+      "author": {
+        "name": "alexgetmancom",
+        "url": "https://x.com/alexgetmancom"
+      },
+      "demoUrl": "https://tidal-rush-paradise-gp.skirano.chatgpt.site",
+      "sourceUrl": "https://x.com/alexgetmancom/status/2095598460921614825",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FHRUPSgYawAAPeR1.jpg%3Fname%3Dorig",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -986
+    },
+    {
+      "id": "work-c45391db51a65a85",
+      "name": "Eiffel — Light & Perspective",
+      "description": "可玩 Demo · 3D 场景 / 氛围探索 · ❤ 36",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 3D 场景 / 氛围探索",
+      "author": {
+        "name": "ayaboch",
+        "url": "https://x.com/ayaboch"
+      },
+      "demoUrl": "https://eiffel-tower-omega.vercel.app/",
+      "sourceUrl": "https://x.com/ayaboch/status/2096178212883587094",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096176537926012934%2Fimg%2FM-AJoz-Wx60OTtyB.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096176537926012934%2Fimg%2FM-AJoz-Wx60OTtyB.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096176537926012934/vid/avc1/1956x1080/rRgKQ56A9Y-ZKx-H.mp4?tag=29",
+      "sourceOrder": -987
+    },
+    {
+      "id": "work-7f7c2adf0265cb0b",
+      "name": "Fluid — a little space to get lost",
+      "description": "可玩 Demo · 3D 场景 / 氛围探索 · ❤ 57",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 3D 场景 / 氛围探索",
+      "author": {
+        "name": "LukeYoungblood",
+        "url": "https://x.com/LukeYoungblood"
+      },
+      "demoUrl": "https://fluid-playground.lunar-labs-7954.chatgpt.site/",
+      "sourceUrl": "https://x.com/LukeYoungblood/status/2095974873772568778",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2095974217414291456%2Fimg%2FXsDwEfvUxWChZBgZ.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2095974217414291456%2Fimg%2FXsDwEfvUxWChZBgZ.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2095974217414291456/vid/avc1/2160x2274/3tgOkRubJlyKAFfn.mp4?tag=29",
+      "sourceOrder": -988
+    },
+    {
+      "id": "work-197a0c9ae8686fdc",
+      "name": "Skyward: The Gathering",
+      "description": "可玩 Demo · 3D 场景 / 氛围探索 · ❤ 80",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 3D 场景 / 氛围探索",
+      "author": {
+        "name": "timourxyz",
+        "url": "https://x.com/timourxyz"
+      },
+      "demoUrl": "https://edge-city-skyward-quests.vercel.app/",
+      "sourceUrl": "https://x.com/timourxyz/status/2096379521926840339",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096378530619936768%2Fimg%2FXI4U8_pqXPcKqsiu.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096378530619936768%2Fimg%2FXI4U8_pqXPcKqsiu.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096378530619936768/vid/avc1/1716x1288/mhRR914ueuZO_i3m.mp4?tag=29",
+      "sourceOrder": -989
+    },
+    {
+      "id": "work-cb353236f8be8396",
+      "name": "Diamond Light",
+      "description": "可玩 Demo · 3D 场景 / 氛围探索 · ❤ 113",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 3D 场景 / 氛围探索",
+      "author": {
+        "name": "LexnLin",
+        "url": "https://x.com/LexnLin"
+      },
+      "demoUrl": "https://diamond-light.lexn8.chatgpt.site/",
+      "sourceUrl": "https://x.com/LexnLin/status/2096103821470761033",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FHRbbRCfbkAAAv9D.jpg%3Fname%3Dorig",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -990
+    },
+    {
+      "id": "work-f11beb9fb3b8b4d9",
+      "name": "Ashen Road — A journey to Ravenwatch",
+      "description": "可玩 Demo · 竞速 / 驾驶 · ❤ 286",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 竞速 / 驾驶",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://ashen-road.emad349385.chatgpt.site",
+      "sourceUrl": "https://x.com/i/status/2096359789525639290",
+      "repoUrl": null,
+      "imageUrl": "/previews/playable-f11beb9fb3b8b4d9.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": -991
+    },
+    {
+      "id": "work-14b4be584f4f33fc",
+      "name": "Verdant Forest",
+      "description": "可玩 Demo · 3D 场景 / 氛围探索 · ❤ 326",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 3D 场景 / 氛围探索",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://verdant-forest.lexn8.chatgpt.site/",
+      "sourceUrl": "https://x.com/i/status/2096367614805373200",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096262956774490112%2Fimg%2F9UcY8pI6LuZ8v2c_.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096262956774490112%2Fimg%2F9UcY8pI6LuZ8v2c_.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096262956774490112/vid/avc1/1440x900/vWZ5XdJsINV2T-mD.mp4?tag=29",
+      "sourceOrder": -992
+    },
+    {
+      "id": "work-5c901aeba8108376",
+      "name": "Flora Brush",
+      "description": "可玩 Demo · 3D 场景 / 氛围探索 · ❤ 567",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 3D 场景 / 氛围探索",
+      "author": {
+        "name": "soumyadesign",
+        "url": "https://x.com/soumyadesign"
+      },
+      "demoUrl": "https://flora-brush.soumya-raj.chatgpt.site",
+      "sourceUrl": "https://x.com/soumyadesign/status/2096974030104666568",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096973854774312960%2Fimg%2F6pikJwMO3pbAfrVo.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096973854774312960%2Fimg%2F6pikJwMO3pbAfrVo.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096973854774312960/vid/avc1/2600x2160/RqjVYDHxASbKNOIR.mp4?tag=29",
+      "sourceOrder": -993
+    },
+    {
+      "id": "work-e57cb552d2209a34",
+      "name": "Moonlit Forge",
+      "description": "可玩 Demo · 3D 场景 / 氛围探索 · ❤ 580",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 3D 场景 / 氛围探索",
+      "author": {
+        "name": "op7418",
+        "url": "https://x.com/op7418"
+      },
+      "demoUrl": "https://moonlit-forge-studio.op7418.chatgpt.site",
+      "sourceUrl": "https://x.com/op7418/status/2096205141187956887",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096204966549663744%2Fimg%2FUzdz8t2v75PQhifx.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096204966549663744%2Fimg%2FUzdz8t2v75PQhifx.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096204966549663744/vid/avc1/1794x1080/zr9d2OPCL3gDAEjD.mp4?tag=29",
+      "sourceOrder": -994
+    },
+    {
+      "id": "work-722dc1a5f8ce1737",
+      "name": "Lumbridge | Old-school multiplayer adventure",
+      "description": "可玩 Demo · 联机 / 多人 · ❤ 702",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 联机 / 多人",
+      "author": {
+        "name": "TheRohanVarma",
+        "url": "https://x.com/TheRohanVarma"
+      },
+      "demoUrl": "https://elderwood-realms.rohannvarma.chatgpt.site/",
+      "sourceUrl": "https://x.com/TheRohanVarma/status/2096744577332068549",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096743123301117952%2Fimg%2FW_anzk30lopccNnJ.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096743123301117952%2Fimg%2FW_anzk30lopccNnJ.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096743123301117952/vid/avc1/1568x1200/ez652NHj1oUrNftW.mp4?tag=29",
+      "sourceOrder": -995
+    },
+    {
+      "id": "work-431d6e9afe8ca660",
+      "name": "Pelagic — Ocean & Atmosphere",
+      "description": "可玩 Demo · 3D 场景 / 氛围探索 · ❤ 894",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 3D 场景 / 氛围探索",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://pelagic-ocean.lexn8.chatgpt.site",
+      "sourceUrl": "https://x.com/i/status/2096341945979383932",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096341910197846016%2Fimg%2F8pK3VK4IcgfWtEob.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096341910197846016%2Fimg%2F8pK3VK4IcgfWtEob.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096341910197846016/vid/avc1/854x480/_-aKpcLmeLPIGmeC.mp4?tag=29",
+      "sourceOrder": -996
+    },
+    {
+      "id": "work-c9fc9328dcc828ae",
+      "name": "Daybreak · A piano performance",
+      "description": "可玩 Demo · 音乐 / 表演 · ❤ 1107",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 音乐 / 表演",
+      "author": {
+        "name": "LexnLin",
+        "url": "https://x.com/LexnLin"
+      },
+      "demoUrl": "https://daybreak-piano-film.lexn8.chatgpt.site/",
+      "sourceUrl": "https://x.com/LexnLin/status/2096166277849239804",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096165676897779712%2Fimg%2F2t9Gk4pv4bmd7QOW.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096165676897779712%2Fimg%2F2t9Gk4pv4bmd7QOW.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096165676897779712/vid/avc1/1920x1080/wOq4V1m8aSu6CBr8.mp4?tag=29",
+      "sourceOrder": -997
+    },
+    {
+      "id": "work-58161a636c39b27d",
+      "name": "Anatomy, unfolded.",
+      "description": "可玩 Demo · 教育 / 科普 · ❤ 1156",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 教育 / 科普",
+      "author": {
+        "name": "community",
+        "url": null
+      },
+      "demoUrl": "https://anatomy-unfolded.brianp.chatgpt.site",
+      "sourceUrl": "https://x.com/i/status/2096253408009486619",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096253095894528000%2Fimg%2FVdx2NZnXEqoaOX5R.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096253095894528000%2Fimg%2FVdx2NZnXEqoaOX5R.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096253095894528000/vid/avc1/2880x2160/WtOqB5aRnUN3fl6C.mp4?tag=29",
+      "sourceOrder": -998
+    },
+    {
+      "id": "work-788e9a167d0ea571",
+      "name": "Brandenburg Piano — J. S. Bach",
+      "description": "可玩 Demo · 音乐 / 表演 · ❤ 1531",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 音乐 / 表演",
+      "author": {
+        "name": "DeryaTR_",
+        "url": "https://x.com/DeryaTR_"
+      },
+      "demoUrl": "https://brandenburg-piano.vercel.app/",
+      "sourceUrl": "https://x.com/DeryaTR_/status/2096090915790069857",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096090005085077511%2Fimg%2F36OGv0ZYv9Ap7Xgc.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096090005085077511%2Fimg%2F36OGv0ZYv9Ap7Xgc.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096090005085077511/vid/avc1/1920x1080/HZQT7bedn-2Pj3Dw.mp4?tag=29",
+      "sourceOrder": -999
+    },
+    {
+      "id": "work-325a78cdc3209d88",
+      "name": "STORM RACE · Tsuchiya Workshop",
+      "description": "可玩 Demo · 竞速 / 驾驶 · ❤ 4191",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 竞速 / 驾驶",
+      "author": {
+        "name": "BubuStd",
+        "url": "https://x.com/BubuStd"
+      },
+      "demoUrl": "https://storm-race.vercel.app",
+      "sourceUrl": "https://x.com/BubuStd/status/2096587056755638553",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096586972567646209%2Fimg%2FxK4KpEljcPLZORCx.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096586972567646209%2Fimg%2FxK4KpEljcPLZORCx.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096586972567646209/vid/avc1/1920x1080/RabBv3UNIGc7UmTt.mp4?tag=29",
+      "sourceOrder": -1000
+    },
+    {
+      "id": "work-6f19f9c3e72c1609",
+      "name": "Afterlight · 45 分钟 3D 游戏",
+      "description": "概念图对标到 60fps 的 one-shot 原型。",
+      "category": "experiment",
+      "sourceCategory": "01. Afterlight · 45 分钟 3D 游戏",
+      "author": {
+        "name": "Anshu",
+        "url": "https://x.com/anshuc"
+      },
+      "demoUrl": "https://x.com/anshuc/status/2096008083826725132",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483429437354372",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-05.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 0
+    },
+    {
+      "id": "work-960682b876a67556",
+      "name": "运行时生成的活火车",
+      "description": "没有模型文件，TypeScript / Three.js 几何函数驱动轮子和爆炸。",
+      "category": "experiment",
+      "sourceCategory": "02. 运行时生成的活火车",
+      "author": {
+        "name": "Tom Krcha",
+        "url": "https://x.com/tomkrcha"
+      },
+      "demoUrl": "https://x.com/tomkrcha/status/2096082580554777041",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-183.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 1
+    },
+    {
+      "id": "work-4168b43897d5a4c4",
+      "name": "梵高小镇 + Gogh Strike",
+      "description": "6 幅梵高画合成可漫游小镇，后又做成 5v5 射击。",
+      "category": "other",
+      "sourceCategory": "03. 梵高小镇 + Gogh Strike",
+      "author": {
+        "name": "Peter Gostev",
+        "url": "https://x.com/petergostev"
+      },
+      "demoUrl": "https://x.com/petergostev/status/2095776685807346105",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-014.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 2
+    },
+    {
+      "id": "work-0ed5012771a36f16",
+      "name": "15 分钟 3D iPod",
+      "description": "Blender 做机身，用原版 iPod 交互浏览 Codex threads。",
+      "category": "experiment",
+      "sourceCategory": "04. 15 分钟 3D iPod",
+      "author": {
+        "name": "Pietro Schirano",
+        "url": "https://x.com/skirano"
+      },
+      "demoUrl": "https://x.com/skirano/status/2095648379455861054",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 3
+    },
+    {
+      "id": "work-740caf4780fbb968",
+      "name": "Fall Guys 到 5 天 SimCity",
+      "description": "早期最完整长线程之一，含游戏、世界与浏览器控制。",
+      "category": "game",
+      "sourceCategory": "05. Fall Guys 到 5 天 SimCity",
+      "author": {
+        "name": "Matthew Berman",
+        "url": "https://x.com/MatthewBerman"
+      },
+      "demoUrl": "https://x.com/MatthewBerman/status/2095595892464333065",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2095578042618052608%2Fimg%2FRyBElYNzg3S7Efc4.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2095578042618052608%2Fimg%2FRyBElYNzg3S7Efc4.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2095578042618052608/vid/avc1/1280x720/_EOXtMDQrQABTtHy.mp4?tag=29",
+      "sourceOrder": 4
+    },
+    {
+      "id": "work-92af8aece28bd61f",
+      "name": "10 分钟 Blender 甜甜圈",
+      "description": "新手课通常 1–2 小时的模型，约 10 分钟出可改工程文件。",
+      "category": "experiment",
+      "sourceCategory": "06. 10 分钟 Blender 甜甜圈",
+      "author": {
+        "name": "歸藏",
+        "url": "https://x.com/op7418"
+      },
+      "demoUrl": "https://x.com/op7418/status/2096065904828416286",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 5
+    },
+    {
+      "id": "work-29c6aba6030f419b",
+      "name": "Zillow 房源图 → 3D 宣传片",
+      "description": "真房源照片建出可漫游房屋。作者自认细节有误。",
+      "category": "experiment",
+      "sourceCategory": "07. Zillow 房源图 → 3D 宣传片",
+      "author": {
+        "name": "Yunfan Ye",
+        "url": "https://x.com/realYunfanYe"
+      },
+      "demoUrl": "https://x.com/realYunfanYe/status/2095612137582526615",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 6
+    },
+    {
+      "id": "work-d673e57297fb526d",
+      "name": "Apple Notes 里画自像",
+      "description": "不是生成一张图，是在 Mac 上打开 Notes 一笔一笔画。",
+      "category": "other",
+      "sourceCategory": "08. Apple Notes 里画自像",
+      "author": {
+        "name": "Federico Viticci",
+        "url": "https://x.com/viticci"
+      },
+      "demoUrl": "https://x.com/viticci/status/2096025249582039180",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 7
+    },
+    {
+      "id": "work-e90553f09ef19acd",
+      "name": "只看屏幕通关《火红》",
+      "description": "Astra 18h12m；Sol 96h35m；GPT-5.5 跑 218h 未完。",
+      "category": "other",
+      "sourceCategory": "09. 只看屏幕通关《火红》",
+      "author": {
+        "name": "Clad3815",
+        "url": "https://x.com/Clad3815"
+      },
+      "demoUrl": "https://x.com/Clad3815/status/2095596013168050551",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 8
+    },
+    {
+      "id": "work-adf06a77853769b8",
+      "name": "11 分钟巴赫钢琴",
+      "description": "可弹虚拟钢琴，内置全部 6 首《勃兰登堡协奏曲》。",
+      "category": "other",
+      "sourceCategory": "10. 11 分钟巴赫钢琴",
+      "author": {
+        "name": "Derya Unutmaz",
+        "url": "https://x.com/DeryaTR_"
+      },
+      "demoUrl": "https://x.com/DeryaTR_/status/2096090915790069857",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483681942872449",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-25.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 9
+    },
+    {
+      "id": "work-62b8c5afbee9edce",
+      "name": "机械臂 40% → 95%",
+      "description": "真实抓取对照 Fable 5.1，输出 token 少 6.2 倍。",
+      "category": "other",
+      "sourceCategory": "11. 机械臂 40% → 95%",
+      "author": {
+        "name": "Jay Chooi",
+        "url": "https://x.com/chooi_jeq"
+      },
+      "demoUrl": "https://x.com/chooi_jeq/status/2096064315115839904",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483473490067788",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-21.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 10
+    },
+    {
+      "id": "work-595b5c450c64a100",
+      "name": "Canva 里一块块拼肖像",
+      "description": "Computer Use 在 Canva 里实操组装画像。",
+      "category": "other",
+      "sourceCategory": "12. Canva 里一块块拼肖像",
+      "author": {
+        "name": "iam_zachi",
+        "url": "https://x.com/iam_zachi"
+      },
+      "demoUrl": "https://x.com/iam_zachi/status/2095992132620136677",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483419127762986",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-01.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 11
+    },
+    {
+      "id": "work-fe2ddca89a1193f4",
+      "name": "语音通关《杀戮尖塔 2》",
+      "description": "没写复杂 prompt，模型自学键位打了 48 层。",
+      "category": "experiment",
+      "sourceCategory": "13. 语音通关《杀戮尖塔 2》",
+      "author": {
+        "name": "paulwei",
+        "url": "https://x.com/coolish"
+      },
+      "demoUrl": "https://x.com/coolish/status/2096195104809873710",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483478556782739",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-23.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 12
+    },
+    {
+      "id": "work-a5686a9aa8ea7b7d",
+      "name": "Godot 索尼克 Max vs Medium",
+      "description": "同一提示词：53 分钟 / 4% vs 25 分钟 / 1%。",
+      "category": "other",
+      "sourceCategory": "14. Godot 索尼克 Max vs Medium",
+      "author": {
+        "name": "AiBattle",
+        "url": "https://x.com/AiBattle_"
+      },
+      "demoUrl": "https://x.com/AiBattle_/status/2095994051354919049",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483807767781453",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-27.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 13
+    },
+    {
+      "id": "work-11aa79598c612921",
+      "name": "官方 KiCad / UE5 演示",
+      "description": "原理图到 PCB，Blender 房子导入 Unreal Engine 5。",
+      "category": "other",
+      "sourceCategory": "15. 官方 KiCad / UE5 演示",
+      "author": {
+        "name": "OpenAI",
+        "url": "https://x.com/OpenAI"
+      },
+      "demoUrl": "https://x.com/OpenAI/status/2095595741528125780",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 14
+    },
+    {
+      "id": "work-d54525fd95f093cc",
+      "name": "早餐时给布加迪发了邮件",
+      "description": "已连 Gmail 的 Astra 在画车时主动发了两封邮件。",
+      "category": "other",
+      "sourceCategory": "16. 早餐时给布加迪发了邮件",
+      "author": {
+        "name": "SKEL",
+        "url": "https://x.com/skel"
+      },
+      "demoUrl": "https://x.com/skel/status/2096113092736540685",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 15
+    },
+    {
+      "id": "work-f9ff904926bd8d18",
+      "name": "三岁小孩动力沙 / 卡车 / 恐龙",
+      "description": "一句 prompt，约 27 分钟可玩。imoutoftokensFR · original · 09-05",
+      "category": "game",
+      "sourceCategory": "游戏与可玩原型",
+      "author": {
+        "name": "imoutoftokensFR",
+        "url": "https://x.com/imoutoftokensFR"
+      },
+      "demoUrl": "https://x.com/imoutoftokensFR/status/2096202083561054342",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096201923280117760%2Fimg%2F_R4_8j_xB9Pbvamn.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096201923280117760%2Fimg%2F_R4_8j_xB9Pbvamn.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096201923280117760/vid/avc1/1912x1080/EV53js3rFCEQtUMu.mp4?tag=29",
+      "sourceOrder": 16
+    },
+    {
+      "id": "work-ce04d02d30d0bd4d",
+      "name": "Astral War",
+      "description": "浏览器 FPS，一天做出。RealFedeURU · original · 09-05",
+      "category": "game",
+      "sourceCategory": "游戏与可玩原型",
+      "author": {
+        "name": "RealFedeURU",
+        "url": "https://x.com/RealFedeURU"
+      },
+      "demoUrl": "https://x.com/RealFedeURU/status/2096202133532008758",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096062838892814336%2Fimg%2FME5ZS6OhoEsNAfH6.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096062838892814336%2Fimg%2FME5ZS6OhoEsNAfH6.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096062838892814336/vid/avc1/3840x2160/qG8K0QsahuhNt8q2.mp4?tag=29",
+      "sourceOrder": 17
+    },
+    {
+      "id": "work-b44b856eb604423f",
+      "name": "Three.js MMORPG 区域",
+      "description": "网页端 one prompt：营地、交易、技能栏。oceanbennett · original · 09-05",
+      "category": "game",
+      "sourceCategory": "游戏与可玩原型",
+      "author": {
+        "name": "oceanbennett",
+        "url": "https://x.com/oceanbennett"
+      },
+      "demoUrl": "https://x.com/oceanbennett/status/2096049972437209510",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096048861491933188%2Fimg%2Fjm-TH_77jzA0aj6B.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096048861491933188%2Fimg%2Fjm-TH_77jzA0aj6B.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096048861491933188/vid/avc1/3840x2160/6Vqanl_WiHs3k8P1.mp4?tag=29",
+      "sourceOrder": 18
+    },
+    {
+      "id": "work-89d78b1ddffd5478",
+      "name": "Fernando Galaxy",
+      "description": "原生 iOS，Swift + RealityKit + Blender MCP，5h48m。RayFernando1337 · original · 09-05",
+      "category": "game",
+      "sourceCategory": "游戏与可玩原型",
+      "author": {
+        "name": "RayFernando1337",
+        "url": "https://x.com/RayFernando1337"
+      },
+      "demoUrl": "https://x.com/RayFernando1337/status/2096150987031633961",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-258.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 19
+    },
+    {
+      "id": "work-b8ea85df0fb036d1",
+      "name": "宝可梦风 3D / 渋谷 / 东京塔",
+      "description": "日语回顾视频，剪辑也用了 Codex。masahirochaen · original · 09-05",
+      "category": "game",
+      "sourceCategory": "游戏与可玩原型",
+      "author": {
+        "name": "masahirochaen",
+        "url": "https://x.com/masahirochaen"
+      },
+      "demoUrl": "https://x.com/masahirochaen/status/2096196861287878877",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-310.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 20
+    },
+    {
+      "id": "work-fedc8626a3fb24f1",
+      "name": "可玩射击 + 赛车",
+      "description": "两条简单 prompt，两个可玩回合。k2sbhai · original · 09-05",
+      "category": "game",
+      "sourceCategory": "游戏与可玩原型",
+      "author": {
+        "name": "k2sbhai",
+        "url": "https://x.com/k2sbhai"
+      },
+      "demoUrl": "https://x.com/k2sbhai/status/2096182794737402183",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-294.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 21
+    },
+    {
+      "id": "work-f1fce8541ce14b4a",
+      "name": "1-shot 浏览器游戏",
+      "description": "上线日 Theo 的即席游戏演示。theo · original · 09-03",
+      "category": "game",
+      "sourceCategory": "游戏与可玩原型",
+      "author": {
+        "name": "theo",
+        "url": "https://x.com/theo"
+      },
+      "demoUrl": "https://x.com/theo/status/2095599934766764338",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2095599652796272640%2Fimg%2F-alGPQCkf-Z8Cs-n.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2095599652796272640%2Fimg%2F-alGPQCkf-Z8Cs-n.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2095599652796272640/vid/avc1/3472x2160/OYo0vVmQjfchUfL5.mp4?tag=29",
+      "sourceOrder": 22
+    },
+    {
+      "id": "work-64f4a084e0abc383",
+      "name": "三主题赛车",
+      "description": "Playco 团队的多主题 kart 原型。chetaslua · original · 09-03",
+      "category": "game",
+      "sourceCategory": "游戏与可玩原型",
+      "author": {
+        "name": "chetaslua",
+        "url": "https://x.com/chetaslua"
+      },
+      "demoUrl": "https://x.com/chetaslua/status/2095580402505400369",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2095580316710879232%2Fimg%2F4wyWA9mIaUJywIlc.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2095580316710879232%2Fimg%2F4wyWA9mIaUJywIlc.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2095580316710879232/vid/avc1/1920x1080/Co7RPYXqGzSkNESG.mp4?tag=29",
+      "sourceOrder": 23
+    },
+    {
+      "id": "work-e484d63ac21088fa",
+      "name": "Forgotten Horizon",
+      "description": "更完整的探索游戏原型。ashthepeasant · original · 09-05",
+      "category": "game",
+      "sourceCategory": "游戏与可玩原型",
+      "author": {
+        "name": "ashthepeasant",
+        "url": "https://x.com/ashthepeasant"
+      },
+      "demoUrl": "https://x.com/ashthepeasant/status/2096172063241515218",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096168307766513664%2Fimg%2Fixt5KKFzpf-WlH80.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2096168307766513664%2Fimg%2Fixt5KKFzpf-WlH80.jpg",
+      "videoUrl": "https://video.twimg.com/amplify_video/2096168307766513664/vid/avc1/2560x1380/zjrhDLO_vMhDD-LM.mp4?tag=29",
+      "sourceOrder": 24
+    },
+    {
+      "id": "work-d3f14703da032e8e",
+      "name": "房子照片 → 完整 Blender 场景",
+      "description": "家具玩具都在，可 60fps 浏览。tomkrcha · original · 09-03",
+      "category": "experiment",
+      "sourceCategory": "3D 世界与建模",
+      "author": {
+        "name": "tomkrcha",
+        "url": "https://x.com/tomkrcha"
+      },
+      "demoUrl": "https://x.com/tomkrcha/status/2095598645190291775",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 25
+    },
+    {
+      "id": "work-52bc1cb1a35f1b74",
+      "name": "火车草图 → 3295 个可编辑物体",
+      "description": "同作者的工程级 3D。tomkrcha · original · 09-04",
+      "category": "experiment",
+      "sourceCategory": "3D 世界与建模",
+      "author": {
+        "name": "tomkrcha",
+        "url": "https://x.com/tomkrcha"
+      },
+      "demoUrl": "https://x.com/tomkrcha/status/2095756085890310311",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 26
+    },
+    {
+      "id": "work-ba6009a735a79e35",
+      "name": "椭圆形办公室",
+      "description": "Astra 写几何，视频模型收尾。higgsfield_ai · original · 09-03",
+      "category": "experiment",
+      "sourceCategory": "3D 世界与建模",
+      "author": {
+        "name": "higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2095630197257367857",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-044.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 27
+    },
+    {
+      "id": "work-737afb9beb24c75b",
+      "name": "一条 prompt 用基本体拼出整车",
+      "description": "作者说四个月前还摆不好物体。Stefan_3D_AI · original · 09-05",
+      "category": "experiment",
+      "sourceCategory": "3D 世界与建模",
+      "author": {
+        "name": "Stefan_3D_AI",
+        "url": "https://x.com/Stefan_3D_AI"
+      },
+      "demoUrl": "https://x.com/Stefan_3D_AI/status/2096185294165103049",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 28
+    },
+    {
+      "id": "work-b03c1e0c7e94abab",
+      "name": "Cinema 4D 建模",
+      "description": "不只有 Blender。mojon1 · original · 09-05",
+      "category": "experiment",
+      "sourceCategory": "3D 世界与建模",
+      "author": {
+        "name": "mojon1",
+        "url": "https://x.com/mojon1"
+      },
+      "demoUrl": "https://x.com/mojon1/status/2096189580752081024",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 29
+    },
+    {
+      "id": "work-3e5057f690c19264",
+      "name": "澳洲宿舍照片还原",
+      "description": "约 20 分钟做成可交互场景。rionaifantasy · original · 09-05",
+      "category": "experiment",
+      "sourceCategory": "3D 世界与建模",
+      "author": {
+        "name": "rionaifantasy",
+        "url": "https://x.com/rionaifantasy"
+      },
+      "demoUrl": "https://x.com/rionaifantasy/status/2096163579925770671",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-269.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 30
+    },
+    {
+      "id": "work-1bb82bc128dc3cf0",
+      "name": "零 Blender 经验做美式厨房",
+      "description": "语音 + 出图 + Computer Use。berryxia · original · 09-05",
+      "category": "experiment",
+      "sourceCategory": "3D 世界与建模",
+      "author": {
+        "name": "berryxia",
+        "url": "https://x.com/berryxia"
+      },
+      "demoUrl": "https://x.com/berryxia/status/2096158415894835518",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 31
+    },
+    {
+      "id": "work-48035a9a97a4c159",
+      "name": "GTA6 画风新加坡街道",
+      "description": "Three.js，iPhone POV。birdabo · original · 09-05",
+      "category": "experiment",
+      "sourceCategory": "3D 世界与建模",
+      "author": {
+        "name": "birdabo",
+        "url": "https://x.com/birdabo"
+      },
+      "demoUrl": "https://x.com/birdabo/status/2096156461365960837",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483437507211489",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-08.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 32
+    },
+    {
+      "id": "work-fc4ab7c8e69f71db",
+      "name": "Tesla Model X 拆解站",
+      "description": "334 个零件的 3D 网页。ashebytes · original · 09-04",
+      "category": "experiment",
+      "sourceCategory": "3D 世界与建模",
+      "author": {
+        "name": "ashebytes",
+        "url": "https://x.com/ashebytes"
+      },
+      "demoUrl": "https://x.com/ashebytes/status/2096009146248122416",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483440418013570",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-09.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 33
+    },
+    {
+      "id": "work-ed7d9b1987f15236",
+      "name": "Forest Retreat",
+      "description": "Blender 森林别墅，约 7 小时。UNIBRACITY · original · 09-05",
+      "category": "experiment",
+      "sourceCategory": "3D 世界与建模",
+      "author": {
+        "name": "UNIBRACITY",
+        "url": "https://x.com/UNIBRACITY"
+      },
+      "demoUrl": "https://x.com/UNIBRACITY/status/2096142182050927035",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-250.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 34
+    },
+    {
+      "id": "work-858d9cdfbf63722a",
+      "name": "Backrooms",
+      "description": "Duncan Trussell 的 Blender 限制空间。duncantrussell · original · 09-04",
+      "category": "experiment",
+      "sourceCategory": "3D 世界与建模",
+      "author": {
+        "name": "duncantrussell",
+        "url": "https://x.com/duncantrussell"
+      },
+      "demoUrl": "https://x.com/duncantrussell/status/2096003511104508411",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483426950086800",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-04.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 35
+    },
+    {
+      "id": "work-71752ba6c3bc618f",
+      "name": "地图钉 → 3D 街区",
+      "description": "Pietro 把地图标记重建成街区。skirano · original · 09-04",
+      "category": "experiment",
+      "sourceCategory": "3D 世界与建模",
+      "author": {
+        "name": "skirano",
+        "url": "https://x.com/skirano"
+      },
+      "demoUrl": "https://x.com/skirano/status/2095899479308144981",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 36
+    },
+    {
+      "id": "work-056dad315e3c96b6",
+      "name": "自动 bind 的功夫动作",
+      "description": "角色自动绑骨与动画。thebuggeddev · original · 09-05",
+      "category": "experiment",
+      "sourceCategory": "3D 世界与建模",
+      "author": {
+        "name": "thebuggeddev",
+        "url": "https://x.com/thebuggeddev"
+      },
+      "demoUrl": "https://x.com/thebuggeddev/status/2096141728487178503",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-248.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 37
+    },
+    {
+      "id": "work-da9971651633531a",
+      "name": "3D 钢琴家",
+      "description": "可观看的演奏场景。LexnLin · original · 09-05",
+      "category": "experiment",
+      "sourceCategory": "3D 世界与建模",
+      "author": {
+        "name": "LexnLin",
+        "url": "https://x.com/LexnLin"
+      },
+      "demoUrl": "https://x.com/LexnLin/status/2096166277849239804",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-276.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 38
+    },
+    {
+      "id": "work-e46a99c0b2f0d016",
+      "name": "Hangzhou in Three.js",
+      "description": "西湖到钱江新城的可漫游微缩杭州。NFT_Chen · original · 09-05",
+      "category": "experiment",
+      "sourceCategory": "3D 世界与建模",
+      "author": {
+        "name": "NFT_Chen",
+        "url": "https://x.com/NFT_Chen"
+      },
+      "demoUrl": "https://x.com/NFT_Chen/status/2096143589151756638",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-252.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 39
+    },
+    {
+      "id": "work-a2e33f3ab152b11b",
+      "name": "Paint 里画你",
+      "description": "广被引用的 Computer Use 小检。The_Alex · original · 09-04",
+      "category": "other",
+      "sourceCategory": "Computer Use / 工程",
+      "author": {
+        "name": "The_Alex",
+        "url": "https://x.com/The_Alex"
+      },
+      "demoUrl": "https://x.com/The_Alex/status/2095962639386239400",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 40
+    },
+    {
+      "id": "work-18faf5ef255e0962",
+      "name": "55 段素材自动剪辑",
+      "description": "选曲、切点、遮罩一起做。0xTykoo · original · 09-05",
+      "category": "other",
+      "sourceCategory": "Computer Use / 工程",
+      "author": {
+        "name": "0xTykoo",
+        "url": "https://x.com/0xTykoo"
+      },
+      "demoUrl": "https://x.com/0xTykoo/status/2096183262255386833",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 41
+    },
+    {
+      "id": "work-70598a90d7015088",
+      "name": "无人机飞控 PCB",
+      "description": "原理图到布局走线再自查。GoGoFly23 · original · 09-05",
+      "category": "other",
+      "sourceCategory": "Computer Use / 工程",
+      "author": {
+        "name": "GoGoFly23",
+        "url": "https://x.com/GoGoFly23"
+      },
+      "demoUrl": "https://x.com/GoGoFly23/status/2096145124950708512",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 42
+    },
+    {
+      "id": "work-bd992b2b89d998e8",
+      "name": "KiCad PCB 布线",
+      "description": "另一条被广泛转发的 EE 案例。ChihYang04 · original · 09-03",
+      "category": "other",
+      "sourceCategory": "Computer Use / 工程",
+      "author": {
+        "name": "ChihYang04",
+        "url": "https://x.com/ChihYang04"
+      },
+      "demoUrl": "https://x.com/ChihYang04/status/2095637507337826741",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 43
+    },
+    {
+      "id": "work-1ced54bbe489402a",
+      "name": "Agentic CAD",
+      "description": "作者称 CAD agent 有一阶跳变。adamdotnew · original · 09-05",
+      "category": "other",
+      "sourceCategory": "Computer Use / 工程",
+      "author": {
+        "name": "adamdotnew",
+        "url": "https://x.com/adamdotnew"
+      },
+      "demoUrl": "https://x.com/adamdotnew/status/2096053889141489669",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 44
+    },
+    {
+      "id": "work-72c812918fd98212",
+      "name": "开发—验收闭环",
+      "description": "中文圈对 Computer Use 的早期观察。dotey · original · 09-05",
+      "category": "other",
+      "sourceCategory": "Computer Use / 工程",
+      "author": {
+        "name": "dotey",
+        "url": "https://x.com/dotey"
+      },
+      "demoUrl": "https://x.com/dotey/status/2096051842174087386",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 45
+    },
+    {
+      "id": "work-113f2069615c4244",
+      "name": "iOS 参考做安卓",
+      "description": "一次对齐现有 iOS 应用。jonaswrks · original · 09-05",
+      "category": "app",
+      "sourceCategory": "Computer Use / 工程",
+      "author": {
+        "name": "jonaswrks",
+        "url": "https://x.com/jonaswrks"
+      },
+      "demoUrl": "https://x.com/jonaswrks/status/2096201967982829707",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 46
+    },
+    {
+      "id": "work-4f39d7ff1be591ea",
+      "name": "Three.js 30 分钟可交互场景",
+      "description": "作者说从几小时压到 30 分钟。lepadphone · original · 09-05",
+      "category": "other",
+      "sourceCategory": "Computer Use / 工程",
+      "author": {
+        "name": "lepadphone",
+        "url": "https://x.com/lepadphone"
+      },
+      "demoUrl": "https://x.com/lepadphone/status/2096147245775331419",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 47
+    },
+    {
+      "id": "work-bfb906fc1df55d29",
+      "name": "3D pipeline 工作室测试",
+      "description": "工作室级管线试跑。badxstudio · original · 09-04",
+      "category": "other",
+      "sourceCategory": "Computer Use / 工程",
+      "author": {
+        "name": "badxstudio",
+        "url": "https://x.com/badxstudio"
+      },
+      "demoUrl": "https://x.com/badxstudio/status/2095982983379653113",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483458612944976",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-15.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 48
+    },
+    {
+      "id": "work-2653deaaa9de785e",
+      "name": "UI 生成质量",
+      "description": "短视频观点，但被广泛收藏。MSchwaibold · original · 09-05",
+      "category": "other",
+      "sourceCategory": "Computer Use / 工程",
+      "author": {
+        "name": "MSchwaibold",
+        "url": "https://x.com/MSchwaibold"
+      },
+      "demoUrl": "https://x.com/MSchwaibold/status/2096059496812716307",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483449397985496",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-12.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 49
+    },
+    {
+      "id": "work-c23d4b96d93e9022",
+      "name": "ZX Spectrum 48K 复刻",
+      "description": "橡胶键盘、磅带加载、可玩 Gridrunner。DeryaTR_ · original · 09-05",
+      "category": "other",
+      "sourceCategory": "音乐 / 科学 / Prompt",
+      "author": {
+        "name": "DeryaTR_",
+        "url": "https://x.com/DeryaTR_"
+      },
+      "demoUrl": "https://x.com/DeryaTR_/status/2096062355692048605",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-163.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 50
+    },
+    {
+      "id": "work-bec5dd071ce85ae7",
+      "name": "Ableton 从零做一轨",
+      "description": "Pietro + Ableton MCP。skirano · original · 09-03",
+      "category": "other",
+      "sourceCategory": "音乐 / 科学 / Prompt",
+      "author": {
+        "name": "skirano",
+        "url": "https://x.com/skirano"
+      },
+      "demoUrl": "https://x.com/skirano/status/2095595942544089525",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 51
+    },
+    {
+      "id": "work-ce318ba4e91342aa",
+      "name": "个人风格 MIDI",
+      "description": "Astra 出稿，作者改 MIDI 再进 Suno。super_bonochin · original · 09-05",
+      "category": "other",
+      "sourceCategory": "音乐 / 科学 / Prompt",
+      "author": {
+        "name": "super_bonochin",
+        "url": "https://x.com/super_bonochin"
+      },
+      "demoUrl": "https://x.com/super_bonochin/status/2096183825433084181",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 52
+    },
+    {
+      "id": "work-29515da76d06c559",
+      "name": "9 条能上班的 Agent prompt",
+      "description": "账单、二手市场、夜间 QA、竞品。gregisenberg · original · 09-04",
+      "category": "other",
+      "sourceCategory": "音乐 / 科学 / Prompt",
+      "author": {
+        "name": "gregisenberg",
+        "url": "https://x.com/gregisenberg"
+      },
+      "demoUrl": "https://x.com/gregisenberg/status/2095854071580156338",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 53
+    },
+    {
+      "id": "work-f8ba75cbd771096d",
+      "name": "第一性原理盘问代码库",
+      "description": "先删再简。georgepickett · original · 09-04",
+      "category": "other",
+      "sourceCategory": "音乐 / 科学 / Prompt",
+      "author": {
+        "name": "georgepickett",
+        "url": "https://x.com/georgepickett"
+      },
+      "demoUrl": "https://x.com/georgepickett/status/2095979879137460640",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 54
+    },
+    {
+      "id": "work-02afd2c889a276f4",
+      "name": "Mosswing",
+      "description": "3D 单键飞行，控制小翼穿越障碍间隙得分。作者：Ayi1337。One Shot Prompt 与记录 · 源码 · 单文件 HTML。",
+      "category": "game",
+      "sourceCategory": "动作与街机",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://mosswing-quiet-flight.jack-514.chatgpt.site/",
+      "sourceUrl": "https://x.com/i/status/2096263516181123300",
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 55
+    },
+    {
+      "id": "work-ea7ac6ce81db2b36",
+      "name": "Magic Carpet Wizard — A Thousand Skies",
+      "description": "驾驶魔毯探索球形世界，穿环、施法并挑战 Boss。作者：threapchills。桌面浏览器，需要 WebGL 2；Three.js/Vite 源码。",
+      "category": "game",
+      "sourceCategory": "动作与街机",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://threapchills.github.io/MagicCarpetWizard/",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 56
+    },
+    {
+      "id": "work-9414e523f86ec556",
+      "name": "瓜体实验室",
+      "description": "半流体水果形变与碰撞的西瓜合成玩法。作者：Ayi1337。源码 · 单文件 HTML。",
+      "category": "game",
+      "sourceCategory": "解谜与益智",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://melon-game.jack-514.chatgpt.site/",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 57
+    },
+    {
+      "id": "work-9c7ec2875e8b7ddb",
+      "name": "ORBITAL GARDEN · 轨道花园",
+      "description": "48,000 颗光点在花、引力环和星系之间变形的粒子艺术沙盒。作者：jackroc。支持 WebGL 的现代浏览器，免费、无需登录或 API Key；创作记录 · 源码与运行说明 · 离线 HTML · Prompt。",
+      "category": "experiment",
+      "sourceCategory": "实验玩法",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://orbital-garden.hp20230404.chatgpt.site/",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 58
+    },
+    {
+      "id": "work-4708c9bf953c7d14",
+      "name": "DannyMac180/astra-advisor",
+      "description": "动态 Sol/Terra/Luna 子 Agent 编排",
+      "category": "other",
+      "sourceCategory": "社区项目",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": null,
+      "sourceUrl": "https://github.com/DannyMac180/astra-advisor",
+      "repoUrl": "https://github.com/DannyMac180/astra-advisor",
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 59
+    },
+    {
+      "id": "work-57cacc734ddc43d0",
+      "name": "Ayi1337/gpt6-astra-one-shot-games",
+      "description": "原始 Prompt 与可运行单文件 HTML",
+      "category": "other",
+      "sourceCategory": "社区项目",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": null,
+      "sourceUrl": "https://github.com/Ayi1337/gpt6-astra-one-shot-games",
+      "repoUrl": "https://github.com/Ayi1337/gpt6-astra-one-shot-games",
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 60
+    },
+    {
+      "id": "work-8d49162b51503c1c",
+      "name": "tadamcz/koethe",
+      "description": "mean-value-problem — Lean 4 数学反例探索",
+      "category": "other",
+      "sourceCategory": "社区项目",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": null,
+      "sourceUrl": "https://github.com/tadamcz/koethe",
+      "repoUrl": "https://github.com/tadamcz/koethe",
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 61
+    },
+    {
+      "id": "work-9e8d9df493264dae",
+      "name": "Firnschnee/dual-model-mcp",
+      "description": "Fable 5.1 与 Astra 双模型 MCP",
+      "category": "experiment",
+      "sourceCategory": "社区项目",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": null,
+      "sourceUrl": "https://github.com/Firnschnee/dual-model-mcp",
+      "repoUrl": "https://github.com/Firnschnee/dual-model-mcp",
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 62
+    },
+    {
+      "id": "work-64ffe9e804b852d5",
+      "name": "LunarXuan/task-model-router",
+      "description": "按返工成本路由 Codex 任务",
+      "category": "other",
+      "sourceCategory": "社区项目",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": null,
+      "sourceUrl": "https://github.com/LunarXuan/task-model-router",
+      "repoUrl": "https://github.com/LunarXuan/task-model-router",
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 63
+    },
+    {
+      "id": "work-d76704efa605582a",
+      "name": "MiaAI-Lab/GPT-6-Astra-100-HTML-Files",
+      "description": "100 个独立 HTML 视觉实验",
+      "category": "experiment",
+      "sourceCategory": "社区项目",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": null,
+      "sourceUrl": "https://github.com/MiaAI-Lab/GPT-6-Astra-100-HTML-Files",
+      "repoUrl": "https://github.com/MiaAI-Lab/GPT-6-Astra-100-HTML-Files",
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 64
+    },
+    {
+      "id": "work-c003ef22d863004e",
+      "name": "gih10012/astra-parabox-benchmark",
+      "description": "Patrick's Parabox 364 关屏幕基准",
+      "category": "other",
+      "sourceCategory": "社区项目",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": null,
+      "sourceUrl": "https://github.com/gih10012/astra-parabox-benchmark",
+      "repoUrl": "https://github.com/gih10012/astra-parabox-benchmark",
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 65
+    },
+    {
+      "id": "work-c77aaeb31d06b9cf",
+      "name": "coreprocess/openai-relay-for-cursor",
+      "description": "在 Cursor 中接入 Responses API 模型",
+      "category": "experiment",
+      "sourceCategory": "社区项目",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": null,
+      "sourceUrl": "https://github.com/coreprocess/openai-relay-for-cursor",
+      "repoUrl": "https://github.com/coreprocess/openai-relay-for-cursor",
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 66
+    },
+    {
+      "id": "work-8a31ebd9378a8396",
+      "name": "sjh9714/astra-tandem",
+      "description": "ShunsukeHayashi/gpt6-task-spawner — 构建/审阅与任务分发工作流",
+      "category": "other",
+      "sourceCategory": "社区项目",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": null,
+      "sourceUrl": "https://github.com/sjh9714/astra-tandem",
+      "repoUrl": "https://github.com/sjh9714/astra-tandem",
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 67
+    },
+    {
+      "id": "work-dc81dce77bca9260",
+      "name": "marius4lui/NULLSPACE",
+      "description": "生存恐怖 FPS",
+      "category": "other",
+      "sourceCategory": "社区项目",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": null,
+      "sourceUrl": "https://github.com/marius4lui/NULLSPACE",
+      "repoUrl": "https://github.com/marius4lui/NULLSPACE",
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 68
+    },
+    {
+      "id": "work-7e42ba1b0b9fa540",
+      "name": "Rising1234Sun/qingmingshanghetu",
+      "description": "清明上河图实时 3D 场景",
+      "category": "experiment",
+      "sourceCategory": "社区项目",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": null,
+      "sourceUrl": "https://github.com/Rising1234Sun/qingmingshanghetu",
+      "repoUrl": "https://github.com/Rising1234Sun/qingmingshanghetu",
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 69
+    },
+    {
+      "id": "work-56d2c02b94b7bac8",
+      "name": "da03/astra-plays-gta",
+      "description": "Astra 操作 GTA Vice City",
+      "category": "other",
+      "sourceCategory": "社区项目",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": null,
+      "sourceUrl": "https://github.com/da03/astra-plays-gta",
+      "repoUrl": "https://github.com/da03/astra-plays-gta",
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 70
+    },
+    {
+      "id": "work-eff74cbc4c3f16e9",
+      "name": "xinbenlv/ra2-gpt-6-astra-2026-09-04",
+      "description": "红警 2 one-shot 重建",
+      "category": "other",
+      "sourceCategory": "社区项目",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": null,
+      "sourceUrl": "https://github.com/xinbenlv/ra2-gpt-6-astra-2026-09-04",
+      "repoUrl": "https://github.com/xinbenlv/ra2-gpt-6-astra-2026-09-04",
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 71
+    },
+    {
+      "id": "work-04f3eeac4963586e",
+      "name": "paveljor/agent-bluff",
+      "description": "多模型欺骗能力对赛",
+      "category": "experiment",
+      "sourceCategory": "社区项目",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": null,
+      "sourceUrl": "https://github.com/paveljor/agent-bluff",
+      "repoUrl": "https://github.com/paveljor/agent-bluff",
+      "imageUrl": null,
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 72
+    },
+    {
+      "id": "work-13437626d2614973",
+      "name": "Zork 文字冒险改为 3D 动作冒险",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/emollick/status/2096047660662722620",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-001.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-01-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-01.mp4",
+      "sourceOrder": 73
+    },
+    {
+      "id": "work-4ddddd7991f91259",
+      "name": "浏览器第三人称动作游戏",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/superalesha/status/2095988972879335792",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-004.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-04-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-04.mp4",
+      "sourceOrder": 74
+    },
+    {
+      "id": "work-e072428bf4e9a66d",
+      "name": "反重力竞速游戏",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/superalesha/status/2095967568825582044",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-005.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-05-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-05.mp4",
+      "sourceOrder": 75
+    },
+    {
+      "id": "work-113936e041b40d68",
+      "name": "Mario Kart 风格赛车",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/DeryaTR_/status/2095945186643710171",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-006.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-06-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-06.mp4",
+      "sourceOrder": 76
+    },
+    {
+      "id": "work-4539d57dce6c7bfd",
+      "name": "Gogh Strike 艺术风格射击游戏",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/petergostev/status/2096013280519016608",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-007.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-07-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-07.mp4",
+      "sourceOrder": 77
+    },
+    {
+      "id": "work-2cee9e15bfcb4cb0",
+      "name": "Cut the Rope 风格解谜游戏",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/mirochill/status/2095968487994732974",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-008.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-08-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-08.mp4",
+      "sourceOrder": 78
+    },
+    {
+      "id": "work-f484d21389c91dc9",
+      "name": "可漫游且可编辑的房间",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/onofumi_AI/status/2096020860121596003",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-009.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-09-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-09.mp4",
+      "sourceOrder": 79
+    },
+    {
+      "id": "work-c7f702273bc5fc6b",
+      "name": "从零制作 3D 角色",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/posi_posi8/status/2096017956325224851",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-010.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-10-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-10.mp4",
+      "sourceOrder": 80
+    },
+    {
+      "id": "work-a2b3e32a3bfc8840",
+      "name": "户型图与 3D 漫游同步",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/onofumi_AI/status/2095999282088378520",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-011.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-11-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-11.mp4",
+      "sourceOrder": 81
+    },
+    {
+      "id": "work-c2cfe1b8ac05793c",
+      "name": "办公室复刻",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/bridgemindai/status/2095993644389982294",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-012.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-12-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-12.mp4",
+      "sourceOrder": 82
+    },
+    {
+      "id": "work-3369db0b059aadfb",
+      "name": "房源照片转模型和宣传视频",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/Freyabuilds/status/2095833957447434523",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-013.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-13-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-13.mp4",
+      "sourceOrder": 83
+    },
+    {
+      "id": "work-ec2b5297b79042ba",
+      "name": "批量尝试网站视觉设计",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/nateherk/status/2096018636079026498",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-015.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-15-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-15.mp4",
+      "sourceOrder": 84
+    },
+    {
+      "id": "work-e303c73121faead6",
+      "name": "漫剧产品导演台调研与开发",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/nicknam92226032/status/2096018367937450343",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-016.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-16-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-16.mp4",
+      "sourceOrder": 85
+    },
+    {
+      "id": "work-915811aa1507a24b",
+      "name": "改造抽奖流程界面",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/nabu_lines/status/2096001136566141055",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-017.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-17-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-17.mp4",
+      "sourceOrder": 86
+    },
+    {
+      "id": "work-c0bedca7ad3f55a0",
+      "name": "重做现有网站 onboarding",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/coelhoxyz/status/2096000135184400863",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-018.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-18-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-18.mp4",
+      "sourceOrder": 87
+    },
+    {
+      "id": "work-cc0d8da9c847d8b1",
+      "name": "可操作的笔记界面",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/daradoescode/status/2095978271384990084",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-019.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-19-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-19.mp4",
+      "sourceOrder": 88
+    },
+    {
+      "id": "work-882d0b980a18b798",
+      "name": "Gameboy 风格个人作品集",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/Angaisb_/status/2095964361105789424",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483451843330333",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-13.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-20-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-20.mp4",
+      "sourceOrder": 89
+    },
+    {
+      "id": "work-1af1c117ec6ee018",
+      "name": "macOS App onboarding",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/lucas_montano/status/2095959478411698295",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-021.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-21-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-21.mp4",
+      "sourceOrder": 90
+    },
+    {
+      "id": "work-700d6279a79923b0",
+      "name": "Astra 主题欢迎界面",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/jaimintf/status/2095863849635422679",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-022.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-22-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-22.mp4",
+      "sourceOrder": 91
+    },
+    {
+      "id": "work-3f0d3bf82f0cb295",
+      "name": "品牌 Remotion 营销视频",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/bridgemindai/status/2095963477542056143",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-024.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-24-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-24.mp4",
+      "sourceOrder": 92
+    },
+    {
+      "id": "work-9346160506b7817b",
+      "name": "布列塔尼街景短片",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/thomas_guilcher/status/2095845691373351276",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-025.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-25-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-25.mp4",
+      "sourceOrder": 93
+    },
+    {
+      "id": "work-204c7fc3afd63124",
+      "name": "为 Seedance 视频撰写提示词",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/eachlabs/status/2095911062499381467",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-026.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-26-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-26.mp4",
+      "sourceOrder": 94
+    },
+    {
+      "id": "work-dc8b657140672a49",
+      "name": "Blender 灰模到电影感视频",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/Deevid_AI/status/2095919830423498910",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-027.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-27-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-27.mp4",
+      "sourceOrder": 95
+    },
+    {
+      "id": "work-f66f1c8810b137f3",
+      "name": "不完整扫描网格转 CAD",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/Alpha10six/status/2096042985775386739",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-028.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-28-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-28.mp4",
+      "sourceOrder": 96
+    },
+    {
+      "id": "work-f00994e006560ebf",
+      "name": "C++ 光线追踪器迁移到 Swift 与 GPU",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/PaulSolt/status/2095879835088293931",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-029.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-29-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-29.mp4",
+      "sourceOrder": 97
+    },
+    {
+      "id": "work-28041fe41b42fd5d",
+      "name": "低清人像转可打印模型",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/vi4m/status/2096007521437663706",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-031.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-31-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-31.mp4",
+      "sourceOrder": 98
+    },
+    {
+      "id": "work-92ed718fbed3d617",
+      "name": "实时海岸模拟",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/hajimetwi3/status/2096033088178671755",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-032.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-32-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-32.mp4",
+      "sourceOrder": 99
+    },
+    {
+      "id": "work-e482d91a16545e18",
+      "name": "双摆数值模拟与交互画布",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/AlicanKiraz0/status/2095970338043789323",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-033.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-33-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-33.mp4",
+      "sourceOrder": 100
+    },
+    {
+      "id": "work-25ebe9b21530d5e0",
+      "name": "程序化水面效果",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/PaulSolt/status/2095902741092606154",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-034.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-34-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-34.mp4",
+      "sourceOrder": 101
+    },
+    {
+      "id": "work-4dfe49c71fab5178",
+      "name": "果蝇神经连接组驱动 Minecraft 运动",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/evnsnclr/status/2095975490708291948",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483461041381633",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-16.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-35-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-35.mp4",
+      "sourceOrder": 102
+    },
+    {
+      "id": "work-c9f1227930823113",
+      "name": "化学分析 macOS 应用原型",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/DeryaTR_/status/2095907471042675179",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-036.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-36-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-36.mp4",
+      "sourceOrder": 103
+    },
+    {
+      "id": "work-34d4ccb1ba4e1db1",
+      "name": "已知 CVE 重发现评测",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/pilvar222/status/2095980204912955679",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-037.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-37-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-37.mp4",
+      "sourceOrder": 104
+    },
+    {
+      "id": "work-674a0eba484a96df",
+      "name": "一次生成 PowerPoint",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/gota_bara/status/2096004521143201858",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-038.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-38-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-38.mp4",
+      "sourceOrder": 105
+    },
+    {
+      "id": "work-bcd16cd0b59f3d3f",
+      "name": "Bach 风格四声部乐谱",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/aug5thmusic/status/2096030719156089029",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-039.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-39-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-39.mp4",
+      "sourceOrder": 106
+    },
+    {
+      "id": "work-bf0f0a499c33b193",
+      "name": "为 Suno 准备歌曲材料",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/super_bonochin/status/2096023836747763926",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-040.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-40-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-40.mp4",
+      "sourceOrder": 107
+    },
+    {
+      "id": "work-235c6c99d676cd2f",
+      "name": "Blender 别墅场景对照",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/karankendre/status/2095636679264780481",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-041.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-41-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-41.mp4",
+      "sourceOrder": 108
+    },
+    {
+      "id": "work-cbb5e37e6106e5b4",
+      "name": "旧金山 Palace of Fine Arts 重建",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/sharifshameem/status/2095653641164329143",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-043.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-43-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-43.mp4",
+      "sourceOrder": 109
+    },
+    {
+      "id": "work-6acb12aaaf9905f9",
+      "name": "14 分钟动效视频",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/chddaniel/status/2095775049475313943",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-045.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-45-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-45.mp4",
+      "sourceOrder": 110
+    },
+    {
+      "id": "work-ee80f4a851b651a7",
+      "name": "Panzer Dragoon Episode 1 风格游戏",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/yasei_no_otoko/status/2095975195312029889",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-046.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-46-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-46.mp4",
+      "sourceOrder": 111
+    },
+    {
+      "id": "work-f8b9ad16e1a786fb",
+      "name": "BridgeBench 熔岩灯",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/bridgemindai/status/2095962388503679133",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-048.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-48-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-48.mp4",
+      "sourceOrder": 112
+    },
+    {
+      "id": "work-4b25443bba5e6c39",
+      "name": "Blender Dax Raad 人物",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/kitlangton/status/2095959455238164566",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-049.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-49-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-49.mp4",
+      "sourceOrder": 113
+    },
+    {
+      "id": "work-2c9722eb8052b3fa",
+      "name": "鹈鹕 SVG 转 3D",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/anion_ex/status/2095963142010581098",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483463671238867",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-17.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-50-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-50.mp4",
+      "sourceOrder": 114
+    },
+    {
+      "id": "work-742787bb6344a461",
+      "name": "Street Heat 浏览器街机赛车",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2095916820431827408",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-051.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-51-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-51.mp4",
+      "sourceOrder": 115
+    },
+    {
+      "id": "work-58e6ebb9c677bac2",
+      "name": "Three.js 海上战争场景",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/synthwavedd/status/2095840435319001278",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-052.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-52-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-52.mp4",
+      "sourceOrder": 116
+    },
+    {
+      "id": "work-b5bc968a9dd01d1c",
+      "name": "Blender 香蕉雕塑复测",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/D3VAUX/status/2095989462878560702",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-053.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-53-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-53.mp4",
+      "sourceOrder": 117
+    },
+    {
+      "id": "work-0ef1a40c3e0b2b63",
+      "name": "3D mockup 生成工具",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/joshmillgate/status/2095619319690400253",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-054.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-54-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-54.mp4",
+      "sourceOrder": 118
+    },
+    {
+      "id": "work-5ab0d29f4f7f1d0e",
+      "name": "Three.js PS5 手柄",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/blueemi99/status/2095967131573649552",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-055.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-55-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-55.mp4",
+      "sourceOrder": 119
+    },
+    {
+      "id": "work-e059c4e5330acca6",
+      "name": "单 prompt 游戏展示",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/Ludoowic/status/2095840011501380039",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-056.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-56-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-56.mp4",
+      "sourceOrder": 120
+    },
+    {
+      "id": "work-3039280ca33e1836",
+      "name": "Blender 城堡与视频",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/nemumusitocha/status/2095989696094720158",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-057.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-57-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-57.mp4",
+      "sourceOrder": 121
+    },
+    {
+      "id": "work-7a081d157b90639e",
+      "name": "BridgeMind 火箭发射视频",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/bridgemindai/status/2095968262043349373",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-058.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-58-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-58.mp4",
+      "sourceOrder": 122
+    },
+    {
+      "id": "work-eca91e837b0f4d85",
+      "name": "Roblox 动漫大乱斗",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/WoahWurdz/status/2095999578419929412",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-059.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-59-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-59.mp4",
+      "sourceOrder": 123
+    },
+    {
+      "id": "work-a48440f070c10ce4",
+      "name": "Web to App 转原生移动 App",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/chhddavid/status/2095790622066307451",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-060.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-60-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-60.mp4",
+      "sourceOrder": 124
+    },
+    {
+      "id": "work-eefabe71d89f49af",
+      "name": "20 星球探索游戏",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/hakmgpt/status/2095985014378778986",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-061.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-61-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-61.mp4",
+      "sourceOrder": 125
+    },
+    {
+      "id": "work-7bbede601e8c86b5",
+      "name": "Star Destroyer 室内外场景",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/ChrisGPT/status/2095991474714222782",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-062.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-62-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-62.mp4",
+      "sourceOrder": 126
+    },
+    {
+      "id": "work-a00752a4532529dc",
+      "name": "纽博格林赛道飞行展示",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/reach_vb/status/2095973112097747199",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-063.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-63-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-63.mp4",
+      "sourceOrder": 127
+    },
+    {
+      "id": "work-48704dd166549a23",
+      "name": "单张图转 VRM 角色",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/nemumusitocha/status/2095974763772719484",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-064.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-64-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-64.mp4",
+      "sourceOrder": 128
+    },
+    {
+      "id": "work-41fe6de6010c6bc3",
+      "name": "HELIOS 红石音乐装置",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/Angaisb_/status/2096007325005832642",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-065.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-65-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-65.mp4",
+      "sourceOrder": 129
+    },
+    {
+      "id": "work-1d9529682f9da340",
+      "name": "2D / 3D Chain Reaction Machine",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/KinasRemek/status/2095973918775382487",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-066.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-66-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-66.mp4",
+      "sourceOrder": 130
+    },
+    {
+      "id": "work-877dafd9bb67b1d6",
+      "name": "Pokemon 风格游戏重建",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/MozeTech/status/2096023838102536341",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-067.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-67-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-67.mp4",
+      "sourceOrder": 131
+    },
+    {
+      "id": "work-8549faac0f37b81f",
+      "name": "WoW / RuneScape 风格 RPG",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/DeryaTR_/status/2095952101000016076",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-068.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-68-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-68.mp4",
+      "sourceOrder": 132
+    },
+    {
+      "id": "work-45006dd2b999a32d",
+      "name": "鹈鹕 SVG 动画",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/DeryaTR_/status/2096000334418038940",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-069.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-69-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-69.mp4",
+      "sourceOrder": 133
+    },
+    {
+      "id": "work-ef460b460e9a8dc8",
+      "name": "Astra 自我介绍视频",
+      "description": "CheerSelfAI 公开使用案例。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI 使用案例",
+      "author": {
+        "name": "",
+        "url": null
+      },
+      "demoUrl": "https://x.com/nemumusitocha/status/2095967527755305130",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-070.jpg",
+      "posterUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-70-poster.jpg",
+      "videoUrl": "https://pub-62cf7640cd0f4066b60933bd2e9b85ef.r2.dev/site-assets/usecases/gpt-6-astra/case-70.mp4",
+      "sourceOrder": 134
+    },
+    {
+      "id": "work-378bdf401b2d545a",
+      "name": "2. 3D 人体解剖网站",
+      "description": "3D 网页把男性解剖结构拆成 2,234 个可观察模型部件。",
+      "category": "website",
+      "sourceCategory": "X 线程新增案例 · 02",
+      "author": {
+        "name": "ashe / @ashebytes",
+        "url": "https://x.com/ashebytes"
+      },
+      "demoUrl": "https://x.com/ashebytes/status/2096221988763173186",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483421585600687",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-02.jpg",
+      "sourceOrder": 135,
+      "posterUrl": null,
+      "videoUrl": null
+    },
+    {
+      "id": "work-e731cd44c1d01c3a",
+      "name": "3. 生成超逼真的产品广告",
+      "description": "一次生成产品宣传视频，完整提示词见原帖评论。",
+      "category": "other",
+      "sourceCategory": "X 线程新增案例 · 03",
+      "author": {
+        "name": "leo / @leomeethewoo",
+        "url": "https://x.com/leomeethewoo"
+      },
+      "demoUrl": "https://x.com/leomeethewoo/status/2096207831695564833",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483424492195995",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-03.jpg",
+      "sourceOrder": 136,
+      "posterUrl": null,
+      "videoUrl": null
+    },
+    {
+      "id": "work-b320abd91ce0328b",
+      "name": "6. 26 分钟生成的完整作品",
+      "description": "作者记录 Astra Ultra 生成作品的过程与 token 用量。",
+      "category": "other",
+      "sourceCategory": "X 线程新增案例 · 06",
+      "author": {
+        "name": "Adam Lyttle / @adamlyttleapps",
+        "url": "https://x.com/adamlyttleapps"
+      },
+      "demoUrl": "https://x.com/adamlyttleapps/status/2095991822623654124",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483431953887523",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-06.jpg",
+      "sourceOrder": 137,
+      "posterUrl": null,
+      "videoUrl": null
+    },
+    {
+      "id": "work-ae91774ab8aa558a",
+      "name": "7. 在画板里用鼠标给素描上色",
+      "description": "Astra 自动创建图层、放大画布、选择画笔并给手绘线稿上色。",
+      "category": "other",
+      "sourceCategory": "X 线程新增案例 · 07",
+      "author": {
+        "name": "taiyaki_sun",
+        "url": "https://x.com/taiyaki_sun"
+      },
+      "demoUrl": "https://x.com/taiyaki_sun/status/2096149368193839455",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483434621476991",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-07.jpg",
+      "sourceOrder": 138,
+      "posterUrl": null,
+      "videoUrl": null
+    },
+    {
+      "id": "work-22ff739867ccffe8",
+      "name": "10. Minecraft 屏幕展示 OpenAI 标志变成 GPT-6 Astra",
+      "description": "在 Minecraft 中制作屏幕动画，让 OpenAI 标志变成 “6 Astra”。",
+      "category": "other",
+      "sourceCategory": "X 线程新增案例 · 10",
+      "author": {
+        "name": "Angel / @Angaisb_",
+        "url": "https://x.com/Angaisb_"
+      },
+      "demoUrl": "https://x.com/Angaisb_/status/2096199660687745134",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483442804588758",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-10.jpg",
+      "sourceOrder": 139,
+      "posterUrl": null,
+      "videoUrl": null
+    },
+    {
+      "id": "work-2a33f9a6e675b74d",
+      "name": "11. 没有拍摄，没有剪辑，只用一个 prompt",
+      "description": "公开案例声称用一个提示词生成 30 秒 AI 视频。",
+      "category": "tool",
+      "sourceCategory": "X 线程新增案例 · 11",
+      "author": {
+        "name": "NΞKO_SHΛRK / @cat_shark_L1011",
+        "url": "https://x.com/cat_shark_L1011"
+      },
+      "demoUrl": "https://x.com/cat_shark_L1011/status/2096215847438291002",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483445820269033",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-11.jpg",
+      "sourceOrder": 140,
+      "posterUrl": null,
+      "videoUrl": null
+    },
+    {
+      "id": "work-fd985aaa8039a25b",
+      "name": "14. 在 Aseprite 里画初音未来像素画",
+      "description": "在 Aseprite 中制作真正的点阵图，而非像素风插画。",
+      "category": "tool",
+      "sourceCategory": "X 线程新增案例 · 14",
+      "author": {
+        "name": "すえまる / @suemaruuuuuuX",
+        "url": "https://x.com/suemaruuuuuuX"
+      },
+      "demoUrl": "https://x.com/suemaruuuuuuX/status/2096212351502721361",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483456100585762",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-14.jpg",
+      "sourceOrder": 141,
+      "posterUrl": null,
+      "videoUrl": null
+    },
+    {
+      "id": "work-6df22c87815603cb",
+      "name": "18. 完整可玩的卡牌游戏",
+      "description": "从抽卡动画需求扩展成可上线的完整卡牌游戏。",
+      "category": "tool",
+      "sourceCategory": "X 线程新增案例 · 18",
+      "author": {
+        "name": "ギガビット@ゲームつくるひと / @gigabit_million",
+        "url": "https://x.com/gigabit_million"
+      },
+      "demoUrl": "https://x.com/gigabit_million/status/2096094717989867681",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483466057801819",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-18.jpg",
+      "sourceOrder": 142,
+      "posterUrl": null,
+      "videoUrl": null
+    },
+    {
+      "id": "work-fe85e86986201154",
+      "name": "19. 完整的 Final Cut 项目",
+      "description": "自动导入片段、调色、同步剪辑，为后续视频编辑准备工程。",
+      "category": "tool",
+      "sourceCategory": "X 线程新增案例 · 19",
+      "author": {
+        "name": "Ben Davis / @davis7",
+        "url": "https://x.com/davis7"
+      },
+      "demoUrl": "https://x.com/davis7/status/2095742249275699415",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483468549226939",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-19.jpg",
+      "sourceOrder": 143,
+      "posterUrl": null,
+      "videoUrl": null
+    },
+    {
+      "id": "work-a112776f77c5a2cc",
+      "name": "20. GPT-6 Astra 与其他模型的视觉对比",
+      "description": "让多个模型根据同一张扑克牌绘制真实感眼睛并对比结果。",
+      "category": "tool",
+      "sourceCategory": "X 线程新增案例 · 20",
+      "author": {
+        "name": "Ann Nguyen / @ann_nnng",
+        "url": "https://x.com/ann_nnng"
+      },
+      "demoUrl": "https://x.com/ann_nnng/status/2096060924998348918",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483471032238491",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-20.jpg",
+      "sourceOrder": 144,
+      "posterUrl": null,
+      "videoUrl": null
+    },
+    {
+      "id": "work-4949fef340ffe507",
+      "name": "22. 8 分钟生成动效设计视频",
+      "description": "作者记录只修改 3 次、约 8 分钟完成动效视频。",
+      "category": "other",
+      "sourceCategory": "X 线程新增案例 · 22",
+      "author": {
+        "name": "Titouan Gillet / @titouangillet_",
+        "url": "https://x.com/titouangillet_"
+      },
+      "demoUrl": "https://x.com/titouangillet_/status/2096176174032359469",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483475968958492",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-22.jpg",
+      "sourceOrder": 145,
+      "posterUrl": null,
+      "videoUrl": null
+    },
+    {
+      "id": "work-531476ed78c7c585",
+      "name": "24. 完整的 BMX 赛车游戏",
+      "description": "一次生成包含下坡物理、特技、碰撞、降雨和电影镜头的 3D BMX 游戏。",
+      "category": "game",
+      "sourceCategory": "X 线程新增案例 · 24",
+      "author": {
+        "name": "Irushi / @Im_IrushiK",
+        "url": "https://x.com/Im_IrushiK"
+      },
+      "demoUrl": "https://x.com/Im_IrushiK/status/2096280064019353891",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483481178218886",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-24.jpg",
+      "sourceOrder": 146,
+      "posterUrl": null,
+      "videoUrl": null
+    },
+    {
+      "id": "work-a53f63a8578c3292",
+      "name": "26. 在 Photoshop 里为自己画肖像",
+      "description": "Astra 在 Photoshop 中完成肖像绘制，作者记录了不同于人类的操作方式。",
+      "category": "other",
+      "sourceCategory": "X 线程新增案例 · 26",
+      "author": {
+        "name": "Kris Kashtanova / @icreatelife",
+        "url": "https://x.com/icreatelife"
+      },
+      "demoUrl": "https://x.com/icreatelife/status/2096243539411697678",
+      "sourceUrl": "https://x.com/3three_AI/status/2096483751236939920",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-26.jpg",
+      "sourceOrder": 147,
+      "posterUrl": null,
+      "videoUrl": null
+    },
+    {
+      "id": "work-4e83100d51b4b7ba",
+      "name": "30. 地铁跑酷小游戏",
+      "description": "使用 GPT-6 Astra 制作的可玩地铁跑酷小游戏。",
+      "category": "game",
+      "sourceCategory": "X 线程新增案例 · 30",
+      "author": {
+        "name": "Furqan / @Furqanware",
+        "url": "https://x.com/Furqanware"
+      },
+      "demoUrl": "https://x.com/Furqanware/status/2094954714345677052",
+      "sourceUrl": "https://x.com/3three_AI/status/2096484191240421378",
+      "repoUrl": null,
+      "imageUrl": "/previews/x-thread-30.jpg",
+      "sourceOrder": 148,
+      "posterUrl": null,
+      "videoUrl": null
+    },
+    {
+      "id": "work-ff1f44e327b9cb73",
+      "name": "从街道到赌场桌的连续镜头预演与生成",
+      "description": "Astra 规划全局空间，低多边形预演固定调度，Medeo 上的 Seedance 2.5 渲染。 Astra 的角色是空间规划；最终画面来自 Seedance，不能归作 Astra 原生视频。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@Medeo_AI",
+        "url": "https://x.com/Medeo_AI"
+      },
+      "demoUrl": "https://x.com/Medeo_AI/status/2095931387966640231",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-071.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 149
+    },
+    {
+      "id": "work-6ebc1e63c5bf943b",
+      "name": "将 Opus 跑车结果与 Pietro 的 Astra 输出对照",
+      "description": "作者认为 Opus 更流畅，去除 Astra 的镜头光晕后两者相近。 Astra 输出来自 Pietro 的已有作品，不能说发帖者重新运行 Astra。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@TimJayas",
+        "url": "https://x.com/TimJayas"
+      },
+      "demoUrl": "https://x.com/TimJayas/status/2095937263104667824",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-072.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 150
+    },
+    {
+      "id": "work-0683106f933529ae",
+      "name": "在 Blender 中构建城市",
+      "description": "城市三维场景演示 作者未说明城市名称和具体规模；影视行业预测不属于该成果。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@Loofyb0i",
+        "url": "https://x.com/Loofyb0i"
+      },
+      "demoUrl": "https://x.com/Loofyb0i/status/2095941061390573621",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-073.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 151
+    },
+    {
+      "id": "work-67563f80cbce990a",
+      "name": "实时流体网站的双模型同提示对照",
+      "description": "Astra 与 Fable 使用相同提示，全流程在 Higgsfield Supercomputer。 平台自营演示，未验证数值流体物理或逐模型运行。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 模拟与科学可视化",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2095943653198119309",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-074.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 152
+    },
+    {
+      "id": "work-4b861e6c9fd7d388",
+      "name": "把现有 tile map demo 改为巨龙俯视射击游戏",
+      "description": "作者称 38 分钟完成。 建立在已有 demo 上，不能描述为完全从零生成。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@PaulSolt",
+        "url": "https://x.com/PaulSolt"
+      },
+      "demoUrl": "https://x.com/PaulSolt/status/2095945953412882695",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-075.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 153
+    },
+    {
+      "id": "work-f84bef2242965847",
+      "name": "KiCad 中从原理图到 PCB 布局的官方演示解读",
+      "description": "由电子原理图转成的 PCB 布局演示 15 秒片段为压缩播放，不代表完成用时。",
+      "category": "tool",
+      "sourceCategory": "CheerSelfAI · 工程文件与代码迁移",
+      "author": {
+        "name": "@lagerskoy",
+        "url": "https://x.com/lagerskoy"
+      },
+      "demoUrl": "https://x.com/lagerskoy/status/2095954273498796282",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-076.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 154
+    },
+    {
+      "id": "work-7d5de28f1ac95d7c",
+      "name": "火车场景视频及声音克隆误用反馈",
+      "description": "作者称 Astra 自行使用了自己的声音克隆。 作者对声音克隆使用提出意外反馈，不能描述为已获专门授权的流程。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@AdamHoltererer",
+        "url": "https://x.com/AdamHoltererer"
+      },
+      "demoUrl": "https://x.com/AdamHoltererer/status/2095957170491732276",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-077.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 155
+    },
+    {
+      "id": "work-44d6f4e45566c85c",
+      "name": "Call of Duty 风格游戏的首次单轮测试",
+      "description": "作者称 Astra 三十分钟，Fable 近五小时，Astra token 更少。 未附账单或统一计时日志，不能推广为整体最快模型。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@WoahWurdz",
+        "url": "https://x.com/WoahWurdz"
+      },
+      "demoUrl": "https://x.com/WoahWurdz/status/2095958882732355908",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-078.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 156
+    },
+    {
+      "id": "work-24b1ff07c2bd84f2",
+      "name": "Unreal Engine 曼哈顿街区重建的报道",
+      "description": "发帖者称 Astra 逐街区迭代约一周。 原始执行者未明确，持续一周及全城规模未核实。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@hitu_monke",
+        "url": "https://x.com/hitu_monke"
+      },
+      "demoUrl": "https://x.com/hitu_monke/status/2095961973435314195",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-079.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 157
+    },
+    {
+      "id": "work-860056d898134d87",
+      "name": "中途停止后的游戏生成与 UI 比较",
+      "description": "作者认为 Astra 的 UI、机制与完整感领先，Kimi 性价比较高。 游戏名称与完整提示未在正文说明。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@adxtyahq",
+        "url": "https://x.com/adxtyahq"
+      },
+      "demoUrl": "https://x.com/adxtyahq/status/2095962504543527295",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-080.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 158
+    },
+    {
+      "id": "work-060af4d4bd14c611",
+      "name": "纽约场景细节与相机运动的模型比较",
+      "description": "在 Codex 运行；完成后追加指令要求相机运动。 作者称初版不到二十分钟、较 Sol 进步，但缺少部分桥梁车辆细节。 时间、细节和与 Opus/Fable 的比较是作者观察。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@aipulseda1ly",
+        "url": "https://x.com/aipulseda1ly"
+      },
+      "demoUrl": "https://x.com/aipulseda1ly/status/2095962962808746380",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-081.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 159
+    },
+    {
+      "id": "work-a98fd158dfb78f30",
+      "name": "十分钟在 Blender 构建火箭飞船",
+      "description": "作者称约十分钟完成。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@SafaElmali",
+        "url": "https://x.com/SafaElmali"
+      },
+      "demoUrl": "https://x.com/SafaElmali/status/2095965848066294220",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-082.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 160
+    },
+    {
+      "id": "work-96f2708c08376280",
+      "name": "将《远岬夜航》文字转为 Three.js 三维演出",
+      "description": "不看渲染画面盲写，不加载外部模型或贴图；作者报告 48 分钟。 时间、盲写和资产约束来自作者描述，未复现。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@cxjwin",
+        "url": "https://x.com/cxjwin"
+      },
+      "demoUrl": "https://x.com/cxjwin/status/2095968856682750102",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-083.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 161
+    },
+    {
+      "id": "work-9062557a14776900",
+      "name": "前端生成中有无 skills 的对照",
+      "description": "两组前端输出对照 未给出 skills 名称、统一提示或量化评价；仅记录明确的条件对照。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 专业研究与安全评测",
+      "author": {
+        "name": "@AdamHoltererer",
+        "url": "https://x.com/AdamHoltererer"
+      },
+      "demoUrl": "https://x.com/AdamHoltererer/status/2095970281479180536",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-084.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 162
+    },
+    {
+      "id": "work-d80cb0cdd01c71f7",
+      "name": "Unreal Engine 中的多代理生存世界报道",
+      "description": "二手转述 Matt Shumer 让 Astra 创建世界，并以 Astra 代理控制角色。 多小时或隔夜运行、自治程度和声音故事为转述，未验证。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 模拟与科学可视化",
+      "author": {
+        "name": "@precisox",
+        "url": "https://x.com/precisox"
+      },
+      "demoUrl": "https://x.com/precisox/status/2095970738112974973",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-085.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 163
+    },
+    {
+      "id": "work-9db93168aa273a2b",
+      "name": "从照片重建 Geisel Library 的三模型对照",
+      "description": "根帖补上引用预告中留待 Astra 的建筑重建实验。 平台认为 Astra 在整体结构与细节上表现好。 引用明确 Geisel Library 任务，保留对应来源。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@EnactraAI",
+        "url": "https://x.com/EnactraAI"
+      },
+      "demoUrl": "https://x.com/EnactraAI/status/2095971556128399464",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-086.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 164
+    },
+    {
+      "id": "work-429aed92c36ced23",
+      "name": "包含可控内饰的汽车驾驶模拟",
+      "description": "作者称首次在其测试中没有出现移动控制错误。 GTA 终极版是后续目标，当前只完成驾驶模拟前期任务。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@mirochill",
+        "url": "https://x.com/mirochill"
+      },
+      "demoUrl": "https://x.com/mirochill/status/2095971781165076645",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-087.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 165
+    },
+    {
+      "id": "work-6262b071493bcda0",
+      "name": "四种灾难场景的 HTML 生成成本对照",
+      "description": "每个场景一个自包含 HTML；单轮且不修改。 平台报告 Astra 25159 token、1.67 美元，Fable 37767 token、2.51 美元。 平台自营同题评测，成本与无修改声明未独立复现。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 专业研究与安全评测",
+      "author": {
+        "name": "@aimlapi",
+        "url": "https://x.com/aimlapi"
+      },
+      "demoUrl": "https://x.com/aimlapi/status/2095971826656817194",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-088.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 166
+    },
+    {
+      "id": "work-064c1ce3dd910988",
+      "name": "Subway Surfers 风格跑酷的单轮测试",
+      "description": "作者报告 Astra 二十分钟，Fable 超过一小时且效果较差。 时间、质量和单轮状态均为作者自述，未独立试玩。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@_MaxBlade",
+        "url": "https://x.com/_MaxBlade"
+      },
+      "demoUrl": "https://x.com/_MaxBlade/status/2095972303037198821",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-089.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 167
+    },
+    {
+      "id": "work-e979a8d2dd9d41e1",
+      "name": "海洋模拟的同提示模型比较",
+      "description": "作者认为 Astra 明显优于 Sol，Fable 仍有竞争力。 同提示和质量判断来自作者，未核验模拟物理正确性。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@TimJayas",
+        "url": "https://x.com/TimJayas"
+      },
+      "demoUrl": "https://x.com/TimJayas/status/2095972421195141247",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-090.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 168
+    },
+    {
+      "id": "work-4bcf25d8b514437f",
+      "name": "单轮生成 BMW M4 CS 模型",
+      "description": "Max effort，一次生成。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@HarshithLucky3",
+        "url": "https://x.com/HarshithLucky3"
+      },
+      "demoUrl": "https://x.com/HarshithLucky3/status/2095973405111849025",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-091.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 169
+    },
+    {
+      "id": "work-bce9cd3097bc4e9b",
+      "name": "使用 ProGPU 的跨平台 2.5D 冒险游戏",
+      "description": "使用作者的 ProGPU 渲染库，基于 WebGPU 与 .NET C#。 跨端运行是作者自述，未逐平台测试。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@wieslawsoltes",
+        "url": "https://x.com/wieslawsoltes"
+      },
+      "demoUrl": "https://x.com/wieslawsoltes/status/2095973549118804080",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-092.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 170
+    },
+    {
+      "id": "work-3e9cbf0850773aca",
+      "name": "使用 Devin 与两项设计 skill 一次生成网站",
+      "description": "一次生成的网站设计演示 skill 名称和网站业务未具体公开；原帖有工具步骤，不能描述为无外部指导。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@JustinGorya",
+        "url": "https://x.com/JustinGorya"
+      },
+      "demoUrl": "https://x.com/JustinGorya/status/2095977339893039308",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-093.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 171
+    },
+    {
+      "id": "work-115917a682c5fe75",
+      "name": "让 Astra 在 Paint 绘制本人肖像",
+      "description": "带随帖视频的人像绘画演示 帖子以建议任务形式呈现，原始执行者与绘画准确性未核实。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@vision_ia",
+        "url": "https://x.com/vision_ia"
+      },
+      "demoUrl": "https://x.com/vision_ia/status/2095979231444345279",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-094.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 172
+    },
+    {
+      "id": "work-19ed0bc7b5813447",
+      "name": "鲁布·戈德堡连锁装置的双模型对照",
+      "description": "不用物理引擎；手写逐帧重叠碰撞；固定 1200 帧、60 fps、20 秒录制，反馈观察但不手改代码。 作者报告 Astra 1.84 美元、9 分 56 秒、约 45k token；第二轮才完成。 成本、计时和确定性来自作者测试，未独立复现。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 模拟与科学可视化",
+      "author": {
+        "name": "@thehypedotnews",
+        "url": "https://x.com/thehypedotnews"
+      },
+      "demoUrl": "https://x.com/thehypedotnews/status/2095980885732704629",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-095.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 173
+    },
+    {
+      "id": "work-8c07bc1aac7235fe",
+      "name": "Angry Birds 风格 3D 重建及画质不足反馈",
+      "description": "作者对 Astra 的三维画面不满意，认为 Fable 更精致，但称 Astra 价格更低。 保留画质不满意反馈，不能把标题中的 ARR 当作生成游戏收入。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@MozeTech",
+        "url": "https://x.com/MozeTech"
+      },
+      "demoUrl": "https://x.com/MozeTech/status/2095981655370666076",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-096.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 174
+    },
+    {
+      "id": "work-ac1c014d58ac1c1c",
+      "name": "把大型交易系统代码库转为三维说明网站",
+      "description": "两模型研究现有数百万行代码库，并使用 Codex 的 Sites 插件呈现。 作者称两份方案整体相似，细节分析另在线程中。 根帖当前展示部分标为 Sol，Astra 的细节与完整对照未取齐。",
+      "category": "tool",
+      "sourceCategory": "CheerSelfAI · 工程文件与代码迁移",
+      "author": {
+        "name": "@nishffx",
+        "url": "https://x.com/nishffx"
+      },
+      "demoUrl": "https://x.com/nishffx/status/2095986973525594614",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-097.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 175
+    },
+    {
+      "id": "work-27b221b993da21d8",
+      "name": "从犬吠录音尝试重建空间",
+      "description": "把音频交给 Astra，要求尽可能依据声音重建。 声音到空间的推断未以真实测绘核验，不能写成获得准确地图。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 专业研究与安全评测",
+      "author": {
+        "name": "@literallydenis",
+        "url": "https://x.com/literallydenis"
+      },
+      "demoUrl": "https://x.com/literallydenis/status/2095989219390844985",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-098.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 176
+    },
+    {
+      "id": "work-083422af645cd8b8",
+      "name": "可映射真实手柄输入的交互 PS5 模型",
+      "description": "可旋转、按键、拖动摇杆并镜像真实手柄输入的 Three.js 演示 作者给出 Demo 和代码入口，未独立运行或连接手柄验证。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@SafaElmali",
+        "url": "https://x.com/SafaElmali"
+      },
+      "demoUrl": "https://x.com/SafaElmali/status/2095989925627789490",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-099.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 177
+    },
+    {
+      "id": "work-82804a4da3ecaa3d",
+      "name": "单提示构建可检查的 A380 Blender 模型",
+      "description": "发帖者称一条提示生成，可旋转检查比例。 原帖明确不是航空工程级几何，拓扑、材料和系统未验收。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@irinatoxi",
+        "url": "https://x.com/irinatoxi"
+      },
+      "demoUrl": "https://x.com/irinatoxi/status/2095991176411119919",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-100.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 178
+    },
+    {
+      "id": "work-924f3a913dc6cbf6",
+      "name": "在 Monocode 内生成模型庆祝效果",
+      "description": "Monocode 内的庆祝展示效果 原帖未详述视觉形式或实现方式，不能据此补写具体动画。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@nikolay_dp",
+        "url": "https://x.com/nikolay_dp"
+      },
+      "demoUrl": "https://x.com/nikolay_dp/status/2095992327240028179",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-101.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 179
+    },
+    {
+      "id": "work-c0070ac97fe27b22",
+      "name": "Astra 与 Higgsfield 的可玩广告流程",
+      "description": "Astra 构建逻辑和机制，Higgsfield 生成三维世界、角色及资产，再迭代玩法和创意。 平台自营流程演示；未提供实际投放、转化率或批量生成验证。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2095993175659982985",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-102.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 180
+    },
+    {
+      "id": "work-60c76e520618d35d",
+      "name": "含烟雾场景的四模型输出与成本复测",
+      "description": "作者记录 Astra 11 分钟、12.85 美元；并列出其他模型时间与成本。 具体场景和统一提示未在正文命名，不能进一步推断对象。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 专业研究与安全评测",
+      "author": {
+        "name": "@Bhavani_00007",
+        "url": "https://x.com/Bhavani_00007"
+      },
+      "demoUrl": "https://x.com/Bhavani_00007/status/2095993683447611740",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-103.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 181
+    },
+    {
+      "id": "work-23c192403f6f404b",
+      "name": "对 Next.js 游戏运动与物理表现的复测",
+      "description": "引用先前 Sol 的 Next.js 游戏实验；作者先前表示将用 Astra 重做同一游戏。 同任务关系由同作者前后叙述支持；未给完整提示或量化物理评分。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@b4dgerr",
+        "url": "https://x.com/b4dgerr"
+      },
+      "demoUrl": "https://x.com/b4dgerr/status/2095996823039078547",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-104.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 182
+    },
+    {
+      "id": "work-a1ec4fb5a73f1019",
+      "name": "含 NPC、职业与巨龙的体素世界",
+      "description": "一次生成，回复中提供试玩入口。 作者考虑把测试项目发展为真实游戏。 数量、能力和可玩性为作者自述，未独立统计或试玩。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@knowixbuilds",
+        "url": "https://x.com/knowixbuilds"
+      },
+      "demoUrl": "https://x.com/knowixbuilds/status/2095996882678169800",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-105.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 183
+    },
+    {
+      "id": "work-bc04b1a0c152205b",
+      "name": "从 SVG 到可拆解的三维硬件网站",
+      "description": "先从 SVG 开始，再持续追加要求；提供浏览器体验链接。 多轮生成，未独立打开试玩验证。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@alexprokhorov",
+        "url": "https://x.com/alexprokhorov"
+      },
+      "demoUrl": "https://x.com/alexprokhorov/status/2095997514940092704",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-106.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 184
+    },
+    {
+      "id": "work-418ac5c405899c2d",
+      "name": "参考图绘制 Sam Altman 人像的偏差测试",
+      "description": "作者称视频按实际速度播放，但画面不像输入图。 保留作者明确指出的相似度失败，未量化图像误差或核对播放速度。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 模拟与科学可视化",
+      "author": {
+        "name": "@1littlecoder",
+        "url": "https://x.com/1littlecoder"
+      },
+      "demoUrl": "https://x.com/1littlecoder/status/2095998329415205240",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-107.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 185
+    },
+    {
+      "id": "work-c3d5e20317651af5",
+      "name": "电脑操作创建表格的双模型比较",
+      "description": "两个 computer-use agent 的表格创建演示 平台引流演示，未核查表格正确性或操作成功率。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@coastyai",
+        "url": "https://x.com/coastyai"
+      },
+      "demoUrl": "https://x.com/coastyai/status/2095999601685963081",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-108.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 186
+    },
+    {
+      "id": "work-1749606705488891",
+      "name": "HTML 房屋场景与努力档位比较",
+      "description": "作者称 xHigh 约三十分钟，Low 也能得到接近结果且优于 GPT-5.6。 场景质量、时间和档位比较均为作者判断，未复现实验。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@mirochill",
+        "url": "https://x.com/mirochill"
+      },
+      "demoUrl": "https://x.com/mirochill/status/2095999828069163119",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-109.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 187
+    },
+    {
+      "id": "work-9f92d7c45bd0c28e",
+      "name": "Astra computer use 操作 smash.fun 的失败测试",
+      "description": "操作游戏的测试，作者称速度快但尚不能玩好 这是游戏操作能力测试，不是 Astra 创建该游戏。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@kylejeong",
+        "url": "https://x.com/kylejeong"
+      },
+      "demoUrl": "https://x.com/kylejeong/status/2096004273876381916",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-110.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 188
+    },
+    {
+      "id": "work-77220a1745fd95c3",
+      "name": "巨像题材游戏与控制机制演示",
+      "description": "作者评价控制机制理解准确。 控制准确性为作者评价，未独立试玩。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@TimJayas",
+        "url": "https://x.com/TimJayas"
+      },
+      "demoUrl": "https://x.com/TimJayas/status/2096005792428437708",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-111.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 189
+    },
+    {
+      "id": "work-dbe2e155452c404d",
+      "name": "Crayon 上的 Naruto 题材游戏演示",
+      "description": "Naruto 标签的游戏演示 平台展示的简短原帖，具体机制、提示和可玩性未验证。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@usecrayon",
+        "url": "https://x.com/usecrayon"
+      },
+      "demoUrl": "https://x.com/usecrayon/status/2096007051378139282",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-112.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 190
+    },
+    {
+      "id": "work-825b0d8636b62cb4",
+      "name": "十分钟制作卡通城堡模型",
+      "description": "作者称十分钟完成。 制作时间及执行过程为发帖者陈述，未核查原始模型文件。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@digitalcloudno",
+        "url": "https://x.com/digitalcloudno"
+      },
+      "demoUrl": "https://x.com/digitalcloudno/status/2096008984331264320",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-113.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 191
+    },
+    {
+      "id": "work-f06ac946d4a99fbe",
+      "name": "为 PlayStation 1 制作 3D 格斗原型",
+      "description": "制作中的格斗游戏原型 作者明确仍在制作中；未验证可在真机运行。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@GOROman",
+        "url": "https://x.com/GOROman"
+      },
+      "demoUrl": "https://x.com/GOROman/status/2096009079105966164",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-114.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 192
+    },
+    {
+      "id": "work-5ee19d60813999ac",
+      "name": "将美国自然历史博物馆重建为游戏",
+      "description": "Higgsfield Supercomputer 上使用单提示；平台声称 DLSS 5 改善画面。 平台自营演示；单提示、DLSS 5 参与和可玩性均未独立验证。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096009543327404491",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-115.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 193
+    },
+    {
+      "id": "work-e693fb752e65fb45",
+      "name": "麦田中的浪人 Three.js 场景",
+      "description": "Max reasoning；作者报告约两小时。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@zwb44",
+        "url": "https://x.com/zwb44"
+      },
+      "demoUrl": "https://x.com/zwb44/status/2096013227012354507",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-116.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 194
+    },
+    {
+      "id": "work-d0024dfa8e75383c",
+      "name": "简易射击游戏",
+      "description": "射击游戏演示",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@npaka123",
+        "url": "https://x.com/npaka123"
+      },
+      "demoUrl": "https://x.com/npaka123/status/2096013842665124246",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-117.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 195
+    },
+    {
+      "id": "work-99bba54ee5eda907",
+      "name": "Sonic Dash Run 3D 游戏演示",
+      "description": "发帖者称单提示约花费 5 美元。 原始执行者与费用账单未核实；不把 5 美元视为可复现报价。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@0x0SojalSec",
+        "url": "https://x.com/0x0SojalSec"
+      },
+      "demoUrl": "https://x.com/0x0SojalSec/status/2096014293443760198",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-118.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 196
+    },
+    {
+      "id": "work-3e15aebb81ba8296",
+      "name": "简易 3D 格斗游戏",
+      "description": "3D 格斗游戏演示",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@npaka123",
+        "url": "https://x.com/npaka123"
+      },
+      "demoUrl": "https://x.com/npaka123/status/2096014561652666386",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-119.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 197
+    },
+    {
+      "id": "work-a1fdbe4f21f557db",
+      "name": "3D 战斗编排的 Astra 与 Fable 对照",
+      "description": "作者认为 Fable 总体逻辑略好，但 Astra 的战斗编排更贴近现实。 战斗场景名称、统一提示及完整评分未公开；结论为作者主观比较。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@OmedVibeCodes",
+        "url": "https://x.com/OmedVibeCodes"
+      },
+      "demoUrl": "https://x.com/OmedVibeCodes/status/2096016463458951296",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-120.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 198
+    },
+    {
+      "id": "work-662781586936285d",
+      "name": "程序化悬浮古寺场景的模型对照",
+      "description": "沿用引用帖的提示：黄昏峡谷古寺、程序化 Three.js、布料、风、体积光和闪电，无外部资产。 作者认为 Astra 在细节、运镜、贴图和美感上更好。 任务细节取自同作者被引用的旧实验，根帖明确复用相同提示。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@pradeepXkapoor",
+        "url": "https://x.com/pradeepXkapoor"
+      },
+      "demoUrl": "https://x.com/pradeepXkapoor/status/2096016935519760581",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-121.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 199
+    },
+    {
+      "id": "work-82131a163ae009df",
+      "name": "可眨眼与挤压的交互饺子宴",
+      "description": "Astra Ultra 与 Three.js；作者称 15 分钟。 未独立运行，15 分钟为作者自述。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@mech_eng_dev",
+        "url": "https://x.com/mech_eng_dev"
+      },
+      "demoUrl": "https://x.com/mech_eng_dev/status/2096019217698967809",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-122.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 200
+    },
+    {
+      "id": "work-06cd409c615d9669",
+      "name": "原生 macOS 游戏的 Astra 与 Sol 单轮对照",
+      "description": "无跟进与修正，对照 Astra Ultra 和 Sol Ultra。 作者报告 Astra 32 分 32 秒、Sol 33 分 58 秒，两次合计约占 20x 套餐 5%。 时间与额度为作者自述；套餐百分比不等于 API 成本。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@arthurdisper",
+        "url": "https://x.com/arthurdisper"
+      },
+      "demoUrl": "https://x.com/arthurdisper/status/2096019292433404400",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-123.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 201
+    },
+    {
+      "id": "work-61b4b9b45306e91c",
+      "name": "单张图片生成弹珠台的局限测试",
+      "description": "作者认为视觉处理有效，但隐含机械行为知识仍不足。 保留失败与局部成功；未把可见墙体当完整可玩证明。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@Maoku",
+        "url": "https://x.com/Maoku"
+      },
+      "demoUrl": "https://x.com/Maoku/status/2096019402550583440",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-124.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 202
+    },
+    {
+      "id": "work-247a84fb5878acc0",
+      "name": "为 ScaleBot 构建热门短视频研究库",
+      "description": "作者称使用 Astra 一次生成。 产品方自述演示，功能和真实数据效果未独立验证。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@mikefutia",
+        "url": "https://x.com/mikefutia"
+      },
+      "demoUrl": "https://x.com/mikefutia/status/2096019572365181428",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-125.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 203
+    },
+    {
+      "id": "work-13b4d17a65dc9bf7",
+      "name": "在现有机甲项目上构建战斗游戏",
+      "description": "一次主提示，部分 Three.js 工作使用作者的 Crayon harness。 使用已有机甲项目，不能描述为完全从零。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@aniketjart",
+        "url": "https://x.com/aniketjart"
+      },
+      "demoUrl": "https://x.com/aniketjart/status/2096019868713984080",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-126.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 204
+    },
+    {
+      "id": "work-9120d42638daaa50",
+      "name": "游戏机风格的个人作品集网站",
+      "description": "作者称一轮完成。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@shotatykr",
+        "url": "https://x.com/shotatykr"
+      },
+      "demoUrl": "https://x.com/shotatykr/status/2096020111014670364",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-127.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 205
+    },
+    {
+      "id": "work-466526181e067f3a",
+      "name": "日经 225 期权交易数据视频化",
+      "description": "向 Astra 输入交易数据并一次生成。 仅记录数据呈现任务，未验证数据、计算或交易结论。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 模拟与科学可视化",
+      "author": {
+        "name": "@_map_universe_",
+        "url": "https://x.com/_map_universe_"
+      },
+      "demoUrl": "https://x.com/_map_universe_/status/2096020997887664450",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-128.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 206
+    },
+    {
+      "id": "work-9fea672e587d95bf",
+      "name": "单轮复刻苹果 107 秒宣传视频的测试",
+      "description": "沿用作者对各模型使用的固定视频重建任务，一次生成。 作者称 Astra 首次达到其预期。 属于作者自设基准和主观验收，未独立比对原片。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@pallavmac",
+        "url": "https://x.com/pallavmac"
+      },
+      "demoUrl": "https://x.com/pallavmac/status/2096022283642949797",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-129.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 207
+    },
+    {
+      "id": "work-4fe0fc2905dcb75c",
+      "name": "为町田 SEO 酒场制作网站",
+      "description": "作者表示该版本可用。 原帖仅展示网站，未验证线上功能与部署状态。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@shotatykr",
+        "url": "https://x.com/shotatykr"
+      },
+      "demoUrl": "https://x.com/shotatykr/status/2096022409359003965",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-130.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 208
+    },
+    {
+      "id": "work-d7028c8bad713f50",
+      "name": "照片转角色并集成演讲轨道作品集",
+      "description": "在网页搜索、Blender computer use 与代码间切换，生成资产后集成并反复检查调整。 作者的个人演示，未独立运行网站或检查三维资产。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@HowDevelop",
+        "url": "https://x.com/HowDevelop"
+      },
+      "demoUrl": "https://x.com/HowDevelop/status/2096023793772998704",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-131.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 209
+    },
+    {
+      "id": "work-25ebcb5814f1beb8",
+      "name": "在手机 ChatGPT Work 给视频添加注释",
+      "description": "作者在手机应用的 Work 中切换到 Astra 后执行。 原帖也讨论账户开放状态；这里只收录实际视频注释操作。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@taya_mama_AI",
+        "url": "https://x.com/taya_mama_AI"
+      },
+      "demoUrl": "https://x.com/taya_mama_AI/status/2096025522203762947",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-132.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 210
+    },
+    {
+      "id": "work-ae401bde86655d9d",
+      "name": "统筹虚构咖啡配送服务的宣传视频",
+      "description": "手机发出指令，由 Astra 统筹，Remotion 制作信息图，Higgsfield MCP 接入 Seedance 等视频模型。 Astra 承担设计与流程管理，视频画面包含其他模型生成。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@excel_niisan",
+        "url": "https://x.com/excel_niisan"
+      },
+      "demoUrl": "https://x.com/excel_niisan/status/2096025670388449650",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-133.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 211
+    },
+    {
+      "id": "work-a02882a8af938a14",
+      "name": "Lego Racers 1999 重建的速度与画面对照",
+      "description": "两个模型使用相同的一次性重建要求。 作者称 Astra 更快，Fable 5.1 更接近原作画面。 速度和视觉判断来自作者，无标准化计时或完整试玩验证。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@k2sbhai",
+        "url": "https://x.com/k2sbhai"
+      },
+      "demoUrl": "https://x.com/k2sbhai/status/2096026282094154134",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-134.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 212
+    },
+    {
+      "id": "work-dcbf85715d9d3b4a",
+      "name": "单轮生成室内空间漫游",
+      "description": "作者称一次生成。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@aigeboku",
+        "url": "https://x.com/aigeboku"
+      },
+      "demoUrl": "https://x.com/aigeboku/status/2096026883377013082",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-135.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 213
+    },
+    {
+      "id": "work-751b90525a33bd65",
+      "name": "为 YOLO 制作目标标注",
+      "description": "用于 YOLO 的标注演示 原帖未给出数据规模和标注准确率，未独立验证。",
+      "category": "tool",
+      "sourceCategory": "CheerSelfAI · 工程文件与代码迁移",
+      "author": {
+        "name": "@he81tuki26nichi",
+        "url": "https://x.com/he81tuki26nichi"
+      },
+      "demoUrl": "https://x.com/he81tuki26nichi/status/2096027634337747036",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-136.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 214
+    },
+    {
+      "id": "work-677b53efb2bb6951",
+      "name": "将 3D 模型的线框到贴图过程制成镜头展示",
+      "description": "在生成模型后追加指令，要求从线框逐渐添加纹理并用运镜呈现。 具体模型对象未在正文命名；记录的是有明示步骤的展示流程。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@excel_niisan",
+        "url": "https://x.com/excel_niisan"
+      },
+      "demoUrl": "https://x.com/excel_niisan/status/2096028906197512609",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-137.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 215
+    },
+    {
+      "id": "work-7807ae1b74dea9a3",
+      "name": "Sentinel 中的 DJ 卡车与灯光控制台",
+      "description": "作者称数分钟完成。 时间与完整性为作者自述；未测试灯控功能。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@cerspense",
+        "url": "https://x.com/cerspense"
+      },
+      "demoUrl": "https://x.com/cerspense/status/2096031686786224173",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-138.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 216
+    },
+    {
+      "id": "work-ca3c79bd44e37636",
+      "name": "乐谱视觉特效应用的首屏设计",
+      "description": "作者展示 Astra 生成的首屏并评价正面。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@ramonpiano_",
+        "url": "https://x.com/ramonpiano_"
+      },
+      "demoUrl": "https://x.com/ramonpiano_/status/2096032278472245437",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-139.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 217
+    },
+    {
+      "id": "work-ae9cbab5a167f6e4",
+      "name": "编写 AI 女友应用的演示报道",
+      "description": "Clavicular 展示的 AI 女友应用 资讯账号转述 Clavicular 的使用情况，未取得代码或独立验证。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@ClavicularNews",
+        "url": "https://x.com/ClavicularNews"
+      },
+      "demoUrl": "https://x.com/ClavicularNews/status/2096032333832806840",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-140.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 218
+    },
+    {
+      "id": "work-b8a4270ff6810825",
+      "name": "人形角色生成与 Fable 5.1 对照",
+      "description": "作者认为 Astra 有明显进步，并称剩余问题约需 1—2 次修正。 胜负和修正次数是作者判断。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@gimu_ai",
+        "url": "https://x.com/gimu_ai"
+      },
+      "demoUrl": "https://x.com/gimu_ai/status/2096032408420434415",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-141.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 219
+    },
+    {
+      "id": "work-29e6537c4869e048",
+      "name": "为游戏场景生成路径、资产与空间层次",
+      "description": "作者展示场景，并计划后续接入 Crayon。 Crayon 接入仍是后续计划，不能写成已完成。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@TusharXo",
+        "url": "https://x.com/TusharXo"
+      },
+      "demoUrl": "https://x.com/TusharXo/status/2096037482739683574",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-142.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 220
+    },
+    {
+      "id": "work-3b7f1e3bbe004be3",
+      "name": "Minecraft 红石电路制作",
+      "description": "作者测试Astra在Minecraft创建红石电路并展示结果。 未给电路功能或实际保存与运行检查。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@posi_posi8",
+        "url": "https://x.com/posi_posi8"
+      },
+      "demoUrl": "https://x.com/posi_posi8/status/2096039492968939702",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-143.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 221
+    },
+    {
+      "id": "work-63556fe7370d21df",
+      "name": "Vtuber Live2D 角色与表情尝试",
+      "description": "作者尝试让Astra一次创建Vtuber Live2D角色，自动生成表情差分，但未实现手脚动作。 保留部分完成与限制；未验证Live2D工程和绑定。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@aiclass_g2",
+        "url": "https://x.com/aiclass_g2"
+      },
+      "demoUrl": "https://x.com/aiclass_g2/status/2096041288261140711",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-144.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 222
+    },
+    {
+      "id": "work-ad6870eea20f9aaa",
+      "name": "在线画板绘制 Messi 致敬作品",
+      "description": "作者测试Astra寻找在线Paint并绘制致敬Messi的壁画，展示实时操作。 画面质量和操作完成度未独立验收。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@AlanDaitch",
+        "url": "https://x.com/AlanDaitch"
+      },
+      "demoUrl": "https://x.com/AlanDaitch/status/2096044340795641999",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-145.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 223
+    },
+    {
+      "id": "work-5ab3761516a711d0",
+      "name": "量子主题解说视频",
+      "description": "作者让Astra制作量子主题解说视频并展示一次生成结果。 未独立核验科学准确性、旁白和素材来源。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@kyutaro15",
+        "url": "https://x.com/kyutaro15"
+      },
+      "demoUrl": "https://x.com/kyutaro15/status/2096045534440210587",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-146.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 224
+    },
+    {
+      "id": "work-12c06bf2dfc45939",
+      "name": "酒店广告提示词与 MiniMax H3 成片",
+      "description": "作者让Astra编写广告prompt，经Topview MCP在Codex中调用MiniMaxH3生成酒店广告风格视频，发现文字生成不足并考虑今后用Remotion叠字。 现轮明确未用Remotion；旧Kling酒店片只作参照，不归Astra。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@Naonekozamurai",
+        "url": "https://x.com/Naonekozamurai"
+      },
+      "demoUrl": "https://x.com/Naonekozamurai/status/2096046087790596522",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-147.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 225
+    },
+    {
+      "id": "work-2820df28062a1daa",
+      "name": "Madison 城市飞行展示",
+      "description": "作者用Codex与Astra约20分钟制作美国威斯康星Madison的无人机飞越风格展示。 不是实际无人机拍摄；地理精度未核验，物理实验可视化为未来计划。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@birdman9550",
+        "url": "https://x.com/birdman9550"
+      },
+      "demoUrl": "https://x.com/birdman9550/status/2096046951657812207",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-148.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 226
+    },
+    {
+      "id": "work-57bb736507eef8f9",
+      "name": "进击的巨人风格游戏原型",
+      "description": "作者展示另一款用Astra制作的Attack on Titan风格游戏。 未给具体玩法和工程；不与其20星球游戏合并。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@hakmgpt",
+        "url": "https://x.com/hakmgpt"
+      },
+      "demoUrl": "https://x.com/hakmgpt/status/2096047406424928348",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-149.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 227
+    },
+    {
+      "id": "work-43dca768fdc3fc62",
+      "name": "随歌曲变化的 3D 企鹅舞蹈",
+      "description": "作者用Astra制作分析歌曲并生成对应企鹅动画的应用，称包含自建3D模型、灯光系统和50多种动画变体，每首歌有不同表现。 曲目分析、变体数量和动画同步未独立验证。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@manandua",
+        "url": "https://x.com/manandua"
+      },
+      "demoUrl": "https://x.com/manandua/status/2096047454219391018",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-150.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 228
+    },
+    {
+      "id": "work-03b44c982bfdea81",
+      "name": "按创作者风格生成游戏",
+      "description": "作者让Astra研究yungcontent并创建符合其风格的游戏，称一次生成。 未给具体风格判定或游戏机制，不推断实际研究来源。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@yungcontent",
+        "url": "https://x.com/yungcontent"
+      },
+      "demoUrl": "https://x.com/yungcontent/status/2096047904582721772",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-151.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 229
+    },
+    {
+      "id": "work-82eed0ec454d2844",
+      "name": "WebGL GTA6 风格游戏原型",
+      "description": "作者粗略要求Astra Pro制作WebGL可操作GTA6风格游戏，称20分钟完成展示版本。 不代表商业原作范围；未试玩机制。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@kgsi",
+        "url": "https://x.com/kgsi"
+      },
+      "demoUrl": "https://x.com/kgsi/status/2096048662304666098",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-152.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 230
+    },
+    {
+      "id": "work-e62bb4ecc6dee84d",
+      "name": "躲避撞人男子的交互游戏",
+      "description": "作者用Astra创建躲避撞人男子的游戏，被撞3次或反击3次即结束，含结尾演出和随机暴走角色。 仅虚构游戏机制，未独立测试难度和碰撞判定。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@AiFreak_tool",
+        "url": "https://x.com/AiFreak_tool"
+      },
+      "demoUrl": "https://x.com/AiFreak_tool/status/2096049700172648585",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-153.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 231
+    },
+    {
+      "id": "work-ade19d00b287ae2a",
+      "name": "风暴航海场景的模型对照",
+      "description": "Topview将Astra与Fable5.1用于同一风暴航海场景，展示波浪和人群画面并比较电影感。 平台自营主观对照；不假定Astra原生生成视频，底层工作流未细分。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@TopviewAIJP",
+        "url": "https://x.com/TopviewAIJP"
+      },
+      "demoUrl": "https://x.com/TopviewAIJP/status/2096053141838160045",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-154.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 232
+    },
+    {
+      "id": "work-8c02b8e9b7269c41",
+      "name": "深陵·秦宫星河交互地下世界",
+      "description": "作者把先前单个3D兵马俑项目升级为深陵·秦宫星河，用Astra、Blender和Three.js约30分钟生成120兵俑、自由漫游与星盘机关，称模型源码可编辑且本地可玩。 数量、工程和交互均未独立检查；初模与本次升级归同项目。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@servasyy_ai",
+        "url": "https://x.com/servasyy_ai"
+      },
+      "demoUrl": "https://x.com/servasyy_ai/status/2096055030675906575",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-155.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 233
+    },
+    {
+      "id": "work-1a1a6b65f931125f",
+      "name": "3D 汽车建模的 Astra 与 Fable 对照",
+      "description": "TypingMind展示让Astra与Fable5.1构建3D汽车的比较。 平台自营；具体prompt、工具、时间与评分未给。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@TypingMindApp",
+        "url": "https://x.com/TypingMindApp"
+      },
+      "demoUrl": "https://x.com/TypingMindApp/status/2096057056340177302",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-156.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 234
+    },
+    {
+      "id": "work-8d46417ba0a9fa48",
+      "name": "Krita 照片重绘与金门大桥添加",
+      "description": "转述官方示范：把照片交给Astra，经computer use在Krita画成梵高风格并添加金门大桥。 二手官方演示，不验证图像准确性；其余能力介绍不另算案例。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@xiaohu",
+        "url": "https://x.com/xiaohu"
+      },
+      "demoUrl": "https://x.com/xiaohu/status/2096057117061136838",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-157.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 235
+    },
+    {
+      "id": "work-d227f466c8bd0deb",
+      "name": "电脑操作钢琴演奏测试",
+      "description": "作者测试Astra computer use演奏一首钢琴曲并附录屏。 曲名、软件和完成质量未说明；不与其他作者同题合并。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@yanhua1010",
+        "url": "https://x.com/yanhua1010"
+      },
+      "demoUrl": "https://x.com/yanhua1010/status/2096057156202353027",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-158.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 236
+    },
+    {
+      "id": "work-3e1d2b98e18c362d",
+      "name": "办公室视频转可探索 3D 空间",
+      "description": "GMI Cloud称向Astra提供办公室视频，不到1小时得到接近原貌的可探索3D空间。 平台自营自述；未验证尺寸、还原度与可探索性。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@gmi_cloud",
+        "url": "https://x.com/gmi_cloud"
+      },
+      "demoUrl": "https://x.com/gmi_cloud/status/2096058488648798400",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-159.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 237
+    },
+    {
+      "id": "work-7b1099e4824dfe9e",
+      "name": "温泉小镇场景",
+      "description": "作者让Astra制作自己的温泉小镇世界并展示结果。 场景工具、交互和细节未说明。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@taishik_",
+        "url": "https://x.com/taishik_"
+      },
+      "demoUrl": "https://x.com/taishik_/status/2096059031475359906",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-160.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 238
+    },
+    {
+      "id": "work-9de2d21cf21a78fe",
+      "name": "一行提示生成 3D 游戏",
+      "description": "作者称用约一行提示让Astra制作精细3D游戏，主观认为超过Fable。 无游戏题材和玩法；不把主观优劣当基准。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@masahirochaen",
+        "url": "https://x.com/masahirochaen"
+      },
+      "demoUrl": "https://x.com/masahirochaen/status/2096061462032826495",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-162.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 239
+    },
+    {
+      "id": "work-3b279d23022dea0f",
+      "name": "经需求访谈生成视频编辑应用",
+      "description": "作者以先询问功能和规格的要求启动Astra，约30分钟生成视频编辑应用并认为达到实用水平。 实用性是作者主观判断；具体编辑功能和文件处理未验收。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@old_pgmrs_will",
+        "url": "https://x.com/old_pgmrs_will"
+      },
+      "demoUrl": "https://x.com/old_pgmrs_will/status/2096063127125434701",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-164.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 240
+    },
+    {
+      "id": "work-eebba4c09c50ea72",
+      "name": "双 PCB 穿戴设备外壳设计",
+      "description": "作者把PCB模型交给Astra，在Fusion360设计容纳两块板、电池、外部电源键和衣物磁吸结构的穿戴设备外壳。 3D打印、PCBA和通电均为下一步，未制造验证。",
+      "category": "tool",
+      "sourceCategory": "CheerSelfAI · 工程文件与代码迁移",
+      "author": {
+        "name": "@Peter05704721",
+        "url": "https://x.com/Peter05704721"
+      },
+      "demoUrl": "https://x.com/Peter05704721/status/2096064163831513165",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-165.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 241
+    },
+    {
+      "id": "work-fdd0220c616d46eb",
+      "name": "合唱音轨补掌声与乐谱跟随练习视频",
+      "description": "作者给Astra已购男高音2音轨、八声部乐谱PDF和参考视频，约20分钟按谱补合成掌声到mp3；再约20分钟制作乐谱随播放按小节高亮的练习视频。 未独立检查乐谱对齐和音频；产品化为未来设想，Fable5.1对照尚未执行。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@Gonnector",
+        "url": "https://x.com/Gonnector"
+      },
+      "demoUrl": "https://x.com/Gonnector/status/2096064375870333249",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-167.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 242
+    },
+    {
+      "id": "work-27a42fae59ad0734",
+      "name": "俯视角多人撤离射击游戏",
+      "description": "作者称Astra一次生成俯视角多人撤离射击游戏，图形、声音与玩法通过Blender和Unity完成。 多人、质量、速度与费用优于旧模型为作者主张；未实际测试。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@AlexFinn",
+        "url": "https://x.com/AlexFinn"
+      },
+      "demoUrl": "https://x.com/AlexFinn/status/2096065384290128372",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-168.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 243
+    },
+    {
+      "id": "work-f95cd7ae27b1cbca",
+      "name": "八款浏览器游戏的同题模型对照",
+      "description": "作者让Astra和Fable各生成8款浏览器游戏，主题包括躲避球、卡丁车、GTA、Mario、ARPG、网球、Flappy Bird及跑酷；报告Astra平均15分钟对47分钟，画面更好但游戏性较弱。 本视频只展示GTA、卡丁车与躲避球；整组自述作为1次比较实验，不拆8条。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@chenchengpro",
+        "url": "https://x.com/chenchengpro"
+      },
+      "demoUrl": "https://x.com/chenchengpro/status/2096066915504652776",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-169.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 244
+    },
+    {
+      "id": "work-046ef57b794d525c",
+      "name": "24 秒宇宙主题发布庆祝短片",
+      "description": "作者围绕Astra上线和额度重置制作24秒宇宙庆祝视频，列Astra、HyperFrames与ElevenLabs为制作工具。 音频与画面依赖工具；具体Astra执行步骤未详述。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@takamasa045",
+        "url": "https://x.com/takamasa045"
+      },
+      "demoUrl": "https://x.com/takamasa045/status/2096068927415849406",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-170.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 245
+    },
+    {
+      "id": "work-d5b33c158387fc02",
+      "name": "Apple Park 照片重建",
+      "description": "转述Astra依据数张照片在Blender重建Apple Park，包含环形建筑、内室、桌椅、景观与Steve Jobs Theater。 完全还原为宣传说法；未取原执行者工程和建筑精度。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@masahirochaen",
+        "url": "https://x.com/masahirochaen"
+      },
+      "demoUrl": "https://x.com/masahirochaen/status/2096071849079865785",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-171.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 246
+    },
+    {
+      "id": "work-3928a7173298aef6",
+      "name": "Blender iMac 与鼠标模型",
+      "description": "作者用Astra High要求在Blender创建iMac和鼠标并展示结果。 没有具体流程、尺寸或结构验收。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@diegocabezas01",
+        "url": "https://x.com/diegocabezas01"
+      },
+      "demoUrl": "https://x.com/diegocabezas01/status/2096072775865643194",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-172.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 247
+    },
+    {
+      "id": "work-97af573d7124b67a",
+      "name": "F1 赛车照片转可旋转 Three.js 模型",
+      "description": "作者给Astra一张Kimi Antonelli的Mercedes F1车照片，约15分钟制作可旋转的Three.js模型。 未验证几何准确性或模型工程。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@CoastalFuturist",
+        "url": "https://x.com/CoastalFuturist"
+      },
+      "demoUrl": "https://x.com/CoastalFuturist/status/2096073154686771380",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-173.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 248
+    },
+    {
+      "id": "work-d127d52e910412e5",
+      "name": "Theme Park 游戏重建",
+      "description": "作者把Theme Park的Wiki链接与DOS版说明书给Astra，要求制作游戏并展示一次生成结果。 文档理解和玩法覆盖未核验，不等于完整原作复制。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@nodchip",
+        "url": "https://x.com/nodchip"
+      },
+      "demoUrl": "https://x.com/nodchip/status/2096073907031921045",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-174.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 249
+    },
+    {
+      "id": "work-7b57c8f3f8788726",
+      "name": "Three.js 星月夜油画空间",
+      "description": "二手帖展示Astra将梵高星月夜转换为可进入的Three.js空间，描述立体笔触与流动漩涡。 原执行者未明确；不采信第一次听懂画家等宣传叙述。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@NFT_Chen",
+        "url": "https://x.com/NFT_Chen"
+      },
+      "demoUrl": "https://x.com/NFT_Chen/status/2096075112860856815",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-175.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 250
+    },
+    {
+      "id": "work-e31448bdcd1aed6a",
+      "name": "两张照片参考的 Canva 肖像",
+      "description": "作者给Astra两张本人照片，让其通过浏览器在Canva中绘制本人。 提问耗时和成本但未给数值，保持未知。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@nateherk",
+        "url": "https://x.com/nateherk"
+      },
+      "demoUrl": "https://x.com/nateherk/status/2096075129885204811",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-176.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 251
+    },
+    {
+      "id": "work-29efa8685af49ec4",
+      "name": "甜甜圈建模与糖霜落下展示动画",
+      "description": "作者先用Astra在Blender约10分钟渲染甜甜圈模型，再要求展示视频，得到糖霜落下动画和镜头运动。 两帖属于同一作品进展；未验模型及动画工程。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@op7418",
+        "url": "https://x.com/op7418"
+      },
+      "demoUrl": "https://x.com/op7418/status/2096077414157922681",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-177.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 252
+    },
+    {
+      "id": "work-b6bf1ec746001cd6",
+      "name": "3D 鹈鹕骑车模型演示",
+      "description": "作者转述群友用Astra制作3D骑车鹈鹕。 原作者身份、流程和模型文件缺失；不与其他作者同题实验强行合并。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@zhang_baoqing",
+        "url": "https://x.com/zhang_baoqing"
+      },
+      "demoUrl": "https://x.com/zhang_baoqing/status/2096077580155924741",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-178.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 253
+    },
+    {
+      "id": "work-53bc78361f5c1e04",
+      "name": "Astral War 浏览器多人射击游戏",
+      "description": "作者在旧Modern Claudefare项目上用Astra Ultra fast一天制作Astral War，结合Three.js、Meshy与ElevenLabs，称支持人类/亡灵、单人/多人、手柄、私房语音及最多12人权威服务器。 是现有游戏改造；网络稳定性、12人同房与声聊未独立测试。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@0xRishi",
+        "url": "https://x.com/0xRishi"
+      },
+      "demoUrl": "https://x.com/0xRishi/status/2096079660605997264",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-179.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 254
+    },
+    {
+      "id": "work-4ec50b42cb2f65fe",
+      "name": "为已有 PowerPoint 添加动画",
+      "description": "作者让Astra通过PC操作给已有PowerPoint添加自然动画；引用说明原文稿由Fable5.1和skills制作。 只把动画修改归Astra，非从零生成PPT；未验播放和兼容性。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@taiyo_ai_gakuse",
+        "url": "https://x.com/taiyo_ai_gakuse"
+      },
+      "demoUrl": "https://x.com/taiyo_ai_gakuse/status/2096079684626980876",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-180.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 255
+    },
+    {
+      "id": "work-e30ff1863140be67",
+      "name": "Grok Bot 数字团队配置",
+      "description": "作者把已设计的Grok Bot方案交给Astra computer use，称不到10分钟建立7个bot、2个群、5个skill和定时任务。 机器人创建开头未录到；未验证具体bot职责与运行结果。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@GeekCatX",
+        "url": "https://x.com/GeekCatX"
+      },
+      "demoUrl": "https://x.com/GeekCatX/status/2096081110354845903",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-181.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 256
+    },
+    {
+      "id": "work-26bb38b1b6b15a07",
+      "name": "参考图重建地球仪仪表盘",
+      "description": "作者沿用一张参考图及prompt测试Astra重建Three.js地球仪仪表盘，称一次补出图中未明说的日夜模式和2D/3D视图切换。 像素级和优于前代为单作者主观比较；未复验交互。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@hqmank",
+        "url": "https://x.com/hqmank"
+      },
+      "demoUrl": "https://x.com/hqmank/status/2096082432197837065",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-182.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 257
+    },
+    {
+      "id": "work-b3f961ce388e3c5a",
+      "name": "Hermès 巴黎生活方式广告提示词",
+      "description": "作者用Astra编写30秒巴黎生活方式Hermès时装广告提示词，再交给Seedance2.5生成视频，指定同一人物、Kelly手袋及丝巾的连续性。 为创作者品牌风格测试，不代表品牌委托或投放；视频来自Seedance。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@johnAGI168",
+        "url": "https://x.com/johnAGI168"
+      },
+      "demoUrl": "https://x.com/johnAGI168/status/2096082626364788752",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-184.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 258
+    },
+    {
+      "id": "work-7d089f6d00aaf8eb",
+      "name": "Photoshop 照片肖像绘制",
+      "description": "作者让Astra参考本人照片在Photoshop绘画并展示结果。 未检查绘制步骤和图像质量。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@icreatelife",
+        "url": "https://x.com/icreatelife"
+      },
+      "demoUrl": "https://x.com/icreatelife/status/2096083750870261882",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-185.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 259
+    },
+    {
+      "id": "work-ec7b10660eec288d",
+      "name": "Blender 模型到 Unity 游戏流程",
+      "description": "作者经Astra和Blender MCP自然语言建模，再由Unity CLI将模型做成游戏并报告运行成功。 未给具体游戏主题和工程；不推断玩法完整性。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@keitowebai",
+        "url": "https://x.com/keitowebai"
+      },
+      "demoUrl": "https://x.com/keitowebai/status/2096085354529144842",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-186.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 260
+    },
+    {
+      "id": "work-dfc11c8622a0e234",
+      "name": "七套穿搭连续展示的提示词",
+      "description": "作者用Astra编写同角色同场景连续展示7套Look的视频prompt，再以MiniMax H3生成视频，评价切换顺序、节点和动作更准确。 此前5套用Seedance2.0，不归Astra；效果自述且复杂prompt几乎耗尽一轮额度。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@Chengzilhy",
+        "url": "https://x.com/Chengzilhy"
+      },
+      "demoUrl": "https://x.com/Chengzilhy/status/2096086827467932140",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-187.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 261
+    },
+    {
+      "id": "work-b75497ab05284231",
+      "name": "吉萨大金字塔几何到影片",
+      "description": "平台用Astra创建吉萨大金字塔几何，再经Seedance2.5生成最终画面。 平台自营多工具展示；未验证历史或工程准确性。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096088339548115037",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-188.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 262
+    },
+    {
+      "id": "work-1202e063cd2b3428",
+      "name": "Hogwarts 场景整体生成测试",
+      "description": "作者让Astra High制作Hogwarts，认为空间和持续操作较强，但一次要求全部制作仍粗糙，建议按房间或资产拆解。 建议属于作者经验；未验证拆解后是否更好。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@YuYoshimuta",
+        "url": "https://x.com/YuYoshimuta"
+      },
+      "demoUrl": "https://x.com/YuYoshimuta/status/2096091847366242740",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-190.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 263
+    },
+    {
+      "id": "work-3f7a7fd744dbf502",
+      "name": "旧客厅扫描转 Blender 重建",
+      "description": "作者给Astra父母客厅的旧3D扫描，要求从头在Blender建模，称纹理来自自己的摄影测量扫描并生成程序化shaders，无下载资产。 有扫描输入，不是无素材从零；还原与资产来源未独立验收。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@bilawalsidhu",
+        "url": "https://x.com/bilawalsidhu"
+      },
+      "demoUrl": "https://x.com/bilawalsidhu/status/2096092080397246707",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-191.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 264
+    },
+    {
+      "id": "work-2de50d5b3fa5a7e4",
+      "name": "iPod 3D 模型与 Mac 对话展示 App",
+      "description": "作者首次安装Blender，让Astra建模iPod并做成Mac App，支持物理交互及Codex对话记录展示。 未验证App构建、交互和数据持久化。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@BystAnd3rs",
+        "url": "https://x.com/BystAnd3rs"
+      },
+      "demoUrl": "https://x.com/BystAnd3rs/status/2096092297381531713",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-192.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 265
+    },
+    {
+      "id": "work-10df98cfc5f78f64",
+      "name": "Pokepia 场景搭建与迭代",
+      "description": "作者连接Blender用Astra约10分钟搭好Pokepia基础场景，再调整两轮提示，总计约1小时和12%周额度。 额度及耗时为自述；未检查具体场景细节和工程。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@LerSentAI",
+        "url": "https://x.com/LerSentAI"
+      },
+      "demoUrl": "https://x.com/LerSentAI/status/2096092845962637622",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-193.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 266
+    },
+    {
+      "id": "work-a91052841da04e11",
+      "name": "已有个人网站的界面更新",
+      "description": "作者用6 Astra更新自己的站点，展示效果并反映token消耗快。 具体改动和token数未披露；不写成整站从零构建。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@KeKeYa88",
+        "url": "https://x.com/KeKeYa88"
+      },
+      "demoUrl": "https://x.com/KeKeYa88/status/2096092871208440314",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-194.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 267
+    },
+    {
+      "id": "work-95d76da624cbe183",
+      "name": "六复音减法合成器",
+      "description": "作者展示Astra一次生成的6-poly减法合成器。 未检查声部、振荡器和音频输出行为。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@yskmsd",
+        "url": "https://x.com/yskmsd"
+      },
+      "demoUrl": "https://x.com/yskmsd/status/2096092961780228228",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-195.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 268
+    },
+    {
+      "id": "work-ebbbd445c6348c7f",
+      "name": "黑洞诞生的 WebGL 演示内容",
+      "description": "作者让Astra用WebGL制作黑洞诞生主题的幻灯或演示内容，约20分钟产出。 科学表述和视觉物理精度未核验。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 模拟与科学可视化",
+      "author": {
+        "name": "@zeeeeeen",
+        "url": "https://x.com/zeeeeeen"
+      },
+      "demoUrl": "https://x.com/zeeeeeen/status/2096093614397170104",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-196.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 269
+    },
+    {
+      "id": "work-5631717b23d01996",
+      "name": "Product Design 插件制作 AI 科普个人网站",
+      "description": "作者在Codex安装Product Design插件，用一句需求生成G哥太空漫步站点，含Hero、AI主题卡片、学习路径、介绍和CTA。 结果依赖插件；未验证上线、移动端和用户效果。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@goan999999",
+        "url": "https://x.com/goan999999"
+      },
+      "demoUrl": "https://x.com/goan999999/status/2096093868118708666",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-197.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 270
+    },
+    {
+      "id": "work-ed12fe6a61e81c22",
+      "name": "悉尼歌剧院代码建模与渲染",
+      "description": "Higgsfield用Astra输出悉尼歌剧院代码，Blender转成可编辑几何，Cycles进行路径追踪光照。 平台自述；没有建筑精度或工程验收。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096095994991800573",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-199.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 271
+    },
+    {
+      "id": "work-01d5b6f1dcde4744",
+      "name": "游乐场高速跑酷动态分镜",
+      "description": "作者用Astra和TypeScript/Remotion在笔记本上数分钟构建游乐场跑酷动态分镜，要求WebGL共用3D坐标、不同高度设施和多机位，渲染为MP4。 prompt约束不等于每项已验收；未读取成片工程或检查镜头接触连续性。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@Kashiko_AIart",
+        "url": "https://x.com/Kashiko_AIart"
+      },
+      "demoUrl": "https://x.com/Kashiko_AIart/status/2096096560690209130",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-200.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 272
+    },
+    {
+      "id": "work-e0d80eb328d9e38b",
+      "name": "苏州博物馆庭园重建与配乐巡游",
+      "description": "作者给Astra一个网页和prompt，在Blender重建苏州博物馆庭园并输出60秒连续漫游，称模型自行调用MiniMax Music3生成古琴、古筝、钢琴与大提琴配乐。 网页和建筑还原度未验证；配乐由MiniMax生成。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@whosamberella",
+        "url": "https://x.com/whosamberella"
+      },
+      "demoUrl": "https://x.com/whosamberella/status/2096096998092841449",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-201.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 273
+    },
+    {
+      "id": "work-d9822c080cad9a5c",
+      "name": "最小可玩 3D 格斗游戏",
+      "description": "作者让Codex中的Astra制作最低限度能运行的3D格斗游戏并展示结果。 未试玩检验动作和碰撞。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@alfredplpl",
+        "url": "https://x.com/alfredplpl"
+      },
+      "demoUrl": "https://x.com/alfredplpl/status/2096098790986109047",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-202.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 274
+    },
+    {
+      "id": "work-bcff9f92548d47b5",
+      "name": "3D 怪兽养成游戏原型",
+      "description": "作者使用Astra制作怪兽养成游戏，展示简单prompt生成的3D版本，仍认为继续打磨可提升。 进行中原型，不视为完整高品质游戏。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@seki_anos",
+        "url": "https://x.com/seki_anos"
+      },
+      "demoUrl": "https://x.com/seki_anos/status/2096099608531538303",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-203.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 275
+    },
+    {
+      "id": "work-7945b3ee95d39d2e",
+      "name": "NES 烈火风格射击游戏",
+      "description": "作者让Astra创建类似Summer Carnival92烈火的NES射击游戏，采用KITAQFC编译器、KUROSAKI调试模拟器与SARAKURA观测平台，无敌模式录屏。 录屏用无敌模式；未在NES实机验收，工具还未公开发布。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@bartaro",
+        "url": "https://x.com/bartaro"
+      },
+      "demoUrl": "https://x.com/bartaro/status/2096099649275019512",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-204.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 276
+    },
+    {
+      "id": "work-bfe337c32a2ee672",
+      "name": "星际旅行浏览器游戏",
+      "description": "作者让Astra制作以Astra星群旅行为主题的浏览器游戏。 玩法与运行情况未独立检查。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@AILogDev",
+        "url": "https://x.com/AILogDev"
+      },
+      "demoUrl": "https://x.com/AILogDev/status/2096101439336743159",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-205.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 277
+    },
+    {
+      "id": "work-3d694a6d14e78d58",
+      "name": "巴比伦空中花园的描述重建",
+      "description": "Higgsfield让Astra建立空中花园几何，再用Seedance2.5生成最终画面。 未发现实物的历史建筑属概念重建，不是考古验证。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096101502045835527",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-206.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 278
+    },
+    {
+      "id": "work-921074fa02bc407b",
+      "name": "动作捕捉到 Unity 的重定向管线",
+      "description": "作者用3个Astra Medium与1个xHigh运行goal约2小时，打通模型、绑定、动作/面部/手指捕捉重定向至Unity测试，称用约12%周额度。 建立在卡住一两个月的已有工程上；指标和完整效果为自述。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@DLKFZWilliam2",
+        "url": "https://x.com/DLKFZWilliam2"
+      },
+      "demoUrl": "https://x.com/DLKFZWilliam2/status/2096106328787951710",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-207.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 279
+    },
+    {
+      "id": "work-ed9f0d00197d178e",
+      "name": "阿尔忒弥斯神庙的描述到几何重构",
+      "description": "Higgsfield让Astra依据古代描述生成可编辑神庙几何，Seedance2.5加入电影化画面。 不验证历史建筑尺寸与真实性；平台自营多工具流程。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096109301916205380",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-208.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 280
+    },
+    {
+      "id": "work-e86ffc1f3fd760b6",
+      "name": "こけこけ角色宇宙漂浮动画",
+      "description": "作者把已生成的こけこけ3D模型交给Astra，制作角色在宇宙漂浮的视频。 现有模型创建归属未完整明确；只把本次动画任务归Astra。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@akifumi_ai",
+        "url": "https://x.com/akifumi_ai"
+      },
+      "demoUrl": "https://x.com/akifumi_ai/status/2096110251397562826",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-209.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 281
+    },
+    {
+      "id": "work-7a80b02e881a8b57",
+      "name": "Raven 个人项目介绍视频",
+      "description": "作者用Astra的3D与网页能力制作个人项目raven的介绍视频，先提供期望风格。 未取得完整工程或验证视频对产品描述准确性。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@zhengli",
+        "url": "https://x.com/zhengli"
+      },
+      "demoUrl": "https://x.com/zhengli/status/2096110412320350680",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-210.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 282
+    },
+    {
+      "id": "work-68b09dd470855fe4",
+      "name": "微鼠迷宫探索模拟器与算法改进",
+      "description": "作者让Astra制作微鼠探索模拟器并改进探索算法。 未给算法指标或实体机器人测试。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 模拟与科学可视化",
+      "author": {
+        "name": "@xfa273",
+        "url": "https://x.com/xfa273"
+      },
+      "demoUrl": "https://x.com/xfa273/status/2096110473989197942",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-211.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 283
+    },
+    {
+      "id": "work-f49ede1a423901a3",
+      "name": "手游广告转可玩浏览器游戏",
+      "description": "作者用Astra参考手机游戏广告，经Blender构建不到30分钟的小型浏览器游戏，认为与参考接近。 广告和具体游戏名未写，未验证相似度与玩法。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@buildingadlicio",
+        "url": "https://x.com/buildingadlicio"
+      },
+      "demoUrl": "https://x.com/buildingadlicio/status/2096111709496680842",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-212.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 284
+    },
+    {
+      "id": "work-4779e2f813788fc5",
+      "name": "Clip Studio 参考角色逐笔绘制",
+      "description": "作者让Astra操作Clip Studio逐笔画附件角色，展示完成作品并讨论观察绘制过程的体验。 未声明与后续草稿上色测试为同图，暂不合并；作品质量未独立验收。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@gigabit_million",
+        "url": "https://x.com/gigabit_million"
+      },
+      "demoUrl": "https://x.com/gigabit_million/status/2096111940078858734",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-213.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 285
+    },
+    {
+      "id": "work-f06de90cd85c67b6",
+      "name": "奥林匹亚宙斯神像的几何与成片",
+      "description": "Higgsfield依据文字描述用Astra写3D结构，再以Seedance2.5生成奥林匹亚宙斯神像影片。 历史建筑为想象重构，不是考古准确性验收；平台自营展示。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096112876360790493",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-214.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 286
+    },
+    {
+      "id": "work-4659d6b771c55978",
+      "name": "AI 城市视频转可行走 3D 空间",
+      "description": "作者用Astra参考Midjourney加Kling生成的街道视频，制作可自行行走的3D空间，当前是首次产物，细腻材质仍待完善。 视频模型提供视觉参考；未检验场景拓扑与交互。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@onofumi_AI",
+        "url": "https://x.com/onofumi_AI"
+      },
+      "demoUrl": "https://x.com/onofumi_AI/status/2096113261204979897",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-215.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 287
+    },
+    {
+      "id": "work-67f59136bf65ae01",
+      "name": "官方指南转 95 秒日语模型解说",
+      "description": "作者把OpenAI官方指南交给Codex中的Astra，生成含3D演出和日语旁白的95秒解说视频，并在途中调整指令与思考深度。 未独立核查解说事实、声音来源或完整工程。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@kawai_design",
+        "url": "https://x.com/kawai_design"
+      },
+      "demoUrl": "https://x.com/kawai_design/status/2096115698124865645",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-216.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 288
+    },
+    {
+      "id": "work-3496698d1acefafb",
+      "name": "Three.js WebGPU 动画网站教程",
+      "description": "作者录制10分钟教程，展示使用Astra和Three.js WebGPU制作3D动画网站。 award-winning是宣传形容，未验证实际获奖；教程未完整播放。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@viktoroddy",
+        "url": "https://x.com/viktoroddy"
+      },
+      "demoUrl": "https://x.com/viktoroddy/status/2096115863158133107",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-217.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 289
+    },
+    {
+      "id": "work-f6d9926d6dc57301",
+      "name": "照片转セラドニア与角蛙 3D 模型",
+      "description": "作者用Astra根据照片制作セラドニア与角蛙两类动物的3D模型，并与实物对比。 未确认首个动物日文名的规范中文译名，保留原文；未验几何。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@nakanokaeru",
+        "url": "https://x.com/nakanokaeru"
+      },
+      "demoUrl": "https://x.com/nakanokaeru/status/2096116438398615974",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-218.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 290
+    },
+    {
+      "id": "work-81260287664df4c2",
+      "name": "肖像参考反推交互布光方案",
+      "description": "作者用Codex和Astra Ultra制作肖像布光工具，输入照片后生成可调主灯、轮廓灯、反光板与相机方案，改灯同步改变脸部阴影；约20分钟初版后迭代并剪辑介绍视频。 仅轻量原型，不能视为真实物理反演精确结果。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@takeborn299",
+        "url": "https://x.com/takeborn299"
+      },
+      "demoUrl": "https://x.com/takeborn299/status/2096116536327197129",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-219.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 291
+    },
+    {
+      "id": "work-de545e9886f1c57e",
+      "name": "Blender 资产驱动的浏览器游戏",
+      "description": "作者让Astra用Blender生成游戏资产，称一次生成的游戏已在浏览器运行。 游戏题材、玩法及完整性未说明。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@chimze_art",
+        "url": "https://x.com/chimze_art"
+      },
+      "demoUrl": "https://x.com/chimze_art/status/2096117651911106570",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-220.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 292
+    },
+    {
+      "id": "work-e20d6f1f2a070a71",
+      "name": "浏览器 FPS 的武器手感与瞄准镜",
+      "description": "作者用Astra构建浏览器FPS，再迭代更重后坐力、武器重量和冲击，并要求仅镜内放大，附试玩链接。 多轮打磨，不是一次完成；未独立试玩枪械反馈。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@superalesha",
+        "url": "https://x.com/superalesha"
+      },
+      "demoUrl": "https://x.com/superalesha/status/2096117875908235764",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-221.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 293
+    },
+    {
+      "id": "work-ea25c2b068337430",
+      "name": "单张帆船图片转可编辑 3D",
+      "description": "作者安装Blender后把帆船图片给Astra，让其编写代码在Blender重建，不配置MCP，得到细节粗略但可编辑的3D。 未检验比例、拓扑和可编辑性。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@Kohaku_NFT",
+        "url": "https://x.com/Kohaku_NFT"
+      },
+      "demoUrl": "https://x.com/Kohaku_NFT/status/2096120541816205631",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-222.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 294
+    },
+    {
+      "id": "work-6c93e55edb0a2a79",
+      "name": "HTML 重制 Machine Age 风格发布视频",
+      "description": "作者在自有HyperFrames harness运行Astra，仅用HTML重制a16z Machine Age视频为模型发布片。 原片为参考；完整code2video基准仍在运行，未交付基准结果。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@liu8in",
+        "url": "https://x.com/liu8in"
+      },
+      "demoUrl": "https://x.com/liu8in/status/2096120563156779229",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-223.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 295
+    },
+    {
+      "id": "work-61868c8df139d7d8",
+      "name": "飞机工厂的实时 3D 制造模拟",
+      "description": "作者要求Astra研究飞机制造与Airsup精益生产资料，设计Texas喷气机工厂，建立实时Three.js模拟、测试并部署。 工厂设计可行性、制造数据和模拟精度未独立验收。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 模拟与科学可视化",
+      "author": {
+        "name": "@konstantinsaifo",
+        "url": "https://x.com/konstantinsaifo"
+      },
+      "demoUrl": "https://x.com/konstantinsaifo/status/2096122429319852319",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-224.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 296
+    },
+    {
+      "id": "work-f4539d468d473f25",
+      "name": "电子表格头像创作",
+      "description": "作者让Astra在电子表格中围绕自己的头像进行创作并展示结果。 根帖没有软件和单元格实现细节，不推断像素数量或格式。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@yungcontent",
+        "url": "https://x.com/yungcontent"
+      },
+      "demoUrl": "https://x.com/yungcontent/status/2096122927221805462",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-225.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 297
+    },
+    {
+      "id": "work-7fe40bbf5aa287a5",
+      "name": "在线演奏录制并交付音乐文件",
+      "description": "作者让Astra通过computer use寻找能在线演奏录制的网站，交付mp3，再转成mp4；称歌曲用掉5小时额度80%，转视频耗尽剩余。 音乐质量和原创性未核验；额度不是费用。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@trxuanxw",
+        "url": "https://x.com/trxuanxw"
+      },
+      "demoUrl": "https://x.com/trxuanxw/status/2096123074081091753",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-226.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 298
+    },
+    {
+      "id": "work-7feeb81639f811bc",
+      "name": "赛博朋克横版游戏的配色测试",
+      "description": "作者测试Astra生成赛博朋克横版游戏，观察模型持续偏向粉彩，但认为仍是该组测试中最好结果。 比较模型、prompt与评价标准未完整披露；主观测试。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@NeoAIForecast",
+        "url": "https://x.com/NeoAIForecast"
+      },
+      "demoUrl": "https://x.com/NeoAIForecast/status/2096123621978812526",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-227.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 299
+    },
+    {
+      "id": "work-589741280007327b",
+      "name": "鼠标操作绘制自画像",
+      "description": "作者让Astra computer use绘制自己的画像，称画面全部由AI鼠标操作完成。 根帖未指明软件；其他相同媒体转载声称Canva可作为补充，当前不臆定。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@keitowebai",
+        "url": "https://x.com/keitowebai"
+      },
+      "demoUrl": "https://x.com/keitowebai/status/2096124169406775325",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-228.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 300
+    },
+    {
+      "id": "work-cbd4589bcae2eb6e",
+      "name": "Blender 一级方程式赛车模型",
+      "description": "作者用Astra Extra High经computer use在Blender制作F1赛车模型，报告23分34秒。 未验证几何尺寸或工程模型可用性。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@Conor_D_Dart",
+        "url": "https://x.com/Conor_D_Dart"
+      },
+      "demoUrl": "https://x.com/Conor_D_Dart/status/2096125193580113957",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-229.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 301
+    },
+    {
+      "id": "work-0fec578f2c02638e",
+      "name": "Canva 肖像绘制演示",
+      "description": "作者展示或建议让Astra在Canva绘制本人肖像。 未给原执行者或实际绘画过程说明；不与不同媒体的同题肖像强行合并。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@vision_ia",
+        "url": "https://x.com/vision_ia"
+      },
+      "demoUrl": "https://x.com/vision_ia/status/2096125394470506713",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-230.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 302
+    },
+    {
+      "id": "work-f9d7b11155ce1d00",
+      "name": "ChatGPT Work 云端 PSP 游戏开发",
+      "description": "作者经3至4轮对话让Astra完成PSP游戏的建模、绑定、构建测试，并在云端自动设置PPSSPP环境录制视频。 不是单次指令；未在PSP实机验证。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@bunkaich",
+        "url": "https://x.com/bunkaich"
+      },
+      "demoUrl": "https://x.com/bunkaich/status/2096126334628139221",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-231.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 303
+    },
+    {
+      "id": "work-da1cdf46ce2ee4e0",
+      "name": "Jeep 游戏的 Astra High 复测",
+      "description": "作者用Astra High复测此前Sol Ultra提示并展示Jeep游戏，提到增加鸟鸣。 Jeep主题由同媒体转载补证；未获取完整prompt或实际用量。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@SadAlbert10",
+        "url": "https://x.com/SadAlbert10"
+      },
+      "demoUrl": "https://x.com/SadAlbert10/status/2096126384964088230",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-232.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 304
+    },
+    {
+      "id": "work-9f352242085664c3",
+      "name": "CROWNFALL 第一人称射击游戏",
+      "description": "作者称Astra在10分钟内生成带Kael角色的CROWNFALL FPS，未使用Blender MCP。 不采信AAA品质宣传；功能完整性未试玩验证。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@HexxRL",
+        "url": "https://x.com/HexxRL"
+      },
+      "demoUrl": "https://x.com/HexxRL/status/2096126718930997609",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-233.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 305
+    },
+    {
+      "id": "work-04e9c9578018d496",
+      "name": "实时棋类游戏胶囊演出修复",
+      "description": "作者用Astra修复过去反复未修好的胶囊演出，明确产物为游戏内资产，引用同作者无回合实时棋类项目。 不是AI视频；关卡和地形机制仍是后续计划。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@ShadeLurk",
+        "url": "https://x.com/ShadeLurk"
+      },
+      "demoUrl": "https://x.com/ShadeLurk/status/2096127073479987638",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-234.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 306
+    },
+    {
+      "id": "work-e3975988da58852c",
+      "name": "Legora 多文档错误核对测试",
+      "description": "转述Legora用Astra在数分钟内比较41份文档并找到预置4处错误的测试。 作者明确尚未亲测；仅二手基准，文档内容与错误设置未读取。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 专业研究与安全评测",
+      "author": {
+        "name": "@futuristufuk",
+        "url": "https://x.com/futuristufuk"
+      },
+      "demoUrl": "https://x.com/futuristufuk/status/2096127426698867052",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-235.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 307
+    },
+    {
+      "id": "work-9e129c0dcde9d961",
+      "name": "内容模板开头与展示结构优化",
+      "description": "作者让Astra Ultra优化两个内容模板，约5分钟将热点焦虑开头改为具体场景问题与产品展示，并认为增加了可选写作方式。 不是所有文章都适用；100%到18%额度为作者观察，不作质量或成本保证。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@aehyok",
+        "url": "https://x.com/aehyok"
+      },
+      "demoUrl": "https://x.com/aehyok/status/2096128961470226493",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-236.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 308
+    },
+    {
+      "id": "work-c20cfac0f30858e6",
+      "name": "网页版宝可梦游戏原型",
+      "description": "作者称让Astra一次生成网页版宝可梦游戏并展示结果。 低细节自述，未核查具体玩法、范围或试玩。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@zhengli",
+        "url": "https://x.com/zhengli"
+      },
+      "demoUrl": "https://x.com/zhengli/status/2096130504538091525",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-237.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 309
+    },
+    {
+      "id": "work-8d80c6c6a9945d9d",
+      "name": "可编辑 Blender 蒸汽机车",
+      "description": "二手帖称Astra经computer use在Blender构建可编辑蒸汽机车3D模型。 未给原执行者和工程；不验证结构精度。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@MohammadMsft",
+        "url": "https://x.com/MohammadMsft"
+      },
+      "demoUrl": "https://x.com/MohammadMsft/status/2096131855284056073",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-238.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 310
+    },
+    {
+      "id": "work-f23bb4c678d1be17",
+      "name": "T-rex 模型绑定与动画",
+      "description": "Tripo创建的霸王龙模型由Astra进行绑定和动画，使用Three.js渲染。 不把原始模型生成归Astra；未验绑定与骨骼质量。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@majidmanzarpour",
+        "url": "https://x.com/majidmanzarpour"
+      },
+      "demoUrl": "https://x.com/majidmanzarpour/status/2096133339329536249",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-239.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 311
+    },
+    {
+      "id": "work-897af50819633312",
+      "name": "HyperFrames 与本地旁白的发布视频",
+      "description": "作者用Astra最高档结合HyperFrames制作发布视频，使用Voicebox在本地生成自己的声音作为旁白。 音视频依赖外部工具；未独立核对工程和完整流程。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@SuguruKun_ai",
+        "url": "https://x.com/SuguruKun_ai"
+      },
+      "demoUrl": "https://x.com/SuguruKun_ai/status/2096133389107769703",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-240.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 312
+    },
+    {
+      "id": "work-815c709e71027a68",
+      "name": "演示文稿到产品包装与交互提案网页",
+      "description": "作者用一个prompt让Astra约40分钟连续生成配图PowerPoint、logo、3D产品包装及可拖动模型和动态报价图表的Web演示并部署。 未查文件内容、部署地址和商业验收。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@excel_niisan",
+        "url": "https://x.com/excel_niisan"
+      },
+      "demoUrl": "https://x.com/excel_niisan/status/2096135152246329556",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-241.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 313
+    },
+    {
+      "id": "work-5de0958da6ce7153",
+      "name": "Odyssey 风格关卡的构建与通关录屏",
+      "description": "AIHubMix用Astra制作8平台3月亮的关卡，包含回旋帽攻击、金币敌人、检查点与触控；报告真实键盘7跳5掷帽收集3月亮零跌落并录制720p/30fps音画。 平台自营自测；未独立复跑游戏和测试。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@AiHubMix",
+        "url": "https://x.com/AiHubMix"
+      },
+      "demoUrl": "https://x.com/AiHubMix/status/2096135808243876152",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-242.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 314
+    },
+    {
+      "id": "work-3f5868e0d2eef1a7",
+      "name": "Contra 风格游戏重建",
+      "description": "作者称Astra在30分钟内零样本生成旧Contra风格游戏。 怀旧相似度是主观感觉，不代表完整原作机制。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@Saboo_Shubham_",
+        "url": "https://x.com/Saboo_Shubham_"
+      },
+      "demoUrl": "https://x.com/Saboo_Shubham_/status/2096135898425647292",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-243.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 315
+    },
+    {
+      "id": "work-812186901bf239c4",
+      "name": "角色打碎浏览器画面的特效",
+      "description": "作者让Astra实现屏幕人物破坏浏览器画面的视觉交互功能。 这是画面特效描述，不推断实际破坏浏览器或系统；未验证实现。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@stella_24r",
+        "url": "https://x.com/stella_24r"
+      },
+      "demoUrl": "https://x.com/stella_24r/status/2096135909926416823",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-244.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 316
+    },
+    {
+      "id": "work-eb07c876cd951649",
+      "name": "虚拟人物 UGC 的参考图与视频提示词流程",
+      "description": "作者在Codex中把Seedance2.5提示指南做成skill，用Astra组织GPT Images参考图与30秒虚构人物UGC视频prompt，经Seedance480p生成再由Topaz放大2K。 视频生成归Seedance，放大归Topaz；人物自然程度为主观评估。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@tanabe_fragm",
+        "url": "https://x.com/tanabe_fragm"
+      },
+      "demoUrl": "https://x.com/tanabe_fragm/status/2096136682055864564",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-245.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 317
+    },
+    {
+      "id": "work-5d0f42471b24669d",
+      "name": "科幻工业中庭的角色交互场景",
+      "description": "作者让Astra制作科幻工业中庭，通过Blender建模和Three.js交互，采用授权底模与动作素材，再打磨装备材质光照和步行动作，录制页面实操。 依赖外部资产与动作；角色自然程度未独立验收。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@servasyy_ai",
+        "url": "https://x.com/servasyy_ai"
+      },
+      "demoUrl": "https://x.com/servasyy_ai/status/2096137415895494816",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-246.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 318
+    },
+    {
+      "id": "work-fe7b4cf9c0342a73",
+      "name": "TradingView 图表预读与标线",
+      "description": "作者称让Astra打开TradingView图表，绘制趋势线、阻力线、Fibonacci和波浪理论标记，并给人工交易前的初步读图结论。 仅记录辅助标注流程，低相关交易策略是后续设想；没有收益或预测有效性证据。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@jesselaunz",
+        "url": "https://x.com/jesselaunz"
+      },
+      "demoUrl": "https://x.com/jesselaunz/status/2096141540771111103",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-247.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 319
+    },
+    {
+      "id": "work-e2473cf7a4f04215",
+      "name": "Driftwake 水上战斗游戏",
+      "description": "作者发布用Astra制作的Driftwake，描述为3D roguelike水上战斗游戏并提供链接。 未独立试玩或核查机制。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@_nilni",
+        "url": "https://x.com/_nilni"
+      },
+      "demoUrl": "https://x.com/_nilni/status/2096141925019775334",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-249.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 320
+    },
+    {
+      "id": "work-21905d28ce0d5b9e",
+      "name": "咖啡店照片转 Blender 漫游",
+      "description": "作者给Astra咖啡店照片，重建木吊顶、灯带、烘豆机、货架和植物，生成15秒竖屏漫游及可编辑Blender工程，承认还原度仍需提升。 未读取工程或衡量实际几何误差。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@harrisonitsme",
+        "url": "https://x.com/harrisonitsme"
+      },
+      "demoUrl": "https://x.com/harrisonitsme/status/2096143359505269079",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-251.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 321
+    },
+    {
+      "id": "work-8e50c4a9276bc118",
+      "name": "限时寻找可疑包裹游戏",
+      "description": "作者用Astra Ultra约8小时构建在倒计时内寻找可疑包裹的游戏，附试玩链接。 引用早帖仅26分钟和token，后帖才确认具体任务；不相加两个阶段计时。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@adamlyttleapps",
+        "url": "https://x.com/adamlyttleapps"
+      },
+      "demoUrl": "https://x.com/adamlyttleapps/status/2096149581885309297",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-254.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 322
+    },
+    {
+      "id": "work-8139ee9f22e03412",
+      "name": "聊天 UI 组件演示录屏",
+      "description": "作者让Astra为自己的shadcn/ui聊天组件录制演示，该组件包含模型切换、可搜索历史和文件附件。 Astra在当前证据中的角色是录屏，不能把原组件开发也归给它。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@ephraimduncan",
+        "url": "https://x.com/ephraimduncan"
+      },
+      "demoUrl": "https://x.com/ephraimduncan/status/2096149900417192106",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-255.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 323
+    },
+    {
+      "id": "work-f78bcd91ff93cc69",
+      "name": "Clip Studio 草图上色未完成测试",
+      "description": "作者只给草稿风格参考图，让Astra在Clip Studio逐笔画线稿与上色，观察到遮住文字后撤回改色，1小时仍未完成。 保留未完成结果；不把自动操作当成交付成功。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@gigabit_million",
+        "url": "https://x.com/gigabit_million"
+      },
+      "demoUrl": "https://x.com/gigabit_million/status/2096150291033063514",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-256.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 324
+    },
+    {
+      "id": "work-12be9eec6ba2a54b",
+      "name": "丛林寺庙与神猴守护者场景对照",
+      "description": "作者让Astra用HTML和Three.js生成丛林寺庙唤醒巨大神猴守护者场景，沿用Fable测试prompt，认为Astra清晰度强但仍偏好Fable照明。 单次主观视觉比较；未核查源码和相同条件。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@BuildFastWithAI",
+        "url": "https://x.com/BuildFastWithAI"
+      },
+      "demoUrl": "https://x.com/BuildFastWithAI/status/2096150942894948547",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-257.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 325
+    },
+    {
+      "id": "work-7e64153ac09b4a52",
+      "name": "复古 RPG 战斗攻击特效",
+      "description": "作者让Astra制作旧勇者斗恶龙风格战斗的攻击特效，认为效果改善但招式命名很差。 画面质量为主观评价；未提供游戏工程。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@kojikagames",
+        "url": "https://x.com/kojikagames"
+      },
+      "demoUrl": "https://x.com/kojikagames/status/2096153821907124464",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-259.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 326
+    },
+    {
+      "id": "work-6e0788f339f478d5",
+      "name": "Minecraft 风格游戏原型",
+      "description": "作者指示Astra制作Minecraft风格游戏，并展示首次生成结果。 未说明具体机制和功能覆盖；不等于完整Minecraft。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@daitenP",
+        "url": "https://x.com/daitenP"
+      },
+      "demoUrl": "https://x.com/daitenP/status/2096154379397247092",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-260.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 327
+    },
+    {
+      "id": "work-4b4c8bdc146f712a",
+      "name": "SKYBREAK 武装飞车战斗游戏",
+      "description": "作者展示Astra Pro制作的SKYBREAK，用武装飞车进行大逃杀战斗，认为AI对手过强。 游戏平衡与可玩性未独立验证。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@gosrum",
+        "url": "https://x.com/gosrum"
+      },
+      "demoUrl": "https://x.com/gosrum/status/2096155638758019226",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-261.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 328
+    },
+    {
+      "id": "work-86de786bdb747c66",
+      "name": "波罗蜜开放世界游戏",
+      "description": "作者用Astra制作波罗蜜世界，以佛陀为主角切换五种神通、积累波罗蜜并击败魔罗，提供试玩链接。 未独立试玩或评价宗教叙事准确性。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@naga3",
+        "url": "https://x.com/naga3"
+      },
+      "demoUrl": "https://x.com/naga3/status/2096156076618187111",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-262.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 329
+    },
+    {
+      "id": "work-f188a8f2db949d9e",
+      "name": "Excalidraw 镜面自拍绘制",
+      "description": "作者让Astra通过浏览器在Excalidraw逐笔绘画并上色自拍，称约6分钟、5%额度，保留卷发、眼镜、手机和手表，结果仍粗糙。 额度与耗时自述；未独立评价肖像还原。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@Kappaemme1926",
+        "url": "https://x.com/Kappaemme1926"
+      },
+      "demoUrl": "https://x.com/Kappaemme1926/status/2096156379882951054",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-263.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 330
+    },
+    {
+      "id": "work-8dc481595a6baf4a",
+      "name": "手机与电脑可玩的节奏游戏",
+      "description": "作者用Astra制作名为なんか聴いたことある音ゲー的节奏游戏，称约5分钟完成，包含HARD模式并提供评论区入口。 未检验音轨授权、节奏同步或跨设备可玩性。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@mindup_nari",
+        "url": "https://x.com/mindup_nari"
+      },
+      "demoUrl": "https://x.com/mindup_nari/status/2096156793902948369",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-264.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 331
+    },
+    {
+      "id": "work-499bc78dcbb75d3d",
+      "name": "海上搁浅船的 Blender 动画",
+      "description": "作者在Medium档要求生成海中搁浅船，Astra经Blender MCP建模和动画，耗时约40分钟。 未独立核查模型、动画与计时。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@Ananth7e",
+        "url": "https://x.com/Ananth7e"
+      },
+      "demoUrl": "https://x.com/Ananth7e/status/2096159964247277835",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-265.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 332
+    },
+    {
+      "id": "work-8d50b21ee714d501",
+      "name": "Clip Studio Paint 涂色尝试与额度限制",
+      "description": "作者让Astra操作Clip Studio Paint给画作上色，约10分钟耗尽Plus额度，表示实用仍有门槛但已看到操作与修改设置。 未明确最终着色完成；保留实际失败和限制，不写成成功交付。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@shimadauro",
+        "url": "https://x.com/shimadauro"
+      },
+      "demoUrl": "https://x.com/shimadauro/status/2096161305824751946",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-266.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 333
+    },
+    {
+      "id": "work-c5ac6d77dd4650f4",
+      "name": "KiCad 原理图转 PCB 布局演示",
+      "description": "转述Astra在KiCad中将电路原理图转为PCB布局，放置元件并走铜线。 未识别本帖原执行者与具体板卡；不代表DRC、电气验证或制造通过。",
+      "category": "tool",
+      "sourceCategory": "CheerSelfAI · 工程文件与代码迁移",
+      "author": {
+        "name": "@Alacritic_Super",
+        "url": "https://x.com/Alacritic_Super"
+      },
+      "demoUrl": "https://x.com/Alacritic_Super/status/2096162271517196465",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-267.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 334
+    },
+    {
+      "id": "work-6c5b56257ac56cd8",
+      "name": "实时无限海洋 WebGL2 模拟",
+      "description": "作者用Astra构建浏览器实时海洋，带程序化波浪、天气、时段和五种相机模式。 实时控制为作者自述；未验证物理精度和性能。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 模拟与科学可视化",
+      "author": {
+        "name": "@KeertiMata",
+        "url": "https://x.com/KeertiMata"
+      },
+      "demoUrl": "https://x.com/KeertiMata/status/2096163348786315460",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-268.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 335
+    },
+    {
+      "id": "work-08f8ccc823c91156",
+      "name": "像素大战风格 3D 吃豆人游戏",
+      "description": "作者称用Astra约10分钟制作3D吃豆人游戏，参考电影像素大战的创意。 未试玩或核查关卡、碰撞和性能。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@0xEcho99",
+        "url": "https://x.com/0xEcho99"
+      },
+      "demoUrl": "https://x.com/0xEcho99/status/2096163667977130390",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-270.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 336
+    },
+    {
+      "id": "work-b0c7494f142eac67",
+      "name": "Blender Discovery 航天飞机",
+      "description": "转述Astra在Blender重建Discovery航天飞机，描述机身、座舱、起落架、货舱、尾部与发动机等构件。 近1:1与单prompt耗时为未验证转述；未获原执行者工程。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@irinatoxi",
+        "url": "https://x.com/irinatoxi"
+      },
+      "demoUrl": "https://x.com/irinatoxi/status/2096164527339368809",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-271.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 337
+    },
+    {
+      "id": "work-bf7f366c67cd4e93",
+      "name": "随机细胞到多细胞生物演化模拟",
+      "description": "作者要求Astra模拟随机细胞汤的演化，展示多细胞个体移动、分裂与后代生长，称模型也为生物命名并剪辑视频。 视觉模拟不等于生物学有效性；未验算法和参数。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 模拟与科学可视化",
+      "author": {
+        "name": "@Angaisb_",
+        "url": "https://x.com/Angaisb_"
+      },
+      "demoUrl": "https://x.com/Angaisb_/status/2096165078877835491",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-272.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 338
+    },
+    {
+      "id": "work-24dae61624753fdb",
+      "name": "参考视频转互动游戏 1.0",
+      "description": "作者用Astra参考所引情感主题短视频制作互动游戏1.0，并反映token消耗高。 机制、token数量和参考视频素材来源未核验。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@you1873118",
+        "url": "https://x.com/you1873118"
+      },
+      "demoUrl": "https://x.com/you1873118/status/2096165216467952065",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-273.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 339
+    },
+    {
+      "id": "work-142a3a24f476a32a",
+      "name": "Town to City 风格城镇游戏",
+      "description": "作者展示Astra约2小时制作的Town to City风格游戏结果。 未给原项目8个月与本次产物的同等范围，不能据此计算效率倍数。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@TAbrodi",
+        "url": "https://x.com/TAbrodi"
+      },
+      "demoUrl": "https://x.com/TAbrodi/status/2096165309963206979",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-274.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 340
+    },
+    {
+      "id": "work-f8f1991676695888",
+      "name": "史莱姆互动玩具",
+      "description": "作者用GPT-6 Astra制作可以玩史莱姆的交互作品。 玩法和技术细节未说明；不从视频臆造物理能力。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@halukik_0520",
+        "url": "https://x.com/halukik_0520"
+      },
+      "demoUrl": "https://x.com/halukik_0520/status/2096165542247940557",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-275.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 341
+    },
+    {
+      "id": "work-83762c6578a56980",
+      "name": "ICE 骑车战斗网页游戏",
+      "description": "作者在ChatGPT手机端用Astra Max约33分钟制作3D骑车战斗游戏，要求8名敌人、Sky9首领与结局舞蹈，称手机和电脑均可玩。 角色、图像和音乐依赖参考素材；关卡完成度和跨设备能力均为作者自述。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@khajochi",
+        "url": "https://x.com/khajochi"
+      },
+      "demoUrl": "https://x.com/khajochi/status/2096166729701638393",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-277.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 342
+    },
+    {
+      "id": "work-a5ee3d2dc3149ca6",
+      "name": "Blender 人形狼与奔跑动画",
+      "description": "转述Matt Wolfe评测：Astra通过computer use在Blender构建人形狼，并制作步幅、摆臂、腾空和尾部运动的奔跑循环。 未取得原作者完整评测或工程；不独立确认绑骨和游戏资产可用性。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@Arcane_Aii",
+        "url": "https://x.com/Arcane_Aii"
+      },
+      "demoUrl": "https://x.com/Arcane_Aii/status/2096169051747938418",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-278.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 343
+    },
+    {
+      "id": "work-bf34fab1c55051d1",
+      "name": "Lego 1999 Racers 重建对照",
+      "description": "作者以重建Lego 1999 racers为prompt比较Astra和Fable，声称Astra构建速度快25倍。 未提供两次具体计时、玩法覆盖或公平比较设置；倍数仅为作者主张。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@SBnft25",
+        "url": "https://x.com/SBnft25"
+      },
+      "demoUrl": "https://x.com/SBnft25/status/2096169622261424261",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-279.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 344
+    },
+    {
+      "id": "work-8ab56cf00be0ad8a",
+      "name": "黑神话悟空风格游戏演示",
+      "description": "作者转述他人用Astra做出黑神话悟空风格游戏，并展示视频。 未给原作者或工程；只记录二手低细节演示，不代表原作规模。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@you1873118",
+        "url": "https://x.com/you1873118"
+      },
+      "demoUrl": "https://x.com/you1873118/status/2096172881889931617",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-280.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 345
+    },
+    {
+      "id": "work-517904b19a97ce73",
+      "name": "人偶固定与胶带缠绕游戏",
+      "description": "作者用Astra制作随机移动人偶的交互游戏，点击固定部位，再通过鼠标拖拽缠绕并补加胶带。 未独立试玩或检查物理模拟。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@Ushizaru_LAB",
+        "url": "https://x.com/Ushizaru_LAB"
+      },
+      "demoUrl": "https://x.com/Ushizaru_LAB/status/2096174633762607296",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-281.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 346
+    },
+    {
+      "id": "work-d82e2a708cfbaedc",
+      "name": "GTA IV 风格游戏原型",
+      "description": "作者称Astra基本一次生成了GTA IV风格游戏克隆。 不能理解为完整商业游戏复制；无关卡和机制验收。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@enisco",
+        "url": "https://x.com/enisco"
+      },
+      "demoUrl": "https://x.com/enisco/status/2096174745624498223",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-282.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 347
+    },
+    {
+      "id": "work-5c9971965a3d6d90",
+      "name": "四张照片经代码生成场景视频",
+      "description": "作者在Codex中用Astra将4张照片转为代码生成的视频，称没有此前Fable结果中的z-fighting。 具体场景与渲染工具未说明；画面问题改善为作者自述。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@ai_ai_ailover",
+        "url": "https://x.com/ai_ai_ailover"
+      },
+      "demoUrl": "https://x.com/ai_ai_ailover/status/2096175723614703738",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-283.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 348
+    },
+    {
+      "id": "work-b960a0d400abfc7a",
+      "name": "3D 渲染参考转交互网页开关",
+      "description": "作者用几个prompt让Astra把cerpow的3D渲染参考转成可交互web toggle，实现仅使用React和WebGL shaders。 原始视觉参考来自其他创作者；未检查交互代码和可访问性。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@fabiuix",
+        "url": "https://x.com/fabiuix"
+      },
+      "demoUrl": "https://x.com/fabiuix/status/2096175936211194125",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-284.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 349
+    },
+    {
+      "id": "work-5d2de4640b6000e0",
+      "name": "AFTERIMAGE 游戏原型",
+      "description": "作者发布GPT-6 Astra Pro制作的AFTERIMAGE，附可玩链接，并描述失败成为道路的主题。 未打开试玩验证机制、难度或完成度。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@gosrum",
+        "url": "https://x.com/gosrum"
+      },
+      "demoUrl": "https://x.com/gosrum/status/2096176593131741260",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-286.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 350
+    },
+    {
+      "id": "work-76d83f1382821554",
+      "name": "新加坡街道的手机视角场景",
+      "description": "作者先要求以手机POV制作GTA6画面风格的新加坡街道，后帖展示Astra结果。 前帖写Three.js，后帖称Unreal Engine，实际引擎未确认。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@birdabo",
+        "url": "https://x.com/birdabo"
+      },
+      "demoUrl": "https://x.com/birdabo/status/2096176846408945789",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-287.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 351
+    },
+    {
+      "id": "work-deb8f302b24a85fa",
+      "name": "社区项目视频的提示词编写",
+      "description": "作者称所引用Leve Poços社区供水及收获项目视频的prompt由GPT-6 Astra编写。 只证实作者对prompt角色的陈述；最终生成工具、prompt正文和素材事实未核验。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@henriqueim0veis",
+        "url": "https://x.com/henriqueim0veis"
+      },
+      "demoUrl": "https://x.com/henriqueim0veis/status/2096176901664518253",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-288.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 352
+    },
+    {
+      "id": "work-ff2b19c86527cdbe",
+      "name": "可访问的埃菲尔铁塔展示",
+      "description": "作者展示用Astra创建的埃菲尔铁塔观看作品，并附访问链接。 未打开链接验证3D形式、交互或还原准确性。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@ayaboch",
+        "url": "https://x.com/ayaboch"
+      },
+      "demoUrl": "https://x.com/ayaboch/status/2096178212883587094",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-289.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 353
+    },
+    {
+      "id": "work-7d09e7a04a6d2cb9",
+      "name": "整理开发中游戏的 UI",
+      "description": "作者在已有开发中游戏上让Astra反复调整界面，提升界面完成度。 不属于从零构建整款游戏；未提供具体改动清单或用户测试。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@yugiriworks",
+        "url": "https://x.com/yugiriworks"
+      },
+      "demoUrl": "https://x.com/yugiriworks/status/2096178313547133382",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-290.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 354
+    },
+    {
+      "id": "work-b177e6751ec83108",
+      "name": "设计、配乐与旁白动效视频",
+      "description": "作者称Astra约25分钟生成设计、动作、音效、音乐及人声的视频，又进行了4到5次调整。 并非零返工；音频素材来源与工程未核验。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@TROOVY",
+        "url": "https://x.com/TROOVY"
+      },
+      "demoUrl": "https://x.com/TROOVY/status/2096178387207225513",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-291.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 355
+    },
+    {
+      "id": "work-69c12e9315eb0570",
+      "name": "必杀技作品的 Astra 改稿与 Topview 视频化",
+      "description": "作者用Astra润色已发布的必杀技作品，再交给Topview生成视频，称镜头切分更贴合招式。 最终视频依赖Topview；未提供完整改稿或prompt。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@YaReYaRu30Life",
+        "url": "https://x.com/YaReYaRu30Life"
+      },
+      "demoUrl": "https://x.com/YaReYaRu30Life/status/2096179235501265279",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-292.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 356
+    },
+    {
+      "id": "work-f2f151cee2e4e3ff",
+      "name": "照片转可编辑教堂 3D 巡游",
+      "description": "GPT-6 Astra和Blender参考教堂照片建柱、彩窗、长椅与钢琴，并通过相机运动输出23秒视频；保留可改家具与机位的3D数据。 几何准确性与后续编辑未独立验收。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@noel_ai_lab",
+        "url": "https://x.com/noel_ai_lab"
+      },
+      "demoUrl": "https://x.com/noel_ai_lab/status/2096181084405047767",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-293.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 357
+    },
+    {
+      "id": "work-621d061dfb9b656f",
+      "name": "Three.js 汽车游戏与网格优化",
+      "description": "作者称不到3分钟构建Three.js游戏，随后把汽车14个mesh减到6个，并生成回归测试，报告9/9通过。 耗时、网格和测试通过均为作者自述；未读取测试源码。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@svector_eth",
+        "url": "https://x.com/svector_eth"
+      },
+      "demoUrl": "https://x.com/svector_eth/status/2096182841813955029",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-295.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 358
+    },
+    {
+      "id": "work-2637266129779bd1",
+      "name": "照片场景的 Blender 建模与动画",
+      "description": "作者用GPT-6 Astra和Blender重建照片场景，并追加动画。 照片对应的具体地点、几何精度和模型工程未验证。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@neka_nat",
+        "url": "https://x.com/neka_nat"
+      },
+      "demoUrl": "https://x.com/neka_nat/status/2096184394507866425",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-296.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 359
+    },
+    {
+      "id": "work-fcd98b57b0e84d5e",
+      "name": "Subway Surfers 克隆的画质与机制对照",
+      "description": "作者用相同简单指令约20分钟生成跑酷游戏并部署到ChatGPT Sites；称消耗71%额度、部署另23%，缺少道具、上车坡道和移动列车。 额度百分比不是API费用；作者写合计96%，与两分项94%不一致，原文数字不作纠正后统计。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@SahilPanhotra",
+        "url": "https://x.com/SahilPanhotra"
+      },
+      "demoUrl": "https://x.com/SahilPanhotra/status/2096184406734188768",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-297.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 360
+    },
+    {
+      "id": "work-f7fbad6364dca101",
+      "name": "生成游戏原型时快速耗尽额度",
+      "description": "作者用粗略指令离开后让Astra运行。 报告一次尝试就达到额度，仍希望完善角色运动。 并未完成可玩性验收；额度消耗无精确数值。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@taya_mama_AI",
+        "url": "https://x.com/taya_mama_AI"
+      },
+      "demoUrl": "https://x.com/taya_mama_AI/status/2096186558470844755",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-298.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 361
+    },
+    {
+      "id": "work-55bea006be4ed855",
+      "name": "用 Tripo 初模经 Astra 修模绑定并制作动画",
+      "description": "作者先图像生成→Tripo三维化→Astra修模→加rig→做动画，人工组织阶段。 明确分阶段与人为流程安排，不能称单次自动从零完成。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@mocchimocchi991",
+        "url": "https://x.com/mocchimocchi991"
+      },
+      "demoUrl": "https://x.com/mocchimocchi991/status/2096187582837293520",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-299.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 362
+    },
+    {
+      "id": "work-61518ef6db17d713",
+      "name": "用 SPEC 制作 Digital Twin Data Hall 新版",
+      "description": "作者从SPEC启动Astra构建。 没有旧版本来源或改动列表，未据此制造既有案例update。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@aijoey",
+        "url": "https://x.com/aijoey"
+      },
+      "demoUrl": "https://x.com/aijoey/status/2096189270213956042",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-300.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 363
+    },
+    {
+      "id": "work-5a2b15d236ae73b4",
+      "name": "比较并结束 snowboarder 动画基准",
+      "description": "作者将同一snowboarder任务用于两模型，认为均无需修改。 未给具体完整prompt或原始评分。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 专业研究与安全评测",
+      "author": {
+        "name": "@alex_erm",
+        "url": "https://x.com/alex_erm"
+      },
+      "demoUrl": "https://x.com/alex_erm/status/2096190023179608548",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-301.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 364
+    },
+    {
+      "id": "work-70f33e4fe24f46f1",
+      "name": "从一张插画在 Blender 重建三维场景",
+      "description": "作者无建模经验，仅给Astra插画和一句话。 原图主题和还原精度未说明。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@Chechecheur",
+        "url": "https://x.com/Chechecheur"
+      },
+      "demoUrl": "https://x.com/Chechecheur/status/2096191700251341189",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-302.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 365
+    },
+    {
+      "id": "work-b84910adc1ef9146",
+      "name": "制作点击弹跳的 WebGPU 果冻",
+      "description": "Astra配合WebGPU和Three.js。 作者称30分钟。 引用同作者早前30分钟交互作品，是否同一果冻需root查看原内容。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 模拟与科学可视化",
+      "author": {
+        "name": "@lepadphone",
+        "url": "https://x.com/lepadphone"
+      },
+      "demoUrl": "https://x.com/lepadphone/status/2096192125721551273",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-303.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 366
+    },
+    {
+      "id": "work-39e3d02d88d91096",
+      "name": "一次生成 PUBG 风格游戏",
+      "description": "作者用Astra单提示词生成。 “破绽少”为作者评价，不代表完整商业产品。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@usutaku_channel",
+        "url": "https://x.com/usutaku_channel"
+      },
+      "demoUrl": "https://x.com/usutaku_channel/status/2096192231635845335",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-304.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 367
+    },
+    {
+      "id": "work-d3059aaef18a2df4",
+      "name": "在快速启动的 Codex 沙箱中创建文件",
+      "description": "作者用Astra在agent沙箱演示创建文件，并描述秒级启动。 示例仅文件操作，完整full-stack应用与生产部署仍是计划。",
+      "category": "tool",
+      "sourceCategory": "CheerSelfAI · 工程文件与代码迁移",
+      "author": {
+        "name": "@saugardev",
+        "url": "https://x.com/saugardev"
+      },
+      "demoUrl": "https://x.com/saugardev/status/2096193413838192875",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-305.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 368
+    },
+    {
+      "id": "work-e6d748426d66f925",
+      "name": "比较两模型Medium骑车鹈鹕SVG动画",
+      "description": "相同prompt要求鹈鹕骑车并用H5展示。 作者认为Astra腿部运动和外观更好，Sol腿不动。 “无bug/完美”为作者主观评价。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@xueyu1125",
+        "url": "https://x.com/xueyu1125"
+      },
+      "demoUrl": "https://x.com/xueyu1125/status/2096193816864981444",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-306.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 369
+    },
+    {
+      "id": "work-85fafb3f1aeeb892",
+      "name": "以单张建筑照片开展传统软件专业交付实验",
+      "description": "Astra持续运行8小时，生成13类技术/视觉成果。 作者给60/100、约2.1亿tokens，并分别报告完成度。 8小时时明确两部成片与高精模型未完成，后续45给13小时总结。",
+      "category": "tool",
+      "sourceCategory": "CheerSelfAI · 工程文件与代码迁移",
+      "author": {
+        "name": "@ZHO_ZHO_ZHO",
+        "url": "https://x.com/ZHO_ZHO_ZHO"
+      },
+      "demoUrl": "https://x.com/ZHO_ZHO_ZHO/status/2096195128927093076",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-308.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 370
+    },
+    {
+      "id": "work-b9c5a05e179cbf61",
+      "name": "约20分钟生成 Panzer Dragoon 风格游戏",
+      "description": "作者因看到话题而亲自用Astra极高档尝试。 同类任务的作者新实验，不能仅因已发布他人的Panzer案例而判重。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@tetumemo",
+        "url": "https://x.com/tetumemo"
+      },
+      "demoUrl": "https://x.com/tetumemo/status/2096195768726216992",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-309.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 371
+    },
+    {
+      "id": "work-00b3c5e7c2b6fce8",
+      "name": "参考视频把分别录制的画面与声音自动剪辑",
+      "description": "Astra读取参考视频并处理分开录制的素材。 一稿质量为作者评价，未给完整编辑工程。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@fujiryu00",
+        "url": "https://x.com/fujiryu00"
+      },
+      "demoUrl": "https://x.com/fujiryu00/status/2096197109401940357",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-311.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 372
+    },
+    {
+      "id": "work-32235957d5b790c6",
+      "name": "以照片为参考在 Photoshop 自动画图",
+      "description": "作者提供照片让Astra自动操作。 作者报告和演示，未独立运行验收。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@William_Wangyun",
+        "url": "https://x.com/William_Wangyun"
+      },
+      "demoUrl": "https://x.com/William_Wangyun/status/2096197571480056003",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-312.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 373
+    },
+    {
+      "id": "work-053b5f83e744ba0a",
+      "name": "制作 PSP 自制游戏新原型",
+      "description": "作者用Astra构建受多个游戏启发的新作。 未明确实机运行和完整玩法，与旧Sol PSP项目不混同。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@bunkaich",
+        "url": "https://x.com/bunkaich"
+      },
+      "demoUrl": "https://x.com/bunkaich/status/2096198577546781153",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-313.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 374
+    },
+    {
+      "id": "work-f2d64bf983bf52af",
+      "name": "制作征华传P2介绍片",
+      "description": "作者让Astra制作。 作者指出未抠干净和未修发型的地方更显眼。 保留素材与编辑缺陷，不能称无修成片。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@rouga_Aiart",
+        "url": "https://x.com/rouga_Aiart"
+      },
+      "demoUrl": "https://x.com/rouga_Aiart/status/2096200183256358955",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-315.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 375
+    },
+    {
+      "id": "work-7477594b5cf719ca",
+      "name": "比较 Sol 与 Astra 的木乃伊三维模型",
+      "description": "使用Pixal3D、ComfyUI和headless Blender。 未给同prompt条件或定量评价。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@luisnomad",
+        "url": "https://x.com/luisnomad"
+      },
+      "demoUrl": "https://x.com/luisnomad/status/2096201196042145885",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-316.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 376
+    },
+    {
+      "id": "work-84a9369938e998c8",
+      "name": "在 Fusion 360 制作并打印铰接香蕉",
+      "description": "作者让Astra建模并打印，称除此未干预。 数小时后取得演示结果。 实物打印与装配未独立核验，硬件操作过程未披露。",
+      "category": "tool",
+      "sourceCategory": "CheerSelfAI · 工程文件与代码迁移",
+      "author": {
+        "name": "@Co_ben_",
+        "url": "https://x.com/Co_ben_"
+      },
+      "demoUrl": "https://x.com/Co_ben_/status/2096201932289274176",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-317.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 377
+    },
+    {
+      "id": "work-f5541a59f86b209e",
+      "name": "为 HANSHACORE 制作音乐视频",
+      "description": "原帖明确MV由Astra负责，音乐为AI与DAW。 不将歌曲音乐制作归给Astra；具体视频工具未给。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@tenchodono",
+        "url": "https://x.com/tenchodono"
+      },
+      "demoUrl": "https://x.com/tenchodono/status/2096202751315480950",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-318.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 378
+    },
+    {
+      "id": "work-0dae2bc01baf403a",
+      "name": "操作 GarageBand 作曲并母带处理",
+      "description": "Astra通过computer-use使用GarageBand。 作者报告和演示，未独立运行验收。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@aigeboku",
+        "url": "https://x.com/aigeboku"
+      },
+      "demoUrl": "https://x.com/aigeboku/status/2096205002960507270",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-319.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 379
+    },
+    {
+      "id": "work-2b382298ad8e41af",
+      "name": "把 Blender 场景扩展为 Sites 交互网站",
+      "description": "Astra将Blender模型导入Three.js并部署ChatGPT Sites；引用说明原场景主要由bpy/MCP制作。 作者报告和演示，未独立运行验收。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@op7418",
+        "url": "https://x.com/op7418"
+      },
+      "demoUrl": "https://x.com/op7418/status/2096205141187956887",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-320.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 380
+    },
+    {
+      "id": "work-6497d5e1baf35a35",
+      "name": "验证 Astra 与 Blender 的视频制作流程",
+      "description": "作者明确自己在测试Astra×Blender制片。 未给影片主题或完整方法，保留为单次流程试作。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@ria_aicreator",
+        "url": "https://x.com/ria_aicreator"
+      },
+      "demoUrl": "https://x.com/ria_aicreator/status/2096205626477338792",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-321.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 381
+    },
+    {
+      "id": "work-89cdf92a4247f586",
+      "name": "在 Blender 生成 MacBook Pro 模型并制作视频",
+      "description": "作者让Astra建模后生成视频。 作者报告和演示，未独立运行验收。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@blueemi99",
+        "url": "https://x.com/blueemi99"
+      },
+      "demoUrl": "https://x.com/blueemi99/status/2096206007193976876",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-322.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 382
+    },
+    {
+      "id": "work-6f08970ebfbe9f5d",
+      "name": "用一天测试游戏生成并观察额度消耗",
+      "description": "为测试Astra制作一天游戏。 作者不确定比Sol有优势，认为粗略指令会增加额外工作与用量。 游戏名未给，额度体验不能推广为通用成本。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@YugamiaLuna",
+        "url": "https://x.com/YugamiaLuna"
+      },
+      "demoUrl": "https://x.com/YugamiaLuna/status/2096206311629402253",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-323.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 383
+    },
+    {
+      "id": "work-f453e18110ed6726",
+      "name": "制作手绘笔记本风格第一人称射击游戏",
+      "description": "作者用Astra构建。 作者报告和演示，未独立运行验收。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@Aish2004Gupta",
+        "url": "https://x.com/Aish2004Gupta"
+      },
+      "demoUrl": "https://x.com/Aish2004Gupta/status/2096207995076313162",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-325.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 384
+    },
+    {
+      "id": "work-b96aac0a9c7c470c",
+      "name": "生成 Palmimo 主题30秒小游戏",
+      "description": "作者使用Astra制作。 具体玩法未充分描述，30秒难度为作者反应。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@maze_rapid",
+        "url": "https://x.com/maze_rapid"
+      },
+      "demoUrl": "https://x.com/maze_rapid/status/2096208743243612586",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-326.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 385
+    },
+    {
+      "id": "work-07ae7bdfd5d7d083",
+      "name": "生成响应风和玩家的浏览器草地",
+      "description": "Astra单提示词构建。 作者报告26分钟、周额度6%。 作者报告和演示，未独立运行验收。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 模拟与科学可视化",
+      "author": {
+        "name": "@PenguinWeb3",
+        "url": "https://x.com/PenguinWeb3"
+      },
+      "demoUrl": "https://x.com/PenguinWeb3/status/2096209358128615683",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-327.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 386
+    },
+    {
+      "id": "work-c3eb48c9afd9bcc5",
+      "name": "制作 Astra 自己的发布介绍视频",
+      "description": "六行prompt加参考视频；HyperFrames制作，ElevenLabs男声与音效。 不与别的作者参考同一官方片的作品自动合并。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@athrix_codes",
+        "url": "https://x.com/athrix_codes"
+      },
+      "demoUrl": "https://x.com/athrix_codes/status/2096209514248958161",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-328.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 387
+    },
+    {
+      "id": "work-354c20346a33e3fe",
+      "name": "生成可弹奏可交互钢琴",
+      "description": "作者称Astra一句话生成。 还原度和弹奏能力未独立验收。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@anion_ex",
+        "url": "https://x.com/anion_ex"
+      },
+      "demoUrl": "https://x.com/anion_ex/status/2096212906178400328",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-330.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 388
+    },
+    {
+      "id": "work-4bf65b8d23b6757a",
+      "name": "制作可变速放大的三维骑车鹈鹕",
+      "description": "Astra单提示词生成，支持缩放和加速。 作者称数十分钟。 未验证踏车机构物理准确性。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 模拟与科学可视化",
+      "author": {
+        "name": "@aibuilderclub_",
+        "url": "https://x.com/aibuilderclub_"
+      },
+      "demoUrl": "https://x.com/aibuilderclub_/status/2096213850383331489",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-331.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 389
+    },
+    {
+      "id": "work-4beaa2997bc96713",
+      "name": "用 Three.js 重建悉尼歌剧院",
+      "description": "Codex中Astra max单提示词建模，引用是作者此前计划。 形状准确性是作者说法，未实测；不将同地标不同作者合并。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@HarshithLucky3",
+        "url": "https://x.com/HarshithLucky3"
+      },
+      "demoUrl": "https://x.com/HarshithLucky3/status/2096214595602149857",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-332.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 390
+    },
+    {
+      "id": "work-7fa354b21efc19bb",
+      "name": "开发作曲软件并生成 RPG 战斗曲",
+      "description": "作者给Astra“制作作曲软件与RPG战斗曲”的任务。 未打开软件验证，音乐编曲质量为作者观察。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@gigabit_million",
+        "url": "https://x.com/gigabit_million"
+      },
+      "demoUrl": "https://x.com/gigabit_million/status/2096214882630983961",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-333.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 391
+    },
+    {
+      "id": "work-cb51d0f952d7272c",
+      "name": "依据工房网页制作18秒12镜招募视频",
+      "description": "Codex Astra与HyperFrames读取网页设计，多轮调整镜头与文本；ElevenLabs配乐音效，Tsugite管理制作。 明确多轮修改；引用为同一招募宣传，当前补充竖版与完整流程。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@takamasa045",
+        "url": "https://x.com/takamasa045"
+      },
+      "demoUrl": "https://x.com/takamasa045/status/2096214997785616775",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-334.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 392
+    },
+    {
+      "id": "work-7c6e16d2f708b835",
+      "name": "在 Replit 制作熊猫冒险游戏",
+      "description": "作者用Replit与Astra制作。 作者报告和演示，未独立运行验收。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@Noni_Shehnoor",
+        "url": "https://x.com/Noni_Shehnoor"
+      },
+      "demoUrl": "https://x.com/Noni_Shehnoor/status/2096215589190566035",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-335.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 393
+    },
+    {
+      "id": "work-101435a30d19cbcc",
+      "name": "自动制作全量字幕并剪掉口头停顿",
+      "description": "作者用Astra做full captions与filler cuts。 “完美”为作者评价，未量化错误率。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@shupeiman",
+        "url": "https://x.com/shupeiman"
+      },
+      "demoUrl": "https://x.com/shupeiman/status/2096218468442124672",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-336.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 394
+    },
+    {
+      "id": "work-5e8c8b1cb396a022",
+      "name": "为全盲儿童开发声音寻宝游戏",
+      "description": "作者让Astra为自己的孩子制作。 作者称20分钟完成。 未独立评估无障碍交互与可玩性。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@sawadayuru",
+        "url": "https://x.com/sawadayuru"
+      },
+      "demoUrl": "https://x.com/sawadayuru/status/2096218784864653636",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-337.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 395
+    },
+    {
+      "id": "work-944b50d18cc47cc9",
+      "name": "在 Roblox Studio 制作卡丁车竞速游戏",
+      "description": "作者描述Astra单提示词约30分钟完成。 未独立验证全部玩法，属于Mario Kart风格原型。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@givros",
+        "url": "https://x.com/givros"
+      },
+      "demoUrl": "https://x.com/givros/status/2096219700879331665",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-338.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 396
+    },
+    {
+      "id": "work-eeec902ef2e23d08",
+      "name": "制作现实画面转 GTA 风格视频",
+      "description": "Halai平台使用Halai MCP与ChatGPT Astra。 最终渲染模型未拆清，平台自营展示。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@Halaiapp",
+        "url": "https://x.com/Halaiapp"
+      },
+      "demoUrl": "https://x.com/Halaiapp/status/2096221074157412559",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-339.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 397
+    },
+    {
+      "id": "work-460c50a97fa54e93",
+      "name": "在画图中重绘作者头像",
+      "description": "作者指示Astra在Paint绘制其头像。 作者以“对不起”表达戏谑反应。 未推定具体绘画错误，质量反应来自作者。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@hmmmmmm1458",
+        "url": "https://x.com/hmmmmmm1458"
+      },
+      "demoUrl": "https://x.com/hmmmmmm1458/status/2096223601552965960",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-341.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 398
+    },
+    {
+      "id": "work-9129f9cd780a8dca",
+      "name": "开展六自由度轨道交会对接工程基准",
+      "description": "作者要求双体ECI传播、HCW引导、四元数动力学、燃料和力矩约束，并分项审核。 作者给Astra92.6、Fable81.4；Astra43分钟，Fable74分钟。 分数是作者engineering-quality评分；其说明严格hard-fail下Fable应为0，未独立复核实现。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 模拟与科学可视化",
+      "author": {
+        "name": "@AlicanKiraz0",
+        "url": "https://x.com/AlicanKiraz0"
+      },
+      "demoUrl": "https://x.com/AlicanKiraz0/status/2096225621303042258",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-342.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 399
+    },
+    {
+      "id": "work-3d0b9221b3730865",
+      "name": "修复 Fable 构建的 Three.js 哥特教堂",
+      "description": "Fable/Opus完成约95%初始场景；Astra一小时处理渲染缺陷。 Astra负责修复，不能把整体教堂创作归给它；40%额度属于Claude部分。",
+      "category": "tool",
+      "sourceCategory": "CheerSelfAI · 工程文件与代码迁移",
+      "author": {
+        "name": "@Big14teru",
+        "url": "https://x.com/Big14teru"
+      },
+      "demoUrl": "https://x.com/Big14teru/status/2096225907224485992",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-343.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 400
+    },
+    {
+      "id": "work-82b3e1e13fc867c7",
+      "name": "生成超级马里奥风格游戏",
+      "description": "作者让Astra做Super Mario游戏。 “真的本物”为作者夸张，不代表官方游戏或完整复刻。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@Aivy___X",
+        "url": "https://x.com/Aivy___X"
+      },
+      "demoUrl": "https://x.com/Aivy___X/status/2096227063636369410",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-344.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 401
+    },
+    {
+      "id": "work-8ae469b77d16e935",
+      "name": "用简短指令测试浏览器游戏生成",
+      "description": "泰文根帖说明以ChatGPT Astra指令生成游戏。 游戏名称与完整功能未写，保留为单次游戏试作。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@iaumreview",
+        "url": "https://x.com/iaumreview"
+      },
+      "demoUrl": "https://x.com/iaumreview/status/2096228169464557924",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-345.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 402
+    },
+    {
+      "id": "work-2ba46eef89dcb443",
+      "name": "把浏览器游戏扩为带移动镜头和大地图的三维版",
+      "description": "先由概念生成UI玩法，再第二条指令改为3D并扩图。 作者称全程约45分钟。 明确两步流程，未独立试玩。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@philippsieben",
+        "url": "https://x.com/philippsieben"
+      },
+      "demoUrl": "https://x.com/philippsieben/status/2096230927085060515",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-346.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 403
+    },
+    {
+      "id": "work-2df218ff09b07757",
+      "name": "改进既有竞速游戏的可变翼视觉",
+      "description": "Astra在作者外出期间修改旧whitebox项目。 作者仍认为翼运动不理想；旧引用未说明用Astra，所以只把本次改进归因Astra。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@ShadeLurk",
+        "url": "https://x.com/ShadeLurk"
+      },
+      "demoUrl": "https://x.com/ShadeLurk/status/2096231227946864782",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-347.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 404
+    },
+    {
+      "id": "work-26890bf34ec911fc",
+      "name": "测试从图片制作角色的 computer-use 并中止",
+      "description": "Astra使用computer-use从图制作角色。 作者称存文件约5分钟，等待1小时后认为过慢而终止。 单次负面体验，未给全部设备和工具配置。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@Stefan_3D_AI",
+        "url": "https://x.com/Stefan_3D_AI"
+      },
+      "demoUrl": "https://x.com/Stefan_3D_AI/status/2096232061585731874",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-348.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 405
+    },
+    {
+      "id": "work-8cd2a697f8bd24c9",
+      "name": "生成弹珠店店长模拟游戏",
+      "description": "作者让Astra创建店长模拟器。 为游戏机制演示，不作为实际经营数据。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@X64zzotSKCGtYmt",
+        "url": "https://x.com/X64zzotSKCGtYmt"
+      },
+      "demoUrl": "https://x.com/X64zzotSKCGtYmt/status/2096232182515933567",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-349.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 406
+    },
+    {
+      "id": "work-847bfea55505c482",
+      "name": "为海岸屋舍场景增加材质、三时段光照与交互",
+      "description": "Blender扫描纹理和Cycles烘焙日光/落日/蓝调，Three.js处理波浪反射和行走。 作者报告和演示，未独立运行验收。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@LufzzLiz",
+        "url": "https://x.com/LufzzLiz"
+      },
+      "demoUrl": "https://x.com/LufzzLiz/status/2096232605977043293",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-350.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 407
+    },
+    {
+      "id": "work-64d9f3f64652d162",
+      "name": "生成22000星粒子的星系碰撞模拟",
+      "description": "Astra实现近似引力计算。 作者称约3分钟。 近似模拟非天体物理精确求解，数量和时间为作者报告。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 模拟与科学可视化",
+      "author": {
+        "name": "@ozwxy",
+        "url": "https://x.com/ozwxy"
+      },
+      "demoUrl": "https://x.com/ozwxy/status/2096233290936336620",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-351.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 408
+    },
+    {
+      "id": "work-f18ad0f94a9b6c46",
+      "name": "制作猫咪晚餐冒险的可编辑夜市",
+      "description": "作者用Codex和Blender构建。 报告约1小时、20x周额度4%。 作者报告和演示，未独立运行验收。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@heykumaonx",
+        "url": "https://x.com/heykumaonx"
+      },
+      "demoUrl": "https://x.com/heykumaonx/status/2096233696735175020",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-352.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 409
+    },
+    {
+      "id": "work-7e6171ac1b8d32fd",
+      "name": "制作1905年日俄海战模拟器",
+      "description": "Astra按单条指令建立模拟并自行查舰名航线。 史实准确性为作者转述，未核对资料或物理模拟。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 模拟与科学可视化",
+      "author": {
+        "name": "@Genzoh1",
+        "url": "https://x.com/Genzoh1"
+      },
+      "demoUrl": "https://x.com/Genzoh1/status/2096234089124946307",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-353.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 410
+    },
+    {
+      "id": "work-ae5bed461c2bf23c",
+      "name": "为 Elliot Hewitt 制作并两轮修改视频",
+      "description": "Astra生成后作者给两次反馈。 原帖虽称one-shot，实际明确两次修改；未给工具。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@_StainVfx",
+        "url": "https://x.com/_StainVfx"
+      },
+      "demoUrl": "https://x.com/_StainVfx/status/2096234895076913289",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-354.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 411
+    },
+    {
+      "id": "work-998643471c13d1b4",
+      "name": "制作可改信号灯观察拥堵的交通模拟城市",
+      "description": "Astra构建道路、建筑和交通逻辑，车辆对红灯与前车作反应。 未验证模型交通学准确性或车辆数。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 模拟与科学可视化",
+      "author": {
+        "name": "@ozwxy",
+        "url": "https://x.com/ozwxy"
+      },
+      "demoUrl": "https://x.com/ozwxy/status/2096235880528961572",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-355.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 412
+    },
+    {
+      "id": "work-718706140bc105a4",
+      "name": "比较四模型飞行模拟器的体验与成本",
+      "description": "给四模型相同prompt。 作者认为Astra总体第一但卡顿抖动；Kimi/Fable更平滑，Gemini速度价格占优。 排名与费用为作者评估，未取得统一测试日志。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 专业研究与安全评测",
+      "author": {
+        "name": "@adxtyahq",
+        "url": "https://x.com/adxtyahq"
+      },
+      "demoUrl": "https://x.com/adxtyahq/status/2096236137266512181",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-356.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 413
+    },
+    {
+      "id": "work-427a537c5a83a271",
+      "name": "为女儿制作有动物声音与行走交互的小动物世界",
+      "description": "作者使用Astra把图像转成三维并加入音效和互动。 同时推广中转平台，应保留推广关系，未验证v1全部功能。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@LufzzLiz",
+        "url": "https://x.com/LufzzLiz"
+      },
+      "demoUrl": "https://x.com/LufzzLiz/status/2096236975623946589",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-357.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 414
+    },
+    {
+      "id": "work-7c9452ba59d0f426",
+      "name": "将单张背景插画制作成可自由漫游的 Unreal 街景",
+      "description": "Codex agent-alliance分工分析、建模、UE导入验证，修复启动问题。 作者承认结构未完全复现原图。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@Toshi_nyaruo_AI",
+        "url": "https://x.com/Toshi_nyaruo_AI"
+      },
+      "demoUrl": "https://x.com/Toshi_nyaruo_AI/status/2096237124815384822",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-358.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 415
+    },
+    {
+      "id": "work-04758fdbd38a2a72",
+      "name": "用 Codex 与 Remotion 复刻 DJ 主题动画",
+      "description": "Astra结合Codex和Remotion，引用其他作者Apple产品动画作为方法参考。 作者报告5分钟。 引用Apple作品是参考，不将其全部实现细节归给本次DJ视频。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@369Serena",
+        "url": "https://x.com/369Serena"
+      },
+      "demoUrl": "https://x.com/369Serena/status/2096238284351447502",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-359.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 416
+    },
+    {
+      "id": "work-bb50b4c646fdc429",
+      "name": "基于原 CAD 制作 Microduck 机器人70部件拆解工具",
+      "description": "Astra采用原CAD几何和装配。 70部件为作者报告，未验证实体装配适用性。",
+      "category": "tool",
+      "sourceCategory": "CheerSelfAI · 工程文件与代码迁移",
+      "author": {
+        "name": "@tspy",
+        "url": "https://x.com/tspy"
+      },
+      "demoUrl": "https://x.com/tspy/status/2096238855519453662",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-360.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 417
+    },
+    {
+      "id": "work-4a37faf2b664799a",
+      "name": "从 Blender 粗布局推进为电影镜头",
+      "description": "Topview平台称Astra处理全流程。 未命名场景，与同平台其他片段是否同项目需后续证据。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@TopviewAIhq",
+        "url": "https://x.com/TopviewAIhq"
+      },
+      "demoUrl": "https://x.com/TopviewAIhq/status/2096239357586010498",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-361.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 418
+    },
+    {
+      "id": "work-484cad6bafa94e67",
+      "name": "在 HyperFrames 中重建 Astra 发布视频",
+      "description": "Astra结合HyperFrames重做官方发布片，灵感来自vedu_boi。 为另一作者自己的复刻，不因相同官方参考片合并其他作者项目。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@WaterrrMiao",
+        "url": "https://x.com/WaterrrMiao"
+      },
+      "demoUrl": "https://x.com/WaterrrMiao/status/2096240164138004729",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-362.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 419
+    },
+    {
+      "id": "work-5d590f23e012f8ff",
+      "name": "把 GunZ C++ 客户端迁移到 WebAssembly 并加键鼠覆盖层",
+      "description": "Astra将C++客户端迁移到WebAssembly和WebGL，并增加键鼠显示。 作者报告和演示，未独立运行验收。",
+      "category": "tool",
+      "sourceCategory": "CheerSelfAI · 工程文件与代码迁移",
+      "author": {
+        "name": "@toeknee_kim",
+        "url": "https://x.com/toeknee_kim"
+      },
+      "demoUrl": "https://x.com/toeknee_kim/status/2096240184358556110",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-363.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 420
+    },
+    {
+      "id": "work-64e6dec5dbc4cf8b",
+      "name": "为待发布 Quest 游戏制作宣传片",
+      "description": "作者让Astra制作宣传片。 Quest审核通过为作者陈述，游戏公开发布尚未完成。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@3DVR3",
+        "url": "https://x.com/3DVR3"
+      },
+      "demoUrl": "https://x.com/3DVR3/status/2096240577545449795",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-364.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 421
+    },
+    {
+      "id": "work-d6b954de9cce2262",
+      "name": "制作地形可移动旋转的 PatchworkTactics",
+      "description": "作者用Astra制作并上线。 作者报告和演示，未独立运行验收。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@8co28",
+        "url": "https://x.com/8co28"
+      },
+      "demoUrl": "https://x.com/8co28/status/2096241280208810156",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-365.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 422
+    },
+    {
+      "id": "work-f4a5844ef1b6f3a8",
+      "name": "自动制作 Finn Explains 风格广告视频",
+      "description": "作者称全自动使用Astra制作。 广告预算放量与用户吸引力无具体数据，不作商业效果结论。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@0xROAS",
+        "url": "https://x.com/0xROAS"
+      },
+      "demoUrl": "https://x.com/0xROAS/status/2096243418426937576",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-366.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 423
+    },
+    {
+      "id": "work-c83f09f368480694",
+      "name": "生成 Komorebi River Run 皮划艇游戏",
+      "description": "Three.js运行，场景、音乐和音效由代码生成。 作者喜欢观感和音乐，但认为水流湍急度不足。 作者报告和演示，未独立运行验收。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@ItsmeAjayKV",
+        "url": "https://x.com/ItsmeAjayKV"
+      },
+      "demoUrl": "https://x.com/ItsmeAjayKV/status/2096244208533455049",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-367.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 424
+    },
+    {
+      "id": "work-bae544c7dc313f21",
+      "name": "用 Unreal Engine 与 Blender 制作反恐精英风格游戏",
+      "description": "作者使用Astra、UE5与Blender。 报告30分钟、50美元API额度。 费用与完成范围为作者报告，不视为完整商业游戏复刻。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@DeonMen",
+        "url": "https://x.com/DeonMen"
+      },
+      "demoUrl": "https://x.com/DeonMen/status/2096244460866707559",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-368.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 425
+    },
+    {
+      "id": "work-83d956788d81e399",
+      "name": "为新版 Denaria 制作两分钟介绍视频",
+      "description": "Astra从单条prompt自行理解上下文并总结。 准确性为作者评价，未核对产品信息。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@TizianoTridico",
+        "url": "https://x.com/TizianoTridico"
+      },
+      "demoUrl": "https://x.com/TizianoTridico/status/2096244876518072591",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-369.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 426
+    },
+    {
+      "id": "work-a01b1d1a496ad262",
+      "name": "将参考图做成滚动驱动的三维工作室网站",
+      "description": "输入参考图与prompt，Astra用Three.js转为三维。 作者报告和演示，未独立运行验收。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@mx_debbiee",
+        "url": "https://x.com/mx_debbiee"
+      },
+      "demoUrl": "https://x.com/mx_debbiee/status/2096245759121277132",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-370.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 427
+    },
+    {
+      "id": "work-d4f176e2718c32a9",
+      "name": "构建黑魂风格教堂骑士与Boss游戏",
+      "description": "给图像生成做概念、Blender制作资产；Astra连接移动、攻击、闪避和Boss登场。 依赖生成概念图和建模工具；未验证全部玩法。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@filicroval",
+        "url": "https://x.com/filicroval"
+      },
+      "demoUrl": "https://x.com/filicroval/status/2096246680895078470",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-371.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 428
+    },
+    {
+      "id": "work-c7832a9ba5122dda",
+      "name": "介绍 Arena AI 的33分钟三维世界生成对照",
+      "description": "二手汇总多推理档位和单提示词生成演示。 未完整观看评测，课程价值与最强模型宣传不作结论。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 专业研究与安全评测",
+      "author": {
+        "name": "@sheemamoto",
+        "url": "https://x.com/sheemamoto"
+      },
+      "demoUrl": "https://x.com/sheemamoto/status/2096246789804347521",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-372.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 429
+    },
+    {
+      "id": "work-26c14c9c31af4e41",
+      "name": "根据网页图片在 Blender 重建 Winfield 城市",
+      "description": "Astra自行从互联网取参考图并建模。 作者明确不完美、非现实一比一重建。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@TheVRNerd",
+        "url": "https://x.com/TheVRNerd"
+      },
+      "demoUrl": "https://x.com/TheVRNerd/status/2096247120000893382",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-373.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 430
+    },
+    {
+      "id": "work-2061f4357ee5b51f",
+      "name": "通过多轮对话制作苍穹红莲队风格射击游戏",
+      "description": "作者给粗略主题后与Astra多轮沟通。 未独立试玩；介绍视频所用具体模型未拆清。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@SSSS_CRYPTOMAN",
+        "url": "https://x.com/SSSS_CRYPTOMAN"
+      },
+      "demoUrl": "https://x.com/SSSS_CRYPTOMAN/status/2096248797873762805",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-374.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 431
+    },
+    {
+      "id": "work-696fb81891684348",
+      "name": "生成咖啡馆手机点单系统",
+      "description": "作者称Astra一条prompt约5分钟生成。 未验证支付、订单后台或实际餐饮部署。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@sns_ryuto05",
+        "url": "https://x.com/sns_ryuto05"
+      },
+      "demoUrl": "https://x.com/sns_ryuto05/status/2096248925422505992",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-375.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 432
+    },
+    {
+      "id": "work-57fca0681830a3be",
+      "name": "重建可探索 Mysuru Palace 并配原创音轨",
+      "description": "Codex中的Astra使用Blender与Three.js，另作曲后由作者合成。 视频合成由作者完成，不归因模型全程自动。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@mvkaran",
+        "url": "https://x.com/mvkaran"
+      },
+      "demoUrl": "https://x.com/mvkaran/status/2096249702937460876",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-376.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 433
+    },
+    {
+      "id": "work-205e33429e868569",
+      "name": "在 Remotion 中制作 Tender Scout 广告",
+      "description": "Astra分场景、制作motion、检查帧并修正后渲染。 作者只给创意和一条prompt，模型内部有检查修正。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@Abdullah_Ops1",
+        "url": "https://x.com/Abdullah_Ops1"
+      },
+      "demoUrl": "https://x.com/Abdullah_Ops1/status/2096249736349024682",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-377.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 434
+    },
+    {
+      "id": "work-8d2efcd78787a8ec",
+      "name": "把个人积木世界构想做成 Little Wonderhood",
+      "description": "作者给Astra模糊想法。 报告不到10分钟。 作者报告和演示，未独立运行验收。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@ClaireBei",
+        "url": "https://x.com/ClaireBei"
+      },
+      "demoUrl": "https://x.com/ClaireBei/status/2096250058807349755",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-378.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 435
+    },
+    {
+      "id": "work-71a1de035e477e02",
+      "name": "设计饮水机与智能镜面体测仪外观",
+      "description": "给Astra中档概念图或旧效果图，要求实用化与还原，背景流程为Rhino。 作者称相较Sol多轮本次一轮完成。 原帖强调交付为效果图，不当成完整工程建模；3000元是报价设想。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@yhslgg",
+        "url": "https://x.com/yhslgg"
+      },
+      "demoUrl": "https://x.com/yhslgg/status/2096250228315914691",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-379.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 436
+    },
+    {
+      "id": "work-3cb719081111b670",
+      "name": "用 Three.js skill 包制作怪兽主题游戏",
+      "description": "Astra搭配作者游戏skill，Tripo生成模型、ElevenLabs音效。 依赖额外模型/声音工具，未试玩验证。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@majidmanzarpour",
+        "url": "https://x.com/majidmanzarpour"
+      },
+      "demoUrl": "https://x.com/majidmanzarpour/status/2096251574918013135",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-380.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 437
+    },
+    {
+      "id": "work-e2c87bbb61911190",
+      "name": "控制 Mac 建造微型新古典宫殿",
+      "description": "Astra Ultra fast控制Mac，使用两条提示词。 作者报告不到45分钟。 作者报告和演示，未独立运行验收。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@leploutos",
+        "url": "https://x.com/leploutos"
+      },
+      "demoUrl": "https://x.com/leploutos/status/2096251791591510290",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-381.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 438
+    },
+    {
+      "id": "work-fbb2fc7de248ff2c",
+      "name": "把西部场景 Blender 几何做成电影片段",
+      "description": "Topview中让Astra重构经典Western场景。 平台演示，未给具体影片或完整工程。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@TopviewAIhq",
+        "url": "https://x.com/TopviewAIhq"
+      },
+      "demoUrl": "https://x.com/TopviewAIhq/status/2096252019329716464",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-382.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 439
+    },
+    {
+      "id": "work-e1f380f6fe0f742f",
+      "name": "以三维电影重演 OpenAI 与 Hugging Face 事件",
+      "description": "作者让Astra max解释该事件。 报告44分钟、673万tokens、周额度15%。 属于创意重演，不证明事件细节；计时与用量为作者报告。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@haider1",
+        "url": "https://x.com/haider1"
+      },
+      "demoUrl": "https://x.com/haider1/status/2096252283168456958",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-383.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 440
+    },
+    {
+      "id": "work-679509678d10f7ec",
+      "name": "制作右上肢人体结构爆炸视图",
+      "description": "作者用Astra进一步探索解剖展示。 未验证解剖准确性；昨天腕管手术演示是另一任务，不自动合并。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 模拟与科学可视化",
+      "author": {
+        "name": "@HandEManAI",
+        "url": "https://x.com/HandEManAI"
+      },
+      "demoUrl": "https://x.com/HandEManAI/status/2096253408009486619",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-384.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 441
+    },
+    {
+      "id": "work-603a88f3617642fd",
+      "name": "修复 Tripo 机器人网格并在 Substance Painter 纹理化",
+      "description": "先用Grok参考图直接让Astra做出147K三角形模型未达需求，再用Tripo P2初网格交Astra在Blender和Substance Painter处理。 原模型质量不佳与后续改进均保留；作者强调token和混合人工流程。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@insaneUEFN",
+        "url": "https://x.com/insaneUEFN"
+      },
+      "demoUrl": "https://x.com/insaneUEFN/status/2096255563273314618",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-385.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 442
+    },
+    {
+      "id": "work-a9050e64d61b54df",
+      "name": "构建含冲刺追踪与激光剑的机器人对战游戏",
+      "description": "作者用自然语言反复描述希望的动作。 多次调整，不写成一条prompt完成。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@hayashimon1",
+        "url": "https://x.com/hayashimon1"
+      },
+      "demoUrl": "https://x.com/hayashimon1/status/2096255665778069957",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-386.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 443
+    },
+    {
+      "id": "work-27faa07b5f46a442",
+      "name": "生成游戏及其演示画面",
+      "description": "作者称游戏和演示画面均由Astra生成。 游戏任务细节未给，保留为作者单次游戏制作观察。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@budou_umibudou",
+        "url": "https://x.com/budou_umibudou"
+      },
+      "demoUrl": "https://x.com/budou_umibudou/status/2096256827931697488",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-387.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 444
+    },
+    {
+      "id": "work-8797c162654e1b7a",
+      "name": "比较 Astra 与 Sol 中档的直升机建模",
+      "description": "两模型均Medium。 作者评价Astra更精细且能自由翻转，Sol视角受限。 未给正文完整prompt，个人比较不外推模型排名。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@xueyu1125",
+        "url": "https://x.com/xueyu1125"
+      },
+      "demoUrl": "https://x.com/xueyu1125/status/2096258146318880989",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-388.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 445
+    },
+    {
+      "id": "work-fd115711c64a84ac",
+      "name": "生成 Tesla Model S 十六装配体拆解工作台",
+      "description": "作者让Astra从一条提示词建参考模型。 原帖明确reference study，非Tesla工程数据；与Model X334件不同任务。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@Acoramaa",
+        "url": "https://x.com/Acoramaa"
+      },
+      "demoUrl": "https://x.com/Acoramaa/status/2096258222134870370",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-389.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 446
+    },
+    {
+      "id": "work-c59dd054d608c714",
+      "name": "为 AdCar TV 制作30至60秒介绍视频",
+      "description": "在既有代码/3D viewer仓库使用Astra、Remotion、ffmpeg和本地Qwen3TTS。 one-shot依赖已有汽车模型、音乐与声音资产。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@d4m1n",
+        "url": "https://x.com/d4m1n"
+      },
+      "demoUrl": "https://x.com/d4m1n/status/2096258259459964963",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-390.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 447
+    },
+    {
+      "id": "work-0a8a3f8b843a025c",
+      "name": "展示 Matthew Berman 的七区域可探索星球",
+      "description": "二手明确归于Matthew Berman以Astra制作。 未给原作者链接，功能为转述；与同作者传播可由root合并。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@0xJokker",
+        "url": "https://x.com/0xJokker"
+      },
+      "demoUrl": "https://x.com/0xJokker/status/2096258495469277202",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-391.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 448
+    },
+    {
+      "id": "work-f086bf1ae7b9000a",
+      "name": "比较 Astra 与 Fable 的 GTA 风格游戏生成",
+      "description": "作者自述实测Astra与Fable。 认为Fable更符合需求。 GTA6是风格/目标表述，不是完整商业游戏；未给prompt与客观评分。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@Tasihi_89",
+        "url": "https://x.com/Tasihi_89"
+      },
+      "demoUrl": "https://x.com/Tasihi_89/status/2096259499443245153",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-392.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 449
+    },
+    {
+      "id": "work-79c32c196184c76f",
+      "name": "从文字描述生成完整房屋 Blender 场景",
+      "description": "二手称一条prompt完成Blender建模。 未给原作者或房屋输入，基准夸大不作结论。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@noahxops",
+        "url": "https://x.com/noahxops"
+      },
+      "demoUrl": "https://x.com/noahxops/status/2096260976274460998",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-393.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 450
+    },
+    {
+      "id": "work-7cd5040c2007837e",
+      "name": "用 goal 指令构建移动游戏",
+      "description": "Astra与/goal运行。 作者报告约3小时、7300万tokens。 未给游戏名称与完整功能，tokens为报告值。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@jaimintf",
+        "url": "https://x.com/jaimintf"
+      },
+      "demoUrl": "https://x.com/jaimintf/status/2096261065659371822",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-394.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 451
+    },
+    {
+      "id": "work-730662d08a041556",
+      "name": "在 After Effects 中生成特效与动态图形",
+      "description": "作者直接让Astra操作After Effects制作。 作者报告和演示，未独立运行验收。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@icreatelife",
+        "url": "https://x.com/icreatelife"
+      },
+      "demoUrl": "https://x.com/icreatelife/status/2096261585249370516",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-395.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 452
+    },
+    {
+      "id": "work-ca419da268679414",
+      "name": "17分钟生成 Wipeout 风格竞速原型",
+      "description": "Astra构建。 未给作者原流程或与已有反重力竞速的同源证据。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@promptowy",
+        "url": "https://x.com/promptowy"
+      },
+      "demoUrl": "https://x.com/promptowy/status/2096261604195139712",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-396.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 453
+    },
+    {
+      "id": "work-658c913e5e0997e5",
+      "name": "在 Onshape 中按选定传感器迭代机器人设计",
+      "description": "Astra构建connector从后端操作Onshape；作者自己控制鼠标和视角。 不能把鼠标视角操作归给模型；与同作者后续rover项目是否相同待root核查。",
+      "category": "tool",
+      "sourceCategory": "CheerSelfAI · 工程文件与代码迁移",
+      "author": {
+        "name": "@Alpha10six",
+        "url": "https://x.com/Alpha10six"
+      },
+      "demoUrl": "https://x.com/Alpha10six/status/2096261751389978640",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-397.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 454
+    },
+    {
+      "id": "work-cfad65b05d11137e",
+      "name": "开发开源遥控飞机飞行模拟器",
+      "description": "作者因经常摔飞机而用Astra构建。 报告不到24小时。 开源和飞行物理未独立核验。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 模拟与科学可视化",
+      "author": {
+        "name": "@adithya_s_k",
+        "url": "https://x.com/adithya_s_k"
+      },
+      "demoUrl": "https://x.com/adithya_s_k/status/2096261827961463280",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-398.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 455
+    },
+    {
+      "id": "work-9ed13ccf8ab00f96",
+      "name": "生成 SO-101 机械臂参数化 CAD",
+      "description": "作者让Astra创建参数化CAD。 未验证尺寸、装配或实机运动。",
+      "category": "tool",
+      "sourceCategory": "CheerSelfAI · 工程文件与代码迁移",
+      "author": {
+        "name": "@MakerMatters",
+        "url": "https://x.com/MakerMatters"
+      },
+      "demoUrl": "https://x.com/MakerMatters/status/2096262183281692918",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-399.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 456
+    },
+    {
+      "id": "work-3a15823d5d4b411a",
+      "name": "比较 Muse Spark Max 与 Astra 的 RocketLeagueBench",
+      "description": "在RocketLeagueBench比较Muse Spark1.3 Max与Astra。 未给定量成绩或测试配置，“差距大”为作者观点。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 专业研究与安全评测",
+      "author": {
+        "name": "@LLMJunky",
+        "url": "https://x.com/LLMJunky"
+      },
+      "demoUrl": "https://x.com/LLMJunky/status/2096262579815342093",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-400.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 457
+    },
+    {
+      "id": "work-4a7259cfe8ffdcde",
+      "name": "用五小时生成高密度可探索森林",
+      "description": "Astra使用Three.js与自定义shader。 植被数量与五小时为作者报告，未独立统计或测帧率。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@LexnLin",
+        "url": "https://x.com/LexnLin"
+      },
+      "demoUrl": "https://x.com/LexnLin/status/2096263046918197609",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-401.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 458
+    },
+    {
+      "id": "work-b1ba569543c1c24c",
+      "name": "将模糊房间参考图重建为 Blender 场景",
+      "description": "Astra中档通过Blender CLI建模并渲染。 作者报告团队计划5小时额度约40%、月额度约10%。 还有细部待修改；额度和多边形数量为作者报告。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@afrop_afr",
+        "url": "https://x.com/afrop_afr"
+      },
+      "demoUrl": "https://x.com/afrop_afr/status/2096263142829695246",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-402.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 459
+    },
+    {
+      "id": "work-4befd98587146056",
+      "name": "用30分钟构建 Fortnite 风格大逃杀",
+      "description": "作者称Astra从零构建。 30分钟和可玩性为作者报告，未来AAA预测不是已实现结果。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@luckeyfaraday",
+        "url": "https://x.com/luckeyfaraday"
+      },
+      "demoUrl": "https://x.com/luckeyfaraday/status/2096263629905571896",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-403.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 460
+    },
+    {
+      "id": "work-4eb383189875cc7b",
+      "name": "生成轻松简洁的个人博客首页",
+      "description": "作者用Astra生成并提供网站与开源代码线索。 作者报告和演示，未独立运行验收。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@Justin1024go",
+        "url": "https://x.com/Justin1024go"
+      },
+      "demoUrl": "https://x.com/Justin1024go/status/2096263641968611528",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-404.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 461
+    },
+    {
+      "id": "work-78cd3597ec788fdb",
+      "name": "将机器人模型扩成展示与荒野战斗两模式游戏",
+      "description": "参考卡兹克机器人建模，使用Astra、Blender和computer-use并自行迭代材质特效。 已有模型与人工迭代参与，未实际开源或验证完整功能。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@berryxia",
+        "url": "https://x.com/berryxia"
+      },
+      "demoUrl": "https://x.com/berryxia/status/2096264995151704418",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-405.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 462
+    },
+    {
+      "id": "work-821fa7252d1d1db7",
+      "name": "生成可运行的板式网球游戏",
+      "description": "作者持续测试Astra。 报告数小时得到可运行结果并计划继续改善。 作者报告和演示，未独立运行验收。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@AlanDaitch",
+        "url": "https://x.com/AlanDaitch"
+      },
+      "demoUrl": "https://x.com/AlanDaitch/status/2096265072817422369",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-406.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 463
+    },
+    {
+      "id": "work-978aa7cf4a34bf8b",
+      "name": "制作30秒鲨鱼短片",
+      "description": "Astra最高档、Seedance2.5与Topview协作。 模型贡献未拆清，不能将最终画面单独归给Astra。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@AiWithYou1",
+        "url": "https://x.com/AiWithYou1"
+      },
+      "demoUrl": "https://x.com/AiWithYou1/status/2096265891969384690",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-407.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 464
+    },
+    {
+      "id": "work-1c738f88b9b15725",
+      "name": "制作 Apple Intention 风格自我视频",
+      "description": "作者称一次生成。 未给工具或完整prompt，不推断与其他Apple风格演示同源。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@pallavmac",
+        "url": "https://x.com/pallavmac"
+      },
+      "demoUrl": "https://x.com/pallavmac/status/2096266857439539354",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-408.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 465
+    },
+    {
+      "id": "work-b66f471ccfc7ad22",
+      "name": "运行 MineBench 建模基准并比较有效率与成本",
+      "description": "MineBench平台在现有harness运行Astra Pro对照旧Sol。 报告所有构建首轮有效，平均25分54秒、估计总34.71美元。 费用仍待provider更新；未核验全套prompt及历史700美元对照。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 专业研究与安全评测",
+      "author": {
+        "name": "@minebench_ai",
+        "url": "https://x.com/minebench_ai"
+      },
+      "demoUrl": "https://x.com/minebench_ai/status/2096267157965275144",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-409.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 466
+    },
+    {
+      "id": "work-9a1889885b7e3a8a",
+      "name": "用单提示词制作产品宣传视频",
+      "description": "Topview平台展示Astra单条prompt流程。 未给产品名与完整过程，属于平台自营演示。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@TopviewAIhq",
+        "url": "https://x.com/TopviewAIhq"
+      },
+      "demoUrl": "https://x.com/TopviewAIhq/status/2096267361162797118",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-410.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 467
+    },
+    {
+      "id": "work-a70bd862752390a6",
+      "name": "把虚假手游广告视频做成可玩原型",
+      "description": "输入广告视频给Astra，按其中玩法开发。 作者称约20分钟。 未给广告具体游戏名或完整试玩，原型不代表成熟产品。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@givros",
+        "url": "https://x.com/givros"
+      },
+      "demoUrl": "https://x.com/givros/status/2096267413385875592",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-411.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 468
+    },
+    {
+      "id": "work-18c6ca060c94dec9",
+      "name": "展示 Astra 自动剪辑视频",
+      "description": "二手分享并指向原视频公开prompt的评论。 未取得完整prompt或素材，引用仅短链。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@yama_threads",
+        "url": "https://x.com/yama_threads"
+      },
+      "demoUrl": "https://x.com/yama_threads/status/2096267848104743260",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-412.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 469
+    },
+    {
+      "id": "work-badc5a44bc5d05df",
+      "name": "制作 Grand Theft Galaxy Neon Horizon 浏览器原型",
+      "description": "作者用Astra约20分钟制作。 作者明确prototype，未独立验收；引用CROWNFALL是不同游戏。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@HexxRL",
+        "url": "https://x.com/HexxRL"
+      },
+      "demoUrl": "https://x.com/HexxRL/status/2096268813016646029",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-413.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 470
+    },
+    {
+      "id": "work-5b736bcad2134b5d",
+      "name": "生成时空之轮风格浏览器游戏",
+      "description": "作者给Astra一句浏览器游戏指令。 作者报告和演示，未独立运行验收。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@hideki_climax",
+        "url": "https://x.com/hideki_climax"
+      },
+      "demoUrl": "https://x.com/hideki_climax/status/2096269008505053683",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-414.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 471
+    },
+    {
+      "id": "work-6b3b0efae1565226",
+      "name": "开发深海生物荧光交互落地页",
+      "description": "串联Astra与Claude Code，使用React/Next、Three.js、Tailwind和Framer Motion。 15000美元是宣传定位，非实际成交或可验证成本。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@himanshubuildss",
+        "url": "https://x.com/himanshubuildss"
+      },
+      "demoUrl": "https://x.com/himanshubuildss/status/2096269057544831175",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-415.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 472
+    },
+    {
+      "id": "work-c169e9772c6777f1",
+      "name": "根据黑白草图重建布雷未建成的牛顿纪念堂",
+      "description": "给Astra少量1784年黑白草图和描述。 从未建成建筑的想象重建，未验证与设计方案所有细节对应。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@emollick",
+        "url": "https://x.com/emollick"
+      },
+      "demoUrl": "https://x.com/emollick/status/2096270461122347131",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-416.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 473
+    },
+    {
+      "id": "work-9e7524d658e0549c",
+      "name": "制作 Pudgy Penguins 主题三维网页作品",
+      "description": "Astra与Three.js单提示词生成。 作者称不到30分钟。 作者报告和演示，未独立运行验收。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@FoxyPenguinApe",
+        "url": "https://x.com/FoxyPenguinApe"
+      },
+      "demoUrl": "https://x.com/FoxyPenguinApe/status/2096273197083808029",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-417.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 474
+    },
+    {
+      "id": "work-9a707eeb3ed91d87",
+      "name": "用 PixelFork 和 Three.js 制作赛车游戏",
+      "description": "作者使用PixelFork、Astra和Three.js。 称不到10分钟。 作者报告和演示，未独立运行验收。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@zaur_ibra",
+        "url": "https://x.com/zaur_ibra"
+      },
+      "demoUrl": "https://x.com/zaur_ibra/status/2096273776996426055",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-418.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 475
+    },
+    {
+      "id": "work-424ec6c522d802b3",
+      "name": "构建真新镇与盗梦空间交叉三维场景",
+      "description": "作者直接给Astra该主题创意。 作者报告和演示，未独立运行验收。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@yungcontent",
+        "url": "https://x.com/yungcontent"
+      },
+      "demoUrl": "https://x.com/yungcontent/status/2096275376125436214",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-419.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 476
+    },
+    {
+      "id": "work-1c327ffd574005af",
+      "name": "制作 A Room Made of Replies 并改进视频工具",
+      "description": "Astra在eidoverse-video中边制片边改善工具。 物理精确性为作者说法，不证明控制真实机器人能力。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@SkyeSharkie",
+        "url": "https://x.com/SkyeSharkie"
+      },
+      "demoUrl": "https://x.com/SkyeSharkie/status/2096276401204936939",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-420.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 477
+    },
+    {
+      "id": "work-3e96dc7a3979b436",
+      "name": "比较 Astra 与 Sol 的植物生长动画",
+      "description": "Astra在左、Sol5.6在右。 作者主观评价，未给prompt和运行成本。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@developedbyed",
+        "url": "https://x.com/developedbyed"
+      },
+      "demoUrl": "https://x.com/developedbyed/status/2096276420804657257",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-421.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 478
+    },
+    {
+      "id": "work-7634d2a7ff0dc044",
+      "name": "汇总 Peter Gostev 的63组三维世界生成测试",
+      "description": "二手描述无挑选的一次生成实验，引用Arena AI评测介绍。 未打开63条仓库或完整评测，课程价值宣传不作事实；全部样本计一组评测。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 专业研究与安全评测",
+      "author": {
+        "name": "@sopersone",
+        "url": "https://x.com/sopersone"
+      },
+      "demoUrl": "https://x.com/sopersone/status/2096276504368017826",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-422.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 479
+    },
+    {
+      "id": "work-de83622bb60398a5",
+      "name": "测试作曲与演奏肖邦风格夜曲",
+      "description": "作者以引用中的肖邦夜曲标准进行单次测试。 作者评价不佳。 主观音乐测试，未披露演奏工具或乐谱。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@uncledoomer",
+        "url": "https://x.com/uncledoomer"
+      },
+      "demoUrl": "https://x.com/uncledoomer/status/2096276626560503843",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-423.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 480
+    },
+    {
+      "id": "work-54f20b4a9271b738",
+      "name": "比较 Three.js WebGPU 弹性果冻生成",
+      "description": "Astra与Fable5.1均制作美味外观、可弹跳果冻。 作者报告Fable35分钟约15美元，Astra80分钟约20美元。 费用与计时为作者报告，评价主观。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 模拟与科学可视化",
+      "author": {
+        "name": "@vikktorrrre",
+        "url": "https://x.com/vikktorrrre"
+      },
+      "demoUrl": "https://x.com/vikktorrrre/status/2096278239773700351",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-424.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 481
+    },
+    {
+      "id": "work-ac5889c636fc1bcd",
+      "name": "把科研框架图重建为可编辑 PowerPoint",
+      "description": "将PaperBanana以Nano Banana Pro生成的原图交给Astra重建。 对照为作者展示，未下载文件验证可编辑性。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@dwzhu128",
+        "url": "https://x.com/dwzhu128"
+      },
+      "demoUrl": "https://x.com/dwzhu128/status/2096279239255576852",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-425.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 482
+    },
+    {
+      "id": "work-a487e8e23bfc06e5",
+      "name": "生成高细节可交互 V8 发动机",
+      "description": "作者向Astra提出交互发动机任务。 未验证工程精度；与其他作者同题不直接合并。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 模拟与科学可视化",
+      "author": {
+        "name": "@DilumSanjaya",
+        "url": "https://x.com/DilumSanjaya"
+      },
+      "demoUrl": "https://x.com/DilumSanjaya/status/2096280244663775423",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-427.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 483
+    },
+    {
+      "id": "work-9fd7249119148cfa",
+      "name": "建模蟠桃园并在剪映完成30秒短片",
+      "description": "Astra medium fast做6轮建模、调用MiniMax配乐，并操作剪映重排镜头、变速、加字幕封面。 全流程约110分钟含沟通渲染检查。 耗时来自作者实际记录，非无人单次生成。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@nicekate8888",
+        "url": "https://x.com/nicekate8888"
+      },
+      "demoUrl": "https://x.com/nicekate8888/status/2096280438717448531",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-428.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 484
+    },
+    {
+      "id": "work-99b508afb7d9c607",
+      "name": "把8分钟口播剪成7分钟并自动加字幕",
+      "description": "Astra直接操作电脑，删除重复、停顿和说错段落。 作者称初稿连贯，专业术语字幕错误少。 仍为初剪；准确率未量化。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@tiabitcoin",
+        "url": "https://x.com/tiabitcoin"
+      },
+      "demoUrl": "https://x.com/tiabitcoin/status/2096280487262409177",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-429.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 485
+    },
+    {
+      "id": "work-2eed2aab836249ba",
+      "name": "用 JavaScript 绘制蒙娜丽莎",
+      "description": "作者让Astra用JavaScript作画。 作者报告和演示，未独立运行验收。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@NovaXCode",
+        "url": "https://x.com/NovaXCode"
+      },
+      "demoUrl": "https://x.com/NovaXCode/status/2096280576361898483",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-430.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 486
+    },
+    {
+      "id": "work-7e53463655a25e9f",
+      "name": "为 Unity 卡牌实现背景与角色分开的闪卡效果",
+      "description": "Astra配合Unity制作，并按要求区分背景与角色效果。 作者报告和演示，未独立运行验收。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@ShadeLurk",
+        "url": "https://x.com/ShadeLurk"
+      },
+      "demoUrl": "https://x.com/ShadeLurk/status/2096281715958554784",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-431.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 487
+    },
+    {
+      "id": "work-3986d244c21ca572",
+      "name": "制作 One More Vine 藤蔓冒险游戏",
+      "description": "作者用Astra开发并给出在线试玩。 作者报告和演示，未独立运行验收。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@bennash",
+        "url": "https://x.com/bennash"
+      },
+      "demoUrl": "https://x.com/bennash/status/2096282758930645170",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-432.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 488
+    },
+    {
+      "id": "work-5106b2e6cff76176",
+      "name": "一次生成 motion design 短片",
+      "description": "作者称Astra一次生成。 没有给具体主题、底层工具或完整prompt。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@Kirako_ai",
+        "url": "https://x.com/Kirako_ai"
+      },
+      "demoUrl": "https://x.com/Kirako_ai/status/2096283314046767369",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-433.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 489
+    },
+    {
+      "id": "work-2c6d3011eb5f841e",
+      "name": "构建链上新发行扫描与模拟交易终端",
+      "description": "作者用Astra构建bot，以四项合约门槛控制模拟交易。 演示0.3ETH、30K市值和66x是模拟曲线，原帖明确非真实成交。 不证明实盘收益或风控有效，仅模拟逻辑展示。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@0xBackwood",
+        "url": "https://x.com/0xBackwood"
+      },
+      "demoUrl": "https://x.com/0xBackwood/status/2096283642314006583",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-434.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 490
+    },
+    {
+      "id": "work-250d4bb2890affe5",
+      "name": "从一张平面图生成建筑场景与渲染",
+      "description": "Astra生成场景代码，Higgsfield在Blender建模并用Cycles渲染。 平台演示，未核查户型尺寸准确性。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096284092593758631",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-435.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 491
+    },
+    {
+      "id": "work-d1a7fe58a5cead58",
+      "name": "构建糟糕营销创意博物馆",
+      "description": "作者用Astra把营销反例做成主题博物馆。 作者报告和演示，未独立运行验收。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@ecomchasedimond",
+        "url": "https://x.com/ecomchasedimond"
+      },
+      "demoUrl": "https://x.com/ecomchasedimond/status/2096285235961045307",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-436.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 492
+    },
+    {
+      "id": "work-c2f185fa21442a70",
+      "name": "单提示词生成三维火山",
+      "description": "作者首次测试Astra三维能力。 作者称使用周额度3%。 额度为个人计划消耗，未披露建模配置。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@0xRemakw",
+        "url": "https://x.com/0xRemakw"
+      },
+      "demoUrl": "https://x.com/0xRemakw/status/2096285870768668943",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-437.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 493
+    },
+    {
+      "id": "work-bbb313f62192a46f",
+      "name": "重建 Konrad Zuse Z3 计算机",
+      "description": "Astra与Higgsfield重建。 未验证机械或计算功能的真实复刻。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096286544286175611",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-438.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 494
+    },
+    {
+      "id": "work-2901353fccab9a03",
+      "name": "在 CPU 环境运行 DOOM 并比较帧率",
+      "description": "作者对比旧Sol约1FPS与Astra结果。 作者报告Astra达到20+FPS。 原帖称在其CPU上运行，未说明CPU实现或架构；帧率未经独立测量。",
+      "category": "tool",
+      "sourceCategory": "CheerSelfAI · 工程文件与代码迁移",
+      "author": {
+        "name": "@Angaisb_",
+        "url": "https://x.com/Angaisb_"
+      },
+      "demoUrl": "https://x.com/Angaisb_/status/2096287643654840561",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-439.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 495
+    },
+    {
+      "id": "work-d4e19794f16d76cf",
+      "name": "生成 Codex Micro 的 Grok Bot 风格三维版本",
+      "description": "原帖给出单条生成指令。 作者报告和演示，未独立运行验收。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@omarsar0",
+        "url": "https://x.com/omarsar0"
+      },
+      "demoUrl": "https://x.com/omarsar0/status/2096288397811679718",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-440.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 496
+    },
+    {
+      "id": "work-52735c35bc7c6769",
+      "name": "对照 cozy Japan 2.0 场景生成",
+      "description": "作者在同一prompt上运行Astra，引用自己Fable旧作。 作者不确定Astra是否更优，认为可能是审美偏好。 作者报告和演示，未独立运行验收。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@0xPaulius",
+        "url": "https://x.com/0xPaulius"
+      },
+      "demoUrl": "https://x.com/0xPaulius/status/2096288936565817668",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-441.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 497
+    },
+    {
+      "id": "work-635d3da3ce5d91a6",
+      "name": "在 Roblox 重建 Higgsfield 办公室",
+      "description": "平台让Astra在Roblox重建自家办公室。 作者报告和演示，未独立运行验收。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096290616271577239",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-442.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 498
+    },
+    {
+      "id": "work-43168960ed881a35",
+      "name": "展示单提示词生成的浏览器三维游戏",
+      "description": "二手声称一条提示词生成整个游戏。 14000对象、120FPS、5分钟及盲测85%等均无原始证据，不作验证结论；引用索尼克可能是另一演示。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@shmidtqq",
+        "url": "https://x.com/shmidtqq"
+      },
+      "demoUrl": "https://x.com/shmidtqq/status/2096290771288961169",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-443.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 499
+    },
+    {
+      "id": "work-e71798194536df98",
+      "name": "开发截图转可探索三维世界网站",
+      "description": "作者用Astra构建截图转三维体验。 未独立验证任意截图的泛化效果。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@yungcontent",
+        "url": "https://x.com/yungcontent"
+      },
+      "demoUrl": "https://x.com/yungcontent/status/2096291179843440952",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-444.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 500
+    },
+    {
+      "id": "work-c113d6572bd1bd8d",
+      "name": "根据原视频与素材制作线框教程视频",
+      "description": "输入视频与素材，让Astra处理并在Flova制作。 各工具具体分工未拆清。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@Cupang1997",
+        "url": "https://x.com/Cupang1997"
+      },
+      "demoUrl": "https://x.com/Cupang1997/status/2096291647927792037",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-445.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 501
+    },
+    {
+      "id": "work-812b60c115e76740",
+      "name": "创作钢琴圆舞曲并让三维钢琴家按音符演奏",
+      "description": "Astra与Higgsfield组合音乐、代码和动画。 手指逐音对应为平台主张，未核验音画同步。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096292350180163648",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-446.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 502
+    },
+    {
+      "id": "work-5f8c4ca5cfd31393",
+      "name": "生成圣家堂三维导览",
+      "description": "Astra建模，Unreal Engine渲染，运行于Higgsfield Supercomputer。 作者报告和演示，未独立运行验收。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@adilinthewild",
+        "url": "https://x.com/adilinthewild"
+      },
+      "demoUrl": "https://x.com/adilinthewild/status/2096292643101904985",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-447.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 503
+    },
+    {
+      "id": "work-cddd2832c197ece9",
+      "name": "对照20次抓积木放入碗中的操作任务",
+      "description": "各给20次抓放任务。 报告Astra95%、2.5分钟、每次0.94美元，Fable40%、6.8分钟、2.12美元。 运行环境与原始记录未给，指标为帖子报告。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 专业研究与安全评测",
+      "author": {
+        "name": "@alexgetmancom",
+        "url": "https://x.com/alexgetmancom"
+      },
+      "demoUrl": "https://x.com/alexgetmancom/status/2096293480075002060",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-448.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 504
+    },
+    {
+      "id": "work-76477f89969db2cb",
+      "name": "生成可拉伸的橙片软糖网页",
+      "description": "作者让Astra生成gummy orange slice。 作者报告和演示，未独立运行验收。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@vib3coded",
+        "url": "https://x.com/vib3coded"
+      },
+      "demoUrl": "https://x.com/vib3coded/status/2096293644298784949",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-449.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 505
+    },
+    {
+      "id": "work-8c7f76a5a7085c84",
+      "name": "在 MineBench 测试地球大陆建模",
+      "description": "平台用Astra Pro运行社区提示词并展出结果。 平台称首次准确表现所有大陆。 大陆准确性为平台评价，未验证全部样本。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 专业研究与安全评测",
+      "author": {
+        "name": "@minebench_ai",
+        "url": "https://x.com/minebench_ai"
+      },
+      "demoUrl": "https://x.com/minebench_ai/status/2096294038357913797",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-450.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 506
+    },
+    {
+      "id": "work-f2bbede9eb562665",
+      "name": "用 Bricklink Studio 设计积木并渲染4K视频",
+      "description": "Astra操作Bricklink Studio设计，再用Blender渲染。 未下载零件表或验证实体可装配。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@dkundel",
+        "url": "https://x.com/dkundel"
+      },
+      "demoUrl": "https://x.com/dkundel/status/2096297005924729240",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-451.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 507
+    },
+    {
+      "id": "work-edfe867c34ca3a47",
+      "name": "重建火影忍者木叶村",
+      "description": "Higgsfield与Astra协作。 作者称10–15分钟。 作者报告和演示，未独立运行验收。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@adilinthewild",
+        "url": "https://x.com/adilinthewild"
+      },
+      "demoUrl": "https://x.com/adilinthewild/status/2096297824053063957",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-452.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 508
+    },
+    {
+      "id": "work-2c3ec48e6fd7ceb2",
+      "name": "在 Blender 重建里斯本商业广场",
+      "description": "作者用Astra High一条提示词重做其大学图形学课程题目。 作者一次测试，未核查与原建筑一致性。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@goncalo_canhoto",
+        "url": "https://x.com/goncalo_canhoto"
+      },
+      "demoUrl": "https://x.com/goncalo_canhoto/status/2096298425914450021",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-453.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 509
+    },
+    {
+      "id": "work-2fcf7d303d43e4e3",
+      "name": "重建温哥华 Credit Foncier Building",
+      "description": "二手描述Astra建模、编辑引擎场景并测试修正。 转述约30分钟。 二手帖子未给原作者；测试和耗时未独立确认。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@Lummox_eth",
+        "url": "https://x.com/Lummox_eth"
+      },
+      "demoUrl": "https://x.com/Lummox_eth/status/2096298583431467093",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-454.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 510
+    },
+    {
+      "id": "work-9bc1da21770050b1",
+      "name": "液态玻璃三维渲染",
+      "description": "液态玻璃效果的三维渲染",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@stevibe",
+        "url": "https://x.com/stevibe"
+      },
+      "demoUrl": "https://x.com/stevibe/status/2096300155477934368",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-455.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 511
+    },
+    {
+      "id": "work-12cab97fd52cbf86",
+      "name": "代理群代码审核与研究分工",
+      "description": "观察九天使用情况后移除四个不常用代理，并调整审批。 效率收益未给出独立量化；不把去审批推广为通用建议。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@Roxx_0x",
+        "url": "https://x.com/Roxx_0x"
+      },
+      "demoUrl": "https://x.com/Roxx_0x/status/2096300416799801435",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-456.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 512
+    },
+    {
+      "id": "work-eedd3a9ce83add1e",
+      "name": "组件参考驱动的个人作品集",
+      "description": "参考 Rare UI 组件制作的个人作品集页面 参考组件参与设计，不称完全从零独立设计。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@code_kartik",
+        "url": "https://x.com/code_kartik"
+      },
+      "demoUrl": "https://x.com/code_kartik/status/2096300833583624261",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-457.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 513
+    },
+    {
+      "id": "work-7a8d332440c16445",
+      "name": "直播制作并打印可运转齿轮",
+      "description": "经 3D 打印并展示运动的齿轮设计 八小时直播和运转情况为作者证据，未独立做机械测试。",
+      "category": "tool",
+      "sourceCategory": "CheerSelfAI · 工程文件与代码迁移",
+      "author": {
+        "name": "@_MaxBlade",
+        "url": "https://x.com/_MaxBlade"
+      },
+      "demoUrl": "https://x.com/_MaxBlade/status/2096302486277480532",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-458.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 514
+    },
+    {
+      "id": "work-b6fcd2232c87bfc3",
+      "name": "纽约五百年城市变迁展示",
+      "description": "覆盖五百年的纽约历史与未来三维变化 历史部分未核验，未来部分属于想象。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096303855806058934",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-459.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 515
+    },
+    {
+      "id": "work-7f8e0f960665636d",
+      "name": "吉祥物动画生成",
+      "description": "单次生成的吉祥物动画片段",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@tenseidesign",
+        "url": "https://x.com/tenseidesign"
+      },
+      "demoUrl": "https://x.com/tenseidesign/status/2096305008748965921",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-460.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 516
+    },
+    {
+      "id": "work-890c2bbb7b418cdd",
+      "name": "After Effects 参考动效重建",
+      "description": "分析视频动作与时序，然后逐元素建立合成。 二十分钟为平台记录。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096306588978196786",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-461.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 517
+    },
+    {
+      "id": "work-1c706b04c57ff3f0",
+      "name": "产品图到 UGC 鞋广告",
+      "description": "Astra 组织产品图和分镜，结合图像视频工具生成广告。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@jerrod_lew",
+        "url": "https://x.com/jerrod_lew"
+      },
+      "demoUrl": "https://x.com/jerrod_lew/status/2096307244921164232",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-462.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 518
+    },
+    {
+      "id": "work-3bc97702c10bc6ca",
+      "name": "摄像头控制的无接触簧风琴",
+      "description": "先让模型观察硬件并建议项目，再据此构建演奏交互。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@shydev69",
+        "url": "https://x.com/shydev69"
+      },
+      "demoUrl": "https://x.com/shydev69/status/2096308047186719077",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-463.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 519
+    },
+    {
+      "id": "work-6d5d391333e55450",
+      "name": "反乌托邦城市第一人称游戏",
+      "description": "包含蜘蛛、僵尸、战争机器与守卫的城市 FPS 原型",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@techartist_",
+        "url": "https://x.com/techartist_"
+      },
+      "demoUrl": "https://x.com/techartist_/status/2096308761535394034",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-464.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 520
+    },
+    {
+      "id": "work-d672c315480285b9",
+      "name": "户型设计到 Unreal 房屋漫游",
+      "description": "模型设计平面布局、用命令行 Blender 建模，建立导出流程并启动画面检查和修改。 60 FPS 为原作者陈述；尚未验证客户改动能否自动贯穿两工具。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@lagerskoy",
+        "url": "https://x.com/lagerskoy"
+      },
+      "demoUrl": "https://x.com/lagerskoy/status/2096308799942595052",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-465.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 521
+    },
+    {
+      "id": "work-697a6359041acaa6",
+      "name": "五关 2D 射击游戏与预告片",
+      "description": "五个关卡的 2D 射击游戏及预告视频 三次提示、两次修订和六十分钟为作者记录。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@kiyoshi_shin",
+        "url": "https://x.com/kiyoshi_shin"
+      },
+      "demoUrl": "https://x.com/kiyoshi_shin/status/2096312253918421028",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-466.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 522
+    },
+    {
+      "id": "work-a0ec27e84a9da1ae",
+      "name": "行情驱动的大逃杀可视化",
+      "description": "将成交量和流动性映射到大逃杀角色血条的动态界面 实时数据接入为作者陈述，不作为投资效果证明。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@explosss1ve",
+        "url": "https://x.com/explosss1ve"
+      },
+      "demoUrl": "https://x.com/explosss1ve/status/2096313084692337025",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-467.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 523
+    },
+    {
+      "id": "work-6a07b148471e4e24",
+      "name": "Xunantunich 玛雅遗址三维场景",
+      "description": "Xunantunich 遗址三维模型 两小时用时与历史准确性未独立验证。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@omarsar0",
+        "url": "https://x.com/omarsar0"
+      },
+      "demoUrl": "https://x.com/omarsar0/status/2096314593182171545",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-468.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 524
+    },
+    {
+      "id": "work-1d821b15c8a69a46",
+      "name": "38 页木屋图纸转三维模型",
+      "description": "由 PDF 图纸与效果图生成内外部木屋三维模型 十分钟及按比例重建为作者自述，未做尺寸复测。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@LukeW",
+        "url": "https://x.com/LukeW"
+      },
+      "demoUrl": "https://x.com/LukeW/status/2096318130507436073",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-469.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 525
+    },
+    {
+      "id": "work-3be5f0d17a1fffe3",
+      "name": "CapCut 剪辑结合本机转写",
+      "description": "Astra 负责电脑剪辑操作，Gemma 负责设备端转写。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@ivanleomk",
+        "url": "https://x.com/ivanleomk"
+      },
+      "demoUrl": "https://x.com/ivanleomk/status/2096318169497620699",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-470.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 526
+    },
+    {
+      "id": "work-62377b1321acff1b",
+      "name": "Python 随机车流与单向红绿灯测试",
+      "description": "随机车流、单向道路及交通灯的可视化对照 以帖文为准记录 Astra High 的尝试，未独立测算法正确性。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@diegocabezas01",
+        "url": "https://x.com/diegocabezas01"
+      },
+      "demoUrl": "https://x.com/diegocabezas01/status/2096319081280401640",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-471.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 527
+    },
+    {
+      "id": "work-0ccbe36da61e137f",
+      "name": "温哥华 Science World 三维重建",
+      "description": "Science World 建筑的三维模型",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@tokifyi",
+        "url": "https://x.com/tokifyi"
+      },
+      "demoUrl": "https://x.com/tokifyi/status/2096319441072255363",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-472.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 528
+    },
+    {
+      "id": "work-9b2dab9d907f0b2f",
+      "name": "Blender 新闻节目开场动画",
+      "description": "含地球、轨道元素及动态标题的新闻开场片",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096320620862841139",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-473.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 529
+    },
+    {
+      "id": "work-396b38cfc8ab33db",
+      "name": "制造车间 ERP 生产追踪",
+      "description": "跟踪单位、阶段、员工、工序和材料问题的 ERP 界面 面向客户的交互追踪为后续计划。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@dfwstrategy",
+        "url": "https://x.com/dfwstrategy"
+      },
+      "demoUrl": "https://x.com/dfwstrategy/status/2096322330977095881",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-474.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 530
+    },
+    {
+      "id": "work-15b9e327a4693d60",
+      "name": "单提示词产品发布视频",
+      "description": "使用 Astra 制作的产品发布视频 具体剪辑或渲染工具未说明。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@dchernyshuk",
+        "url": "https://x.com/dchernyshuk"
+      },
+      "demoUrl": "https://x.com/dchernyshuk/status/2096325356294910456",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-475.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 531
+    },
+    {
+      "id": "work-636a8e84754cbad2",
+      "name": "Cinema 4D 卡丁车竞速动画",
+      "description": "Cinema 4D 卡丁车竞速片段",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096325376809341069",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-476.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 532
+    },
+    {
+      "id": "work-7bd447f4fa4ad775",
+      "name": "蜘蛛侠蛛丝移动游戏",
+      "description": "带蛛丝摆荡、道路和界面的 Spider-Man 风格游戏 单提示词完成是发布者转述。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@Mr_Salio",
+        "url": "https://x.com/Mr_Salio"
+      },
+      "demoUrl": "https://x.com/Mr_Salio/status/2096326748979765268",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-477.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 533
+    },
+    {
+      "id": "work-425fd1e764f21612",
+      "name": "机器人进入新房间启动洗衣机",
+      "description": "连接 Astra 的机器人识别并旋转洗衣机旋钮 实体操作成功为发布者陈述，未独立重复试验。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@ARXrobotics",
+        "url": "https://x.com/ARXrobotics"
+      },
+      "demoUrl": "https://x.com/ARXrobotics/status/2096328304794210604",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-478.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 534
+    },
+    {
+      "id": "work-cca8d9fbcf0ebe9e",
+      "name": "Apple Log 2 视频调色",
+      "description": "对 Apple Log 2 素材的对比度、阴影和色彩调整",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096330570712400319",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-479.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 535
+    },
+    {
+      "id": "work-1dcca62dbe28f2e7",
+      "name": "Higgsfield 场景搭建与视频风格处理",
+      "description": "先场景构建，再由视频模型处理风格。 具体场景内容未在正文详述。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@Kiber_Alla",
+        "url": "https://x.com/Kiber_Alla"
+      },
+      "demoUrl": "https://x.com/Kiber_Alla/status/2096330873427669455",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-480.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 536
+    },
+    {
+      "id": "work-a99ade911369d8f5",
+      "name": "多代理行情观察与交易执行演示",
+      "description": "分配角色、共享目录，风控代理否决条件不合格的入场。 未核验账户、真实成交或收益，帖称 67 美元变 4560 美元不能视为验证结果。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@immortalhowwl",
+        "url": "https://x.com/immortalhowwl"
+      },
+      "demoUrl": "https://x.com/immortalhowwl/status/2096331356389232994",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-481.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 537
+    },
+    {
+      "id": "work-9cc538ff9b68ffd4",
+      "name": "Figma 参考图转可编辑画面",
+      "description": "包含轮廓、人脸、徽记、纹理的 Figma 画面",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096333291943338210",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-482.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 538
+    },
+    {
+      "id": "work-f08c921f794dc3d1",
+      "name": "依据参考图进行视频调色",
+      "description": "在 DaVinci Resolve 按参考图调整视频色彩 四分钟为平台陈述。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096334648016253339",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-483.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 539
+    },
+    {
+      "id": "work-49ebf613d71dea02",
+      "name": "参考龙图转十秒 Blender 镜头",
+      "description": "通过无界面 Blender 的 Python 脚本持续迭代。 八小时为作者陈述；GUI 测试是后续计划。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@doomdave",
+        "url": "https://x.com/doomdave"
+      },
+      "demoUrl": "https://x.com/doomdave/status/2096335588727349434",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-484.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 540
+    },
+    {
+      "id": "work-e81e7d006f520e85",
+      "name": "单文件 HTML 视觉页面",
+      "description": "由单个 HTML 文件构成的视觉页面 根帖没有提供足够文字命名页面主题，保留为网页演示。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@MiaAI_lab",
+        "url": "https://x.com/MiaAI_lab"
+      },
+      "demoUrl": "https://x.com/MiaAI_lab/status/2096336323183284675",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-485.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 541
+    },
+    {
+      "id": "work-20014c626ae37cb0",
+      "name": "体素城堡村庄与风车麦田",
+      "description": "包含城堡、村庄、风车及麦田的体素场景 412364 根麦秆与五分钟生成是作者自述。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@filicroval",
+        "url": "https://x.com/filicroval"
+      },
+      "demoUrl": "https://x.com/filicroval/status/2096337088396300507",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-486.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 542
+    },
+    {
+      "id": "work-346b2be440ca40fa",
+      "name": "ORBITAL 太阳系探索模拟",
+      "description": "八颗行星、二十颗卫星与简化飞行的太阳系 物理与天体尺度采用简化设定，未独立核验。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@dzhohola",
+        "url": "https://x.com/dzhohola"
+      },
+      "demoUrl": "https://x.com/dzhohola/status/2096339041679442428",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-487.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 543
+    },
+    {
+      "id": "work-80a82879d3904941",
+      "name": "精细 3D 相机模型",
+      "description": "含 122 组、1877 个零件的 Three.js 相机模型 零件统计未独立验证。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@omarsar0",
+        "url": "https://x.com/omarsar0"
+      },
+      "demoUrl": "https://x.com/omarsar0/status/2096339043919237288",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-488.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 544
+    },
+    {
+      "id": "work-edc094b3d596cdd4",
+      "name": "浏览器海洋场景开发",
+      "description": "迭代五小时以上的浏览器海洋场景 开发时长和与其他模型比较为作者体验。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@LexnLin",
+        "url": "https://x.com/LexnLin"
+      },
+      "demoUrl": "https://x.com/LexnLin/status/2096341945979383932",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-489.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 545
+    },
+    {
+      "id": "work-beeacf0a53bf0775",
+      "name": "Astra 与 Fable 胜利界面对照",
+      "description": "两模型生成游戏胜利画面的界面对照 未从视频独立判定胜负。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@developedbyed",
+        "url": "https://x.com/developedbyed"
+      },
+      "demoUrl": "https://x.com/developedbyed/status/2096342406991843555",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-490.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 546
+    },
+    {
+      "id": "work-996c7f2a0bc20da9",
+      "name": "角色概念到绑定和动画的多工具制作",
+      "description": "概念和纹理转三维，Blender 完成拓扑、UV、绑定并检查返工，再进入视频生成。 30 分钟及可用于生产的判断是平台自述。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096342420543660277",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-491.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 547
+    },
+    {
+      "id": "work-b90d22ee76a043bb",
+      "name": "浏览器 Factorio 风格游戏",
+      "description": "在浏览器运行的 Factorio 风格克隆游戏",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@ephraimduncan",
+        "url": "https://x.com/ephraimduncan"
+      },
+      "demoUrl": "https://x.com/ephraimduncan/status/2096342660214649245",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-492.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 548
+    },
+    {
+      "id": "work-846199659cebb5ef",
+      "name": "旋律生成与音乐可视化分工",
+      "description": "不同模型分别负责音乐与可视化。 可视化不归因为 Astra 独立产物。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@R2Cdev_",
+        "url": "https://x.com/R2Cdev_"
+      },
+      "demoUrl": "https://x.com/R2Cdev_/status/2096343375339303253",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-493.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 549
+    },
+    {
+      "id": "work-a464f0bef876f880",
+      "name": "单提示词 Object Show 短片",
+      "description": "Astra Pro 生成的 Object Show 视频 未披露具体视频生成工具。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@AiCanvas88957",
+        "url": "https://x.com/AiCanvas88957"
+      },
+      "demoUrl": "https://x.com/AiCanvas88957/status/2096344373415862616",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-494.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 550
+    },
+    {
+      "id": "work-7125dfab2ee807ee",
+      "name": "Blender 动画到 Magnific 视频",
+      "description": "Astra 建模与关键帧导出，再交给视频工具。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@jerrod_lew",
+        "url": "https://x.com/jerrod_lew"
+      },
+      "demoUrl": "https://x.com/jerrod_lew/status/2096344802371703116",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-495.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 551
+    },
+    {
+      "id": "work-7b1bec7bf07da0c0",
+      "name": "Vice City 直升机任务操作测试",
+      "description": "以 GTA Vice City 直升机任务测试模型操作能力 帖子未给出任务完成率或最终成功结论。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@yuntiandeng",
+        "url": "https://x.com/yuntiandeng"
+      },
+      "demoUrl": "https://x.com/yuntiandeng/status/2096346317479870830",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-496.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 552
+    },
+    {
+      "id": "work-1ca0475228b056e1",
+      "name": "趋势选题到 YouTube Shorts 发布",
+      "description": "研究趋势并生成、配标题标签和发布十支 Shorts 的工作流 十支视频及观看效果为平台陈述，未访问频道验证。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096346331623358796",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-497.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 553
+    },
+    {
+      "id": "work-4aeb151113b5767c",
+      "name": "SwiftUI 活动监视器界面",
+      "description": "Pro 提供设计、Astra Light 负责实现。 44 分钟为作者记录；不把设计全归给 Astra。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@wieslawsoltes",
+        "url": "https://x.com/wieslawsoltes"
+      },
+      "demoUrl": "https://x.com/wieslawsoltes/status/2096346434706481274",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-498.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 554
+    },
+    {
+      "id": "work-1a246caeb01c0a21",
+      "name": "Illustrator 原生插画与导出排障",
+      "description": "在文件选择器冻结后经 Finder 绕过并完成导出。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096347209512178008",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-499.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 555
+    },
+    {
+      "id": "work-2407f7fdd02d5049",
+      "name": "ForgeCAD 机器狗设计",
+      "description": "ForgeCAD 中的机器狗设计模型 未证明制成实体或具备运动能力。",
+      "category": "tool",
+      "sourceCategory": "CheerSelfAI · 工程文件与代码迁移",
+      "author": {
+        "name": "@ruben_kostard",
+        "url": "https://x.com/ruben_kostard"
+      },
+      "demoUrl": "https://x.com/ruben_kostard/status/2096348087425871979",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-500.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 556
+    },
+    {
+      "id": "work-ef272197f8b9bc56",
+      "name": "Blender 对角巷漫游",
+      "description": "分步骤生成场景并设置漫游摄像机。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@koldo2k",
+        "url": "https://x.com/koldo2k"
+      },
+      "demoUrl": "https://x.com/koldo2k/status/2096348588930461731",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-501.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 557
+    },
+    {
+      "id": "work-3f0311e08594e072",
+      "name": "儿童制作 3D 火箭游戏",
+      "description": "作者称其十岁孩子制作的 3D 火箭游戏 作者转述孩子的制作过程。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@AIStockSavvy",
+        "url": "https://x.com/AIStockSavvy"
+      },
+      "demoUrl": "https://x.com/AIStockSavvy/status/2096350330661335365",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-502.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 558
+    },
+    {
+      "id": "work-7f9a0c06063c8522",
+      "name": "动画剑斗从分镜到剪辑",
+      "description": "简述转 Blender 预演，再生成镜头并剪辑。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096352124754104618",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-503.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 559
+    },
+    {
+      "id": "work-ed315901660f0dc7",
+      "name": "3D 游戏截图评分迭代工作流",
+      "description": "使用截图审查反馈迭代游戏视觉，目标超过 8 分。 评分来自作者自设循环，非独立质量测评。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@aisearchio",
+        "url": "https://x.com/aisearchio"
+      },
+      "demoUrl": "https://x.com/aisearchio/status/2096354119368028257",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-504.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 560
+    },
+    {
+      "id": "work-dca6a651f46c95bc",
+      "name": "五分钟 Three.js 外星人",
+      "description": "Three.js 外星人三维角色 五分钟为作者自述。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@CryptoVonDoom",
+        "url": "https://x.com/CryptoVonDoom"
+      },
+      "demoUrl": "https://x.com/CryptoVonDoom/status/2096354164301537484",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-505.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 561
+    },
+    {
+      "id": "work-57515236cfec17d8",
+      "name": "以本人形象构建实时约会模拟器",
+      "description": "结合本人形象与实时对话制作约会体验。 引用同作者较早演示作为背景；未亲自试玩。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@meh_agarwal",
+        "url": "https://x.com/meh_agarwal"
+      },
+      "demoUrl": "https://x.com/meh_agarwal/status/2096355359334269076",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-506.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 562
+    },
+    {
+      "id": "work-e7d58f9d4390a383",
+      "name": "Minecraft 方块光照修改与额度消耗",
+      "description": "单个方块光照修改耗尽两份 Plus 额度的测试 六分钟和订阅额度消耗为作者自述，不换算成 API 成本。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@pigeon__s",
+        "url": "https://x.com/pigeon__s"
+      },
+      "demoUrl": "https://x.com/pigeon__s/status/2096355632031089029",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-507.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 563
+    },
+    {
+      "id": "work-c171e65a5c7d0558",
+      "name": "Minecraft 风格游戏制作展示",
+      "description": "Minecraft 风格游戏演示 根帖未明确说明其本人是执行者。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@Aivy___X",
+        "url": "https://x.com/Aivy___X"
+      },
+      "demoUrl": "https://x.com/Aivy___X/status/2096357713076781101",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-508.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 564
+    },
+    {
+      "id": "work-1e2119b9f873401a",
+      "name": "迈阿密 Brickell 城市模型",
+      "description": "迈阿密 Brickell 区的三维城市展示 作者指出不准确；8 分钟 Medium 与地图输入方式未经验证。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@growingmiami",
+        "url": "https://x.com/growingmiami"
+      },
+      "demoUrl": "https://x.com/growingmiami/status/2096357964718428167",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-509.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 565
+    },
+    {
+      "id": "work-71cc078326ba72d2",
+      "name": "警车追逐驾驶游戏",
+      "description": "含车物理、警察、交通、检查点和计分的驾驶追逐游戏 在线运行与单提示词生成是平台自述。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096358632309071966",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-510.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 566
+    },
+    {
+      "id": "work-cab7dae1a2f2a884",
+      "name": "可调节台灯机构概念",
+      "description": "台灯调整机构的设计原型 作者表达后续制造愿望，未作为实体成品收录。",
+      "category": "tool",
+      "sourceCategory": "CheerSelfAI · 工程文件与代码迁移",
+      "author": {
+        "name": "@ruben_kostard",
+        "url": "https://x.com/ruben_kostard"
+      },
+      "demoUrl": "https://x.com/ruben_kostard/status/2096359354530238936",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-511.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 567
+    },
+    {
+      "id": "work-563f5c24e34d8ffa",
+      "name": "七层动态几何构成动画",
+      "description": "448 面板、7 层持续变形的 Blender 几何艺术 面板数量、40 倍 high 和用时均为作者陈述。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@0xArtix",
+        "url": "https://x.com/0xArtix"
+      },
+      "demoUrl": "https://x.com/0xArtix/status/2096359972724527171",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-512.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 568
+    },
+    {
+      "id": "work-1bb59873ec033cdb",
+      "name": "止损题材女孩故事短片",
+      "description": "以止损为题材的女孩故事短片 具体视频模型与制作流程未知。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@small_world_uta",
+        "url": "https://x.com/small_world_uta"
+      },
+      "demoUrl": "https://x.com/small_world_uta/status/2096360676466061583",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-513.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 569
+    },
+    {
+      "id": "work-555b3cb29bc7c759",
+      "name": "Apple Silicon 上运行帝国时代 IV",
+      "description": "在 Apple Silicon 运行 Age of Empires IV 的移植演示 70–150 FPS、与 CrossOver 的 8 FPS 对照及在线稳定性均为作者自测。",
+      "category": "tool",
+      "sourceCategory": "CheerSelfAI · 工程文件与代码迁移",
+      "author": {
+        "name": "@marc_ibrahim",
+        "url": "https://x.com/marc_ibrahim"
+      },
+      "demoUrl": "https://x.com/marc_ibrahim/status/2096365209111724235",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-514.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 570
+    },
+    {
+      "id": "work-ed65079c9fa218ff",
+      "name": "Saber Descent 光剑地牢游戏",
+      "description": "使用光剑进行战斗的地牢爬行游戏 开源与可玩性为作者自述。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@CtrlAltDwayne",
+        "url": "https://x.com/CtrlAltDwayne"
+      },
+      "demoUrl": "https://x.com/CtrlAltDwayne/status/2096365441472209227",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-515.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 571
+    },
+    {
+      "id": "work-a2ebcc491598de7e",
+      "name": "无技能辅助的故事视频失败尝试",
+      "description": "故事视频中 r2v 背景长时间不变化的失败记录 多工具角色和背景停滞原因未充分说明。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@onofumi_AI",
+        "url": "https://x.com/onofumi_AI"
+      },
+      "demoUrl": "https://x.com/onofumi_AI/status/2096369248138621315",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-516.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 572
+    },
+    {
+      "id": "work-bdf59fe33693b073",
+      "name": "可拉伸翅膀的果冻蝴蝶",
+      "description": "WebGPU 蝴蝶抓取、拉伸交互演示 引用的橘子软糖为另一物体，未据同类任务合并。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@vib3coded",
+        "url": "https://x.com/vib3coded"
+      },
+      "demoUrl": "https://x.com/vib3coded/status/2096369459690680343",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-517.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 573
+    },
+    {
+      "id": "work-bd42bf8c79b4998b",
+      "name": "在 Minecraft 重建纽约",
+      "description": "纽约城市的 Minecraft 场景",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@higgsfield",
+        "url": "https://x.com/higgsfield"
+      },
+      "demoUrl": "https://x.com/higgsfield/status/2096370002849120468",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-518.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 574
+    },
+    {
+      "id": "work-cb31c3e999bd8cf1",
+      "name": "Orbital Atlas 多尺度太阳系",
+      "description": "可从银河缩放到行星内部的牛顿力学太阳系展示 力学精度和内部结构未独立验证。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096371095779901510",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-519.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 575
+    },
+    {
+      "id": "work-e783e48f34f3e40d",
+      "name": "一万年前人类外观的创作演示",
+      "description": "对一万年前人类外观的视觉重建演示 属于创作性重建，未验证历史或科学准确性。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096371499930374536",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-520.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 576
+    },
+    {
+      "id": "work-7aaa4f333818d972",
+      "name": "两小时复刻早期 Fortnite",
+      "description": "OG Fortnite 风格地图与游戏原型 准确地图、两小时及 100% 额度消耗为作者自述。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@vixenovaa",
+        "url": "https://x.com/vixenovaa"
+      },
+      "demoUrl": "https://x.com/vixenovaa/status/2096372027359686689",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-521.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 577
+    },
+    {
+      "id": "work-5ab5c4705a44517b",
+      "name": "Codex 内多模型限流器开发审查",
+      "description": "开发、跨模型审查、接受有效问题并修复。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@sanchitmonga22",
+        "url": "https://x.com/sanchitmonga22"
+      },
+      "demoUrl": "https://x.com/sanchitmonga22/status/2096372075439235580",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-522.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 578
+    },
+    {
+      "id": "work-b1eff629a3c62e0d",
+      "name": "儿童玩具车床与肥皂陀螺设计",
+      "description": "从设计概念、建模到社交短视频进行尝试。 设计概念未证明完成制造与安全测试。",
+      "category": "tool",
+      "sourceCategory": "CheerSelfAI · 工程文件与代码迁移",
+      "author": {
+        "name": "@sibucho_labo",
+        "url": "https://x.com/sibucho_labo"
+      },
+      "demoUrl": "https://x.com/sibucho_labo/status/2096372808661995767",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-523.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 579
+    },
+    {
+      "id": "work-7874f7087a23c693",
+      "name": "可抓取变形的黄色果冻交互体",
+      "description": "可抓取并调节硬度、阻尼的 Three.js WebGPU 果冻 转述 Scott 的演示，原作者关系待后续来源核对。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@ai_300",
+        "url": "https://x.com/ai_300"
+      },
+      "demoUrl": "https://x.com/ai_300/status/2096372811837100208",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-524.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 580
+    },
+    {
+      "id": "work-d31f25513dddd58b",
+      "name": "带油桶运输挑战的公交游戏",
+      "description": "包含运输油桶、技巧挑战的公交游戏 合作模式是下一步计划，未计为已实现。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@artkorotkikh",
+        "url": "https://x.com/artkorotkikh"
+      },
+      "demoUrl": "https://x.com/artkorotkikh/status/2096373869879677250",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-525.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 581
+    },
+    {
+      "id": "work-d0aef09fcc40b9f4",
+      "name": "通过 Ableton Live 制作音乐",
+      "description": "指令要求操作 Ableton Live 生成音乐的演示 帖子未说明具体编曲步骤或完整提示词上下文。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@timourxyz",
+        "url": "https://x.com/timourxyz"
+      },
+      "demoUrl": "https://x.com/timourxyz/status/2096374630525309206",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-526.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 582
+    },
+    {
+      "id": "work-cf238be012e56745",
+      "name": "Machine-Go 射击围棋游戏",
+      "description": "在旧创意基础上多轮迭代。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@NicoSaraintaris",
+        "url": "https://x.com/NicoSaraintaris"
+      },
+      "demoUrl": "https://x.com/NicoSaraintaris/status/2096376258061803803",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-527.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 583
+    },
+    {
+      "id": "work-b991bd9e62042f7c",
+      "name": "图像或创意转 LEGO 零件模型",
+      "description": "使用官方零件并提供 .ldr 下载的 LEGO 模型 结构优化和可搭建性为作者自述，说明书仍在计划中。",
+      "category": "tool",
+      "sourceCategory": "CheerSelfAI · 工程文件与代码迁移",
+      "author": {
+        "name": "@emmanuel_2m",
+        "url": "https://x.com/emmanuel_2m"
+      },
+      "demoUrl": "https://x.com/emmanuel_2m/status/2096377028945576370",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-528.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 584
+    },
+    {
+      "id": "work-4db6f39675e1ae7d",
+      "name": "比奇堡场景到影片和游戏",
+      "description": "先搭建 Blender 场景，再接图像、视频及剪辑工具。 粉丝概念作品；30 秒 1080p 为作者描述。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@groovestreetgen",
+        "url": "https://x.com/groovestreetgen"
+      },
+      "demoUrl": "https://x.com/groovestreetgen/status/2096377742916981247",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-529.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 585
+    },
+    {
+      "id": "work-8db4aca1d42e2c38",
+      "name": "20 平方米空房的可编辑家具布局",
+      "description": "Blender 房间家具布局，物体可单独编辑 30 秒构建时长为作者陈述。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@groovestreetgen",
+        "url": "https://x.com/groovestreetgen"
+      },
+      "demoUrl": "https://x.com/groovestreetgen/status/2096377743701409988",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-530.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 586
+    },
+    {
+      "id": "work-5b635db489533500",
+      "name": "财务文档预埋错误检出测试",
+      "description": "预先在财务数字中植入错误，再对比模型检出结果。 二手转述；41 份、4 处及 50 万英镑差异均未独立验证。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 专业研究与安全评测",
+      "author": {
+        "name": "@vibecodingth",
+        "url": "https://x.com/vibecodingth"
+      },
+      "demoUrl": "https://x.com/vibecodingth/status/2096377980545348029",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-531.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 587
+    },
+    {
+      "id": "work-3db80b71a917c4e3",
+      "name": "爱琴海多人帆船模拟器",
+      "description": "以爱琴海为场景的多人航海模拟器 多人联机能力为作者自述。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@tylercosgrove",
+        "url": "https://x.com/tylercosgrove"
+      },
+      "demoUrl": "https://x.com/tylercosgrove/status/2096378275170054524",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-532.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 588
+    },
+    {
+      "id": "work-0857a660034e3cdc",
+      "name": "在 Photoshop 中绘制蒙娜丽莎",
+      "description": "Astra结合Higgsfield操作Photoshop。 平台演示，未验证绘画步骤和可编辑文件。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096378711444771152",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-533.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 589
+    },
+    {
+      "id": "work-dc917f621215c55c",
+      "name": "通过 Runway 尝试把最终幻想6制作成动画",
+      "description": "给Astra“把Final Fantasy 6动画化”的指令，模型开始调用Runway。 作者认为结果没有超出预期。 最终视频依赖Runway；未说明是否完成完整动画，保留作者负面评价。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@masayasan201911",
+        "url": "https://x.com/masayasan201911"
+      },
+      "demoUrl": "https://x.com/masayasan201911/status/2096378917636719098",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-534.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 590
+    },
+    {
+      "id": "work-168b87e88be0a598",
+      "name": "制作以 Edge City 活动地点为岛屿的三维任务游戏",
+      "description": "作者让Astra松散借鉴Edge City，得到多岛屿可玩世界。 原帖称已上线，未打开试玩验收。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@timourxyz",
+        "url": "https://x.com/timourxyz"
+      },
+      "demoUrl": "https://x.com/timourxyz/status/2096379521926840339",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-535.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 591
+    },
+    {
+      "id": "work-6c917a23a769a2d0",
+      "name": "在 Krita 中绘制创造亚当",
+      "description": "Astra通过Higgsfield MCP操作Krita。 平台自营演示，未取得可编辑文件。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096379627912704049",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-536.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 592
+    },
+    {
+      "id": "work-30cd78c8506f59e9",
+      "name": "以代码制作跨四个世界变换的机械梦境引擎",
+      "description": "作者说明代码由Astra负责。 未提供源码或运行环境，四世界算同一实验组。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@techartist_",
+        "url": "https://x.com/techartist_"
+      },
+      "demoUrl": "https://x.com/techartist_/status/2096380355121234186",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-537.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 593
+    },
+    {
+      "id": "work-55daabb61b6584e8",
+      "name": "通过 Higgsfield MCP 在 Blender 中生成可开始动画制作的机器人",
+      "description": "Astra一次会话操作Blender。 未证实已绑定或完成动画，不将“可开始动画”写为成片结果。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096380489494155652",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-538.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 594
+    },
+    {
+      "id": "work-39ae17c73e4fb0d4",
+      "name": "构建含 Blender 汽车资产的浏览器游戏",
+      "description": "Astra编写游戏并在Blender建模汽车。 没有给具体游戏名，不能把作者关于下一代GTA的预测写成事实。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@xikhar",
+        "url": "https://x.com/xikhar"
+      },
+      "demoUrl": "https://x.com/xikhar/status/2096382232403603752",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-539.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 595
+    },
+    {
+      "id": "work-b8117c92757e7478",
+      "name": "在 Blender 中建立镜面厢式车辆模型",
+      "description": "作者让Astra用Blender制作车辆。 仅模型演示，内部结构未经实物验证。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@Buusk3",
+        "url": "https://x.com/Buusk3"
+      },
+      "demoUrl": "https://x.com/Buusk3/status/2096382949126222123",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-540.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 596
+    },
+    {
+      "id": "work-403d28725de404cc",
+      "name": "将二二六事件部队行动绘制为时间动画",
+      "description": "作者让Astra绘制部队行动，用于考察青年军官与海军行动关系的假设。 动画和假设分析为作者研究演示，未核对史料或证明因果假设。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 模拟与科学可视化",
+      "author": {
+        "name": "@noiehoie",
+        "url": "https://x.com/noiehoie"
+      },
+      "demoUrl": "https://x.com/noiehoie/status/2096383054461985145",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-541.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 597
+    },
+    {
+      "id": "work-8a3f47ad1cba82b2",
+      "name": "在 After Effects 中重建 Higgsfield 自家发布视频",
+      "description": "Astra computer-use操作After Effects，后续同平台帖补充Higgsfield MCP参与。 “逐细节还原”为平台主张，未逐帧比对原片。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@higgsfield",
+        "url": "https://x.com/higgsfield"
+      },
+      "demoUrl": "https://x.com/higgsfield/status/2096383682852610051",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-542.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 598
+    },
+    {
+      "id": "work-d3d5a291bc6abc1a",
+      "name": "生成咖啡杯中暴风雨的三维场景",
+      "description": "作者让Astra按该创意进行三维制作。 作者对3D和前端的总体看法不作测评结论，当前只收具体咖啡杯作品。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@CtrlAltDwayne",
+        "url": "https://x.com/CtrlAltDwayne"
+      },
+      "demoUrl": "https://x.com/CtrlAltDwayne/status/2096383768957538565",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-543.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 599
+    },
+    {
+      "id": "work-9c07a51d5e30a011",
+      "name": "用 Crayon Pro 与 Blender MCP 制作水下吉卜力风格世界",
+      "description": "Astra与Crayon Pro构建，Blender MCP生成资产。 平台自营演示，未验试玩；与Atlantis城市仅主题类似，暂无同源证据。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@usecrayon",
+        "url": "https://x.com/usecrayon"
+      },
+      "demoUrl": "https://x.com/usecrayon/status/2096385137625923682",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-544.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 600
+    },
+    {
+      "id": "work-29ec9c7f5aa08669",
+      "name": "从三维模型设计适合自己手部的钢铁侠护手",
+      "description": "作者让Astra依据三维模型制作。 适配为作者报告，未验证打印、佩戴或尺寸精度。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@riku720720",
+        "url": "https://x.com/riku720720"
+      },
+      "demoUrl": "https://x.com/riku720720/status/2096386143218802850",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-545.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 601
+    },
+    {
+      "id": "work-5b07216512ea9f6e",
+      "name": "在 Blender MCP 中生成 Atlantis 城市",
+      "description": "作者称Astra一次通过Blender MCP创建。 原帖提供试玩但未验证；不能仅凭水下主题合并其他世界项目。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@aniketjart",
+        "url": "https://x.com/aniketjart"
+      },
+      "demoUrl": "https://x.com/aniketjart/status/2096386207639052428",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-546.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 602
+    },
+    {
+      "id": "work-8c34f22957e96bca",
+      "name": "把图像转换为 SVG 再制作可编辑 PPT",
+      "description": "Astra经由图像生成→SVG化→PPT化生成资料。 作者认为SVG插画质量提高，细部颜色可调整。 未获取演示文稿并检查编辑性；图像生成模型未给。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@shin_yoshimura0",
+        "url": "https://x.com/shin_yoshimura0"
+      },
+      "demoUrl": "https://x.com/shin_yoshimura0/status/2096387880696602642",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-547.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 603
+    },
+    {
+      "id": "work-9d09fe3d50a425ad",
+      "name": "制作 CryptoNinja 角色山村经营沙盒",
+      "description": "Astra脚本生成建筑和居民，Meshy从图像生成角色，H3 Max Turbo制作宣传片。 作者称两天完成初版，浏览器试玩已提供，Steam正式版计划10月。 最终游戏依赖多个模型和服务，费用为作者报告；Steam正式版仍是计划。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@jura_log",
+        "url": "https://x.com/jura_log"
+      },
+      "demoUrl": "https://x.com/jura_log/status/2096387909427589494",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-548.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 604
+    },
+    {
+      "id": "work-5add9858111c79f0",
+      "name": "用 Higgsfield MCP 制作相机镜头专业器材网站",
+      "description": "平台称Astra使用Higgsfield MCP从一条提示词构建。 平台未说明全部功能和实际光学精度，不能断言软件替代真实镜头。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096387951026659630",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-549.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 605
+    },
+    {
+      "id": "work-06de159a5ac9d253",
+      "name": "把日本旅行照片组织成 Remotion 视频",
+      "description": "Astra筛照片、取补充视频及免版税音乐、规划叙事写文案、绘动画地图和角色，再用Remotion动画剪辑并按反馈导出。 明确多轮反馈；素材授权与输出效果未独立验证。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@Firisis_",
+        "url": "https://x.com/Firisis_"
+      },
+      "demoUrl": "https://x.com/Firisis_/status/2096389164279214456",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-550.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 606
+    },
+    {
+      "id": "work-89b70f08d5316721",
+      "name": "生成 MIDI 音乐并制作音视频捕获工具",
+      "description": "作者用Astra生成MIDI并演示，另称制作捕获工具。 作者估计MIDI生成约2分钟、后续约1分钟，捕获工具约2小时。 时间为估计；音乐的艺术与商品价值是作者意见，不作事实结论。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@raiteisabota",
+        "url": "https://x.com/raiteisabota"
+      },
+      "demoUrl": "https://x.com/raiteisabota/status/2096389478122451409",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-551.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 607
+    },
+    {
+      "id": "work-19d2307747c44895",
+      "name": "生成知识解锁式横向卷轴解谜游戏",
+      "description": "向Astra直接提出该游戏类型。 原帖提供试玩入口，未打开验证玩法。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@d_d_osorezan",
+        "url": "https://x.com/d_d_osorezan"
+      },
+      "demoUrl": "https://x.com/d_d_osorezan/status/2096390251656933779",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-552.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 608
+    },
+    {
+      "id": "work-c38910abfef59493",
+      "name": "用代码生成 ASCII 与二进制动态自画像",
+      "description": "让名为Ember的Astra生成代码自画像；字符在螺旋、隧道、花、星系等结构间数学变换。 帧数与流程为作者报告；“意识表达”为作者拟人描述，不构成模型主观体验证据。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@Skoorbkaz",
+        "url": "https://x.com/Skoorbkaz"
+      },
+      "demoUrl": "https://x.com/Skoorbkaz/status/2096390330597736853",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-553.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 609
+    },
+    {
+      "id": "work-aaed33c77743976a",
+      "name": "为燃气轮机学习制作可交互模型",
+      "description": "作者补课后让Astra建模以测试能力和帮助理解。 模型用于个人学习，未验证工程精度。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 模拟与科学可视化",
+      "author": {
+        "name": "@GZhan57",
+        "url": "https://x.com/GZhan57"
+      },
+      "demoUrl": "https://x.com/GZhan57/status/2096391170540884343",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-554.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 610
+    },
+    {
+      "id": "work-4906bc8debf2294e",
+      "name": "在魔兽世界经典版中接入 agent 消息与完成通知",
+      "description": "作者在Codex要求为WoW制作Herdr插件。 作者称约3分钟后可在游戏里向agents发消息。 功能与耗时为作者报告，未安装插件验证。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@AlexFinn",
+        "url": "https://x.com/AlexFinn"
+      },
+      "demoUrl": "https://x.com/AlexFinn/status/2096391410048180334",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-555.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 611
+    },
+    {
+      "id": "work-4d6e82d89ccb0144",
+      "name": "在 Eidoverse 中重启虚拟 Vibecamp 世界",
+      "description": "作者用 Astra 重启既有项目，计划改善PBR、建筑、草、植被和水。 初版已存在但仍需大量改进；具身AI交互和公开发布是计划，不当作完成结果。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@SkyeSharkie",
+        "url": "https://x.com/SkyeSharkie"
+      },
+      "demoUrl": "https://x.com/SkyeSharkie/status/2096391841885327647",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-556.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 612
+    },
+    {
+      "id": "work-5c5ad2f916657715",
+      "name": "在 Onshape 中设计 rover 机器人零件",
+      "description": "Astra 使用 Onshape 及其创建的自定义插件。 作者称项目仍在工作中，未给制造与装配测试。",
+      "category": "tool",
+      "sourceCategory": "CheerSelfAI · 工程文件与代码迁移",
+      "author": {
+        "name": "@Alpha10six",
+        "url": "https://x.com/Alpha10six"
+      },
+      "demoUrl": "https://x.com/Alpha10six/status/2096392271776149587",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-557.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 613
+    },
+    {
+      "id": "work-2d3a682bd77ca078",
+      "name": "比较弹簧沿上行扶梯持续翻滚的物理动画",
+      "description": "要求无库 Canvas 实现弹簧在上行扶梯循环翻滚，并有 drop/reset 按钮。 作者报告 Astra 速度与额度较优但有弹簧自穿透，Fable视觉更真实且耗尽5小时窗口并报错。 单次主观对照；物理自穿透为作者观察，未复现或测量。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 模拟与科学可视化",
+      "author": {
+        "name": "@reddmachine",
+        "url": "https://x.com/reddmachine"
+      },
+      "demoUrl": "https://x.com/reddmachine/status/2096392638455026150",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-558.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 614
+    },
+    {
+      "id": "work-7842e9c7812e3852",
+      "name": "自动完成 Excalidraw 讲解视频并沉淀为 Skill",
+      "description": "Astra 完成调研、规划、操作 Excalidraw、录制、声音合成、剪辑和交付。 未给视频具体主题、声音模型和 Skill 文件，流程为作者报告。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@wshuyi",
+        "url": "https://x.com/wshuyi"
+      },
+      "demoUrl": "https://x.com/wshuyi/status/2096393490439749875",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-559.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 615
+    },
+    {
+      "id": "work-2b82e85b5efcf1bf",
+      "name": "在手机上自动筛除坏镜头并安排字幕位置",
+      "description": "Astra 与 Ody 识别坏 takes 并安排不挡脸的文字，作者从手机发起并观看剪辑。 “检测100%坏镜头”为作者说法，未验证召回率或一般化效果。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@_kaitodev",
+        "url": "https://x.com/_kaitodev"
+      },
+      "demoUrl": "https://x.com/_kaitodev/status/2096396128627331271",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-560.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 616
+    },
+    {
+      "id": "work-745d418065fe1c80",
+      "name": "两轮提示词构建 GTA 风格 WebGL 游戏",
+      "description": "首轮要求 WebGL、Blender、参考图建模并使用 RIO_MA002.fbx；二轮改善模型、碰撞破坏、物理、郊区和密度。 明确两轮与既有角色资产，AAA 只是指令目标，未证明达到商业游戏品质。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@djrio_vr",
+        "url": "https://x.com/djrio_vr"
+      },
+      "demoUrl": "https://x.com/djrio_vr/status/2096398839830008292",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-561.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 617
+    },
+    {
+      "id": "work-130234b3e29ae9f8",
+      "name": "以参考游戏和截图构建三维游戏及资产流程",
+      "description": "提供喜爱的游戏、截图、玩法和角色目标，启用 Codex computer use，使用 Three.js、Blender MCP，并安排图像生成资产。 作者报告非 fast 模式下约2小时30分钟。 未命名游戏和发布工程；one-shot 仍依赖参考图及资产生成。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@reeder1865",
+        "url": "https://x.com/reeder1865"
+      },
+      "demoUrl": "https://x.com/reeder1865/status/2096399217119854794",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-562.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 618
+    },
+    {
+      "id": "work-45f636ffb5658b11",
+      "name": "构建含 Stockfish 档位与经典棋局回放的三维国际象棋",
+      "description": "作者用 Astra 建造浏览器游戏并自述玩过数局。 七档难度与可玩性未独立验证；与1851棋局动画是不同作者和不同任务。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@DeryaTR_",
+        "url": "https://x.com/DeryaTR_"
+      },
+      "demoUrl": "https://x.com/DeryaTR_/status/2096403246512287753",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-563.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 619
+    },
+    {
+      "id": "work-951fdddee9b620f9",
+      "name": "为 GRU Space 生成新闻室页面",
+      "description": "作者称 Astra 一次生成。 页面功能与上线状态未核验。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@skyler_chan_",
+        "url": "https://x.com/skyler_chan_"
+      },
+      "demoUrl": "https://x.com/skyler_chan_/status/2096404250607993332",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-564.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 620
+    },
+    {
+      "id": "work-2814212a8192da28",
+      "name": "制作日文版可切换骨骼肌肉与内脏的三维人体图",
+      "description": "作者说明用 Astra 构建或改为日文，支持分层切换和自由视角。 未验证解剖准确性，医疗教育潜力是作者观点。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 模拟与科学可视化",
+      "author": {
+        "name": "@hanageruge",
+        "url": "https://x.com/hanageruge"
+      },
+      "demoUrl": "https://x.com/hanageruge/status/2096404647154163893",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-565.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 621
+    },
+    {
+      "id": "work-456964d161f9f2dd",
+      "name": "制作 Button Box 原型的交互式装配指南",
+      "description": "让 Astra 制作交互指南，并指令生成16:9演示录屏。 提供指南和 GitHub 入口但未打开；不得从交互指南推定实体已通过测试。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@danpeguine",
+        "url": "https://x.com/danpeguine"
+      },
+      "demoUrl": "https://x.com/danpeguine/status/2096405809387258334",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-566.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 622
+    },
+    {
+      "id": "work-c92e53b6c85dbd08",
+      "name": "用既有 AviUtl2 工程与素材自动剪辑视频",
+      "description": "把旧手工 AviUtl2 工程、视频、音频和台词文件交给 Astra，模型剪辑并在缺素材时生成图像。 具体视频主题与图像模型未给，作者未公开可复验工程。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@nakanoyuusuke",
+        "url": "https://x.com/nakanoyuusuke"
+      },
+      "demoUrl": "https://x.com/nakanoyuusuke/status/2096408505418915914",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-567.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 623
+    },
+    {
+      "id": "work-770f66e8ad97fb6e",
+      "name": "制作 HD-2D 风格游戏场景实验",
+      "description": "睡前给 Astra 详细指令，次日检查结果。 作者认为深度和光照较符合目标。 实验进行中，未给完整可玩游戏或工程。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@yugiriworks",
+        "url": "https://x.com/yugiriworks"
+      },
+      "demoUrl": "https://x.com/yugiriworks/status/2096408929073074410",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-568.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 624
+    },
+    {
+      "id": "work-a8553e5b167acebf",
+      "name": "开发通过 CLI 与 MCP 操作的 YachiCut 视频编辑器",
+      "description": "Astra 构建在 Codex 浏览器运行的编辑器，ComfyUI 为后端；支持音视频分别管理、哈希检测与选片判断日志。 作者描述已实现与实施中的功能，未计划分发。 当前仍在实现，未逐项验收所有功能或验证外部编辑器导入。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@yachimat_manga",
+        "url": "https://x.com/yachimat_manga"
+      },
+      "demoUrl": "https://x.com/yachimat_manga/status/2096411125453926759",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-569.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 625
+    },
+    {
+      "id": "work-1ca13d4abbcf4e7b",
+      "name": "在 Canva 中绘画新天鹅堡",
+      "description": "作者让 Astra 在 Canva 作画。 未提供可编辑文件，画作质量未经独立检查。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@Layton_Gott",
+        "url": "https://x.com/Layton_Gott"
+      },
+      "demoUrl": "https://x.com/Layton_Gott/status/2096414946523230215",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-570.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 626
+    },
+    {
+      "id": "work-6cac813a45d0e13d",
+      "name": "仅用 JavaScript 与 Three.js 制作浏览器三维游戏",
+      "description": "作者让 Astra 用 JavaScript 与 Three.js 构建，未使用 Blender。 游戏名和玩法细节未给，保留为作者一次具体游戏试作。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@asagilf",
+        "url": "https://x.com/asagilf"
+      },
+      "demoUrl": "https://x.com/asagilf/status/2096418532083020027",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-571.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 627
+    },
+    {
+      "id": "work-69c995e8294afe92",
+      "name": "为 Tripo 角色在 Blender 中设置模型与表情",
+      "description": "Tripo 生成角色后交给 Astra 做 Blender setup，并采用作者所称特殊方式生成表情。 特殊表情方法未披露；该帖把进一步 rigging 列为后续，和8的关联需同源证据。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@Dstudio_ai",
+        "url": "https://x.com/Dstudio_ai"
+      },
+      "demoUrl": "https://x.com/Dstudio_ai/status/2096420704636019105",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-572.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 628
+    },
+    {
+      "id": "work-0679865267d0ec5d",
+      "name": "自动临摹星空并录制剪辑配乐",
+      "description": "自动下载原画、打开 Photopea、放参考图对照绘画，边绘画边录制并剪辑和配乐。 绘画与音视频流程为作者报告，未独立核验与原画一致性。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@gengdaJ",
+        "url": "https://x.com/gengdaJ"
+      },
+      "demoUrl": "https://x.com/gengdaJ/status/2096421536500683184",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-573.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 629
+    },
+    {
+      "id": "work-2b3c632bffbf6a7c",
+      "name": "构建三维尤克里里练习室",
+      "description": "作者让 Astra 制作面向初学者的练习室，首曲为小星星。 原帖称提供试玩和源码，当前未打开核验。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@Peter05704721",
+        "url": "https://x.com/Peter05704721"
+      },
+      "demoUrl": "https://x.com/Peter05704721/status/2096425300565672317",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-574.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 630
+    },
+    {
+      "id": "work-efd76c32e8a74712",
+      "name": "测试生成日本机关说明风格的复杂示意幻灯片",
+      "description": "作者测试 Astra 对这类传统复杂汇报图解的再现能力。 正文未给量化评价或完整编辑文件。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@taiyo_ai_gakuse",
+        "url": "https://x.com/taiyo_ai_gakuse"
+      },
+      "demoUrl": "https://x.com/taiyo_ai_gakuse/status/2096427200555917808",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-575.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 631
+    },
+    {
+      "id": "work-248270922b581901",
+      "name": "生成带分层运动效果的 SVG",
+      "description": "作者称让 Astra 一次生成并处理分层关系。 引用的视频素材商店是背景推广，未证明本次实际调用该商店资产。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@ryoma_nakajima",
+        "url": "https://x.com/ryoma_nakajima"
+      },
+      "demoUrl": "https://x.com/ryoma_nakajima/status/2096429264241602999",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-576.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 632
+    },
+    {
+      "id": "work-a229e2597eb6d359",
+      "name": "用 SVG 与 JavaScript 构建 Habbo Hotel 风格游戏",
+      "description": "二手描述 Astra Ultra 2x 用 SVG/JavaScript 绘制全部资产，以二维方式模拟光影和纵深，没有游戏引擎或素材包。 转述称两小时完成、使用 100 美元 Pro 计划周额度 42%。 原帖把周额度折算约42美元，这不是可验证 API 支出；未找到原作者工程。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@om_patel5",
+        "url": "https://x.com/om_patel5"
+      },
+      "demoUrl": "https://x.com/om_patel5/status/2096429334319817031",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-577.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 633
+    },
+    {
+      "id": "work-c2a8b683325ebc4e",
+      "name": "不使用自动布线完成八层 PCB artwork",
+      "description": "输入部分设计规则，让 Astra 自行进行 artwork，未使用 Auto routing。 作者称八层板完成，下一步向 JLCPCB 下单与实机测试。 尚未制造与实机测试；引用只说明先前 Fable 尝试，当前 Astra 执行归属明确。",
+      "category": "tool",
+      "sourceCategory": "CheerSelfAI · 工程文件与代码迁移",
+      "author": {
+        "name": "@gclue_akira",
+        "url": "https://x.com/gclue_akira"
+      },
+      "demoUrl": "https://x.com/gclue_akira/status/2096429541782942088",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-578.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 634
+    },
+    {
+      "id": "work-e2a490c65176feb1",
+      "name": "操作 Clip Studio Paint 给手绘草稿分层上色",
+      "description": "二手报道插画师让 Astra 控制鼠标、建立图层、选择笔刷并填色。 报道称底色工作可完成，但阴影和最终修饰逊于作者版本，并消耗大量订阅额度。 二手报道未给原插画师帖子；额度不是精确费用，结果未独立验收。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@SomosKudasai",
+        "url": "https://x.com/SomosKudasai"
+      },
+      "demoUrl": "https://x.com/SomosKudasai/status/2096429707927453749",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-579.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 635
+    },
+    {
+      "id": "work-83755cfc321f222d",
+      "name": "用 Astra computer-use 制作电影原型",
+      "description": "平台称电影制作全程使用 Astra computer-use，并准备公开过程。 平台自述进行中；未给片名、完整电影或工具分工，不能称已完成长片。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096430282329235694",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-580.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 636
+    },
+    {
+      "id": "work-46148d4af4fb98bf",
+      "name": "生成可拆看内部叶片与气流的喷气发动机模型",
+      "description": "让 Astra 制作喷气发动机三维模型。 作者描述内部叶片转动与气流可视化。 教学示意未经工程精度验证，完整 prompt 仅预告在回复。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 模拟与科学可视化",
+      "author": {
+        "name": "@ozwxy",
+        "url": "https://x.com/ozwxy"
+      },
+      "demoUrl": "https://x.com/ozwxy/status/2096431069008728440",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-581.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 637
+    },
+    {
+      "id": "work-0fadb93c86884ac0",
+      "name": "用 Three.js 生成 Counter Strike 2 风格游戏",
+      "description": "二手贴给出的指令是让 Astra 在 Three.js 制作 CS2。 未提供原作者或工程，不能认为完整复刻商业游戏。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@om_patel5",
+        "url": "https://x.com/om_patel5"
+      },
+      "demoUrl": "https://x.com/om_patel5/status/2096431838960971880",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-582.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 638
+    },
+    {
+      "id": "work-1e84be079eff156a",
+      "name": "生成 Nintendo DS 三维模型",
+      "description": "DS 游戏机三维模型 仅有模型名称和演示，未给建模工具与精度检查。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@riku720720",
+        "url": "https://x.com/riku720720"
+      },
+      "demoUrl": "https://x.com/riku720720/status/2096431945202971035",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-583.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 639
+    },
+    {
+      "id": "work-83fa39afa7ebb1ae",
+      "name": "在 Blender 中构建 Strandbeest 风格机械步行结构",
+      "description": "向 Astra 询问能否在 Blender 制作该结构并得到演示。 作者评价结构较稳定，未验证真实连杆几何或物理可行性。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@aiclass_g2",
+        "url": "https://x.com/aiclass_g2"
+      },
+      "demoUrl": "https://x.com/aiclass_g2/status/2096432472695418931",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-584.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 640
+    },
+    {
+      "id": "work-11ac4fd1ec26e565",
+      "name": "用 Blender 制作学校内奔跑的象形人物动画",
+      "description": "给 Astra 一条使用 Blender 制作学校内奔跑 pictogram 的指令。 作者认为图像效果比 5.6 更好。 质量比较为个人评价，未独立复现。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@Yuupapa_free",
+        "url": "https://x.com/Yuupapa_free"
+      },
+      "demoUrl": "https://x.com/Yuupapa_free/status/2096432585111216201",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-585.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 641
+    },
+    {
+      "id": "work-3d3d44d536b47ab5",
+      "name": "从手机指令制作航班天际地图风格 Three.js 演示",
+      "description": "作者在东京至巴黎航班上从手机向 ChatGPT Astra 下指令。 未给公开工程或地理数据来源。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@clockmaker",
+        "url": "https://x.com/clockmaker"
+      },
+      "demoUrl": "https://x.com/clockmaker/status/2096434941336682766",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-586.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 642
+    },
+    {
+      "id": "work-042f1e285fa5d9fa",
+      "name": "用 VRoid Studio 制作 VRM 角色",
+      "description": "Astra 操作 VRoid Studio。 作者报告约 8 分钟。 试作阶段，未验证导出兼容性或角色质量。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@npaka123",
+        "url": "https://x.com/npaka123"
+      },
+      "demoUrl": "https://x.com/npaka123/status/2096435985425010837",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-587.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 643
+    },
+    {
+      "id": "work-d4a325aa3404efc8",
+      "name": "设计 F405 六层 FPV 无人机飞控板",
+      "description": "Codex 中 Astra 高强度直接操作 KiCad，完成布局布线并运行 ERC/DRC 后修改。 作者报告 3 小时 13 分 56 秒、约 5190 万 tokens，完成设计但尚未打样。 尚未制造或实机测试，不能称飞控已稳定工作；耗时/token 为作者报告。",
+      "category": "tool",
+      "sourceCategory": "CheerSelfAI · 工程文件与代码迁移",
+      "author": {
+        "name": "@GoGoFly23",
+        "url": "https://x.com/GoGoFly23"
+      },
+      "demoUrl": "https://x.com/GoGoFly23/status/2096436525110309251",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-588.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 644
+    },
+    {
+      "id": "work-5617b4808b7494f1",
+      "name": "生成跑酷素材供 Seedance 2.5 制作视频",
+      "description": "先让 Astra 制作跑酷素材，再以此为参考调用 Seedance 2.5。 Astra 负责参考素材，最终视频由 Seedance 生成；作者表示素材仍需改善。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@Ayu_AI_0912",
+        "url": "https://x.com/Ayu_AI_0912"
+      },
+      "demoUrl": "https://x.com/Ayu_AI_0912/status/2096437230172832140",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-589.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 645
+    },
+    {
+      "id": "work-83f4e6d68685d3cf",
+      "name": "操作 Sibelius 编写 32 小节肖邦风格圆舞曲",
+      "description": "让 Astra 实际使用 Sibelius 创作。 作者评价操作快、软件理解和音乐效果好。 风格与质量是作者评价，未独立乐谱分析。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@yogo_escentier",
+        "url": "https://x.com/yogo_escentier"
+      },
+      "demoUrl": "https://x.com/yogo_escentier/status/2096437507072434658",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-590.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 646
+    },
+    {
+      "id": "work-fad2fa9c88ee1faa",
+      "name": "将 1851 年经典国际象棋对局制成动画",
+      "description": "Astra 与 Higgsfield 配合。 平台未给完整棋谱或动画准确性检查，未补写具体棋手。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096437543181103449",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-591.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 647
+    },
+    {
+      "id": "work-c11da8cc88b41728",
+      "name": "将乐谱转换为 MSX MGSDRV 演奏数据",
+      "description": "向 Astra 展示乐谱并要求编写可在 MSX MGSDRV 演奏的 MML。 作者称模型进一步生成了演奏数据。 未检查数据格式、乐谱准确性或设备播放。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 办公与音乐创作",
+      "author": {
+        "name": "@takawo_n",
+        "url": "https://x.com/takawo_n"
+      },
+      "demoUrl": "https://x.com/takawo_n/status/2096438867247370318",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-592.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 648
+    },
+    {
+      "id": "work-d967c6a87fefed1f",
+      "name": "用 Fable 与 Astra 制作角色坐在肩膀上的视频",
+      "description": "作者称从昨夜开始组合使用 Claude Fable 5.1 与 Astra。 作者未拆分两个模型的贡献或披露视频生成工具，不能归因 Astra 单独完成。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@Glasses_Lion",
+        "url": "https://x.com/Glasses_Lion"
+      },
+      "demoUrl": "https://x.com/Glasses_Lion/status/2096439080620048788",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-593.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 649
+    },
+    {
+      "id": "work-7b2ffe9dfd79b862",
+      "name": "构建含 1025 个拆解部件的三维相机",
+      "description": "Astra 通过 Higgsfield 在 Blender 建模和动画。 对象数量为平台报告，不代表工程零件准确对应。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096441158465683634",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-594.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 650
+    },
+    {
+      "id": "work-b3ee5c0d5a5f7035",
+      "name": "使用 Blender 为 AI 动画构建街道场景",
+      "description": "作者使用 Astra 与 Blender。 作者称分享的视频在 15 分钟内制作。 15 分钟描述视频制作，不能直接解释为完整场景建模耗时。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@MiraMusic_AI",
+        "url": "https://x.com/MiraMusic_AI"
+      },
+      "demoUrl": "https://x.com/MiraMusic_AI/status/2096441679847006358",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-595.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 651
+    },
+    {
+      "id": "work-dd5b02b63bfcac10",
+      "name": "构建并自动测试钓鱼 iOS 应用",
+      "description": "给 Astra 一条 /goal 指令；模型开发应用、逐按钮测试，并生成持鱼图片测试提交。 作者醒来后收到完整演示录屏和功能测试报告。 完整功能通过是作者转述，未取得测试日志或独立检查后端。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@ashen_one",
+        "url": "https://x.com/ashen_one"
+      },
+      "demoUrl": "https://x.com/ashen_one/status/2096441749493227696",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-596.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 652
+    },
+    {
+      "id": "work-6b9b02a99b55a64d",
+      "name": "为自制游戏制作预告视频",
+      "description": "作者让 Astra 为自己的游戏制作 trailer。 游戏名、剪辑工具和制作步骤未给出。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@reverinu_vtuber",
+        "url": "https://x.com/reverinu_vtuber"
+      },
+      "demoUrl": "https://x.com/reverinu_vtuber/status/2096444378722214015",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-597.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 653
+    },
+    {
+      "id": "work-cc2b33bad0848c8a",
+      "name": "在 Blender 中生成三维别墅导览",
+      "description": "Astra 与 Higgsfield 在 Blender 中一次生成。 平台自营演示，未给原始工程、完整 prompt 或真实性验证。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@higgsfield_ai",
+        "url": "https://x.com/higgsfield_ai"
+      },
+      "demoUrl": "https://x.com/higgsfield_ai/status/2096449719145054373",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-598.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 654
+    },
+    {
+      "id": "work-bc274ac89103d9d8",
+      "name": "操作 Clip Studio Paint 制作剑斗粗动画",
+      "description": "让 Astra 操作 Clip Studio Paint。 作者称生成成功，但步幅非常大。 动作质量缺陷来自作者反馈，未独立检查动画。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@gesoikuo3",
+        "url": "https://x.com/gesoikuo3"
+      },
+      "demoUrl": "https://x.com/gesoikuo3/status/2096452658399994160",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-599.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 655
+    },
+    {
+      "id": "work-9ac82e64da86fab8",
+      "name": "把普通 Zillow 房源重新布置为三维模型与展示图片",
+      "description": "选择近期降价房屋，用房源图建模和布置；两轮处理，作者指出把壁橱变窗户等不合理修改。 作者称约 3 小时完成建模与调整，比先前城堡更准确。 准确性与观感为作者判断，未核对房屋实测；本文是新房屋，引用的城堡为早前不同输入。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@realYunfanYe",
+        "url": "https://x.com/realYunfanYe"
+      },
+      "demoUrl": "https://x.com/realYunfanYe/status/2096456060207001806",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-600.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 656
+    },
+    {
+      "id": "work-321425188213a474",
+      "name": "为 X 主页角色恶作剧动画编写分镜提示词",
+      "description": "Astra 编写提示词；以角色图和 X 主页截图为参考，安排角色出框、文字纸飞机、清扫与手写结尾，再交给 MiniMax H3。 Astra 的角色是提示词与动作设计，最终视频由 MiniMax H3 生成；未逐镜核验全部约束。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@Chengzilhy",
+        "url": "https://x.com/Chengzilhy"
+      },
+      "demoUrl": "https://x.com/Chengzilhy/status/2096456212246364322",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-601.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 657
+    },
+    {
+      "id": "work-831b364e6a45fe8f",
+      "name": "用 Astra Pro 制作 BFDI 动漫片头",
+      "description": "作者称 Astra Pro 单条提示词生成。 未披露底层视频工具、完整提示词或各工具贡献。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@AiCanvas88957",
+        "url": "https://x.com/AiCanvas88957"
+      },
+      "demoUrl": "https://x.com/AiCanvas88957/status/2096456960363163979",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-602.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 658
+    },
+    {
+      "id": "work-e83345a57b53d958",
+      "name": "根据地图和实拍重建可交互悉尼城市",
+      "description": "输入地图和真实照片，使用 Blender 与 Three.js。 作者称一次会话完成。 “整个悉尼城”为作者表述，未验证地理覆盖或精度；与引用的宿舍房间属于不同任务。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@rionaifantasy",
+        "url": "https://x.com/rionaifantasy"
+      },
+      "demoUrl": "https://x.com/rionaifantasy/status/2096460180401889613",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-603.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 659
+    },
+    {
+      "id": "work-0e59f1f0cf63a174",
+      "name": "在 Figma 中制作品牌视觉与页面设计",
+      "description": "让 Astra 实际操作 Figma。 设计质量是作者评价；未给完整设计规范与交付文件。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@issui_ikeda",
+        "url": "https://x.com/issui_ikeda"
+      },
+      "demoUrl": "https://x.com/issui_ikeda/status/2096467418575147367",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-604.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 660
+    },
+    {
+      "id": "work-753b51c22af41c2c",
+      "name": "用 Three.js 构建莱特飞行器穿越日本森林游戏",
+      "description": "让 Astra 自行调研飞行器并用 Three.js 从头生成场景、模型与纹理；未连接 Blender 或外部资产。 作者称共两次会话，实际构建约 10–20 分钟，游戏流畅但部署仍待完成。 作者同时称 one-shot 和两次会话，按原述保留；未独立试玩，实际耗时为估计。",
+      "category": "game",
+      "sourceCategory": "CheerSelfAI · 游戏与玩法原型",
+      "author": {
+        "name": "@thebuggeddev",
+        "url": "https://x.com/thebuggeddev"
+      },
+      "demoUrl": "https://x.com/thebuggeddev/status/2096467585785286808",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-605.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 661
+    },
+    {
+      "id": "work-1f2bc01678d198b1",
+      "name": "把简短创意扩成 Seedance 视频提示词并生成对照",
+      "description": "先由 Astra 扩写简单 brief，再通过 Renoise CLI 运行 Seedance 2.5；引用同作者 Astra/Fable 对照。 视频由 Seedance 生成，Astra 负责提示词；当前引用未给具体场景和完整 prompt。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@Mayz1169",
+        "url": "https://x.com/Mayz1169"
+      },
+      "demoUrl": "https://x.com/Mayz1169/status/2096470693089292710",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-606.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 662
+    },
+    {
+      "id": "work-1ceaf332cca9f019",
+      "name": "从分镜制作三维动画",
+      "description": "使用 Astra、Blender 与 VRoid Studio。 作者明确仍在试作，未给完片验收或制作耗时。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 动效与视频工作流",
+      "author": {
+        "name": "@npaka123",
+        "url": "https://x.com/npaka123"
+      },
+      "demoUrl": "https://x.com/npaka123/status/2096471372235243750",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-607.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 663
+    },
+    {
+      "id": "work-728e9c9c6a8ca6f6",
+      "name": "在应用中集成 Supabase 并改善界面",
+      "description": "ChatGPT Plus 中使用 Astra MAX；指令为 Integrate Supabase and Improve App UI。 作者报告耗尽 5 小时额度、使用周额度 16%、约 500 万 tokens 和 5 万输出 tokens，任务未完成。 耗时和额度为作者报告；未给应用与失败步骤，订阅额度不等于独立 API 费用。",
+      "category": "app",
+      "sourceCategory": "CheerSelfAI · 界面与产品流程",
+      "author": {
+        "name": "@shownotover",
+        "url": "https://x.com/shownotover"
+      },
+      "demoUrl": "https://x.com/shownotover/status/2096478745494175886",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-608.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 664
+    },
+    {
+      "id": "work-211602de86923f9d",
+      "name": "构建 Varanasi 三维世界",
+      "description": "Varanasi 世界构建演示 二手展示只给出场景名和 Astra 归属，未给工程或执行步骤。",
+      "category": "experiment",
+      "sourceCategory": "CheerSelfAI · 3D 空间与建模",
+      "author": {
+        "name": "@EpicCmntsTelugu",
+        "url": "https://x.com/EpicCmntsTelugu"
+      },
+      "demoUrl": "https://x.com/EpicCmntsTelugu/status/2096480727366025689",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-609.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 665
+    },
+    {
+      "id": "work-39b0e034eb3bb54a",
+      "name": "Astra 与 Fable 的游戏、前端和动效实测对照",
+      "description": "转述 @chaseai__ 的实测；游戏经 Codex，动效调用 Higgsfield MCP。 转述称 Astra 游戏与前端更完整、动效打平，偏好与成本判断为评测者主观结论。 二手评测总结；未取得完整测试配置或独立复现，多个输出作为同一评测组。",
+      "category": "other",
+      "sourceCategory": "CheerSelfAI · 专业研究与安全评测",
+      "author": {
+        "name": "@neil_xbt",
+        "url": "https://x.com/neil_xbt"
+      },
+      "demoUrl": "https://x.com/neil_xbt/status/2096481270339604503",
+      "sourceUrl": null,
+      "repoUrl": null,
+      "imageUrl": "/previews/cheerself-610.jpg",
+      "posterUrl": null,
+      "videoUrl": null,
+      "sourceOrder": 666
+    }
+  ],
+  "source": {
+    "repository": "xianyu110/awesome-gpt-6-astra",
+    "url": "https://github.com/xianyu110/awesome-gpt-6-astra/blob/main/PLAYABLE.md",
+    "checkedAt": "2026-09-08T06:10:32.844Z",
+    "lastSuccessfulAt": "2026-09-08T06:10:32.844Z",
+    "revision": "playable-merge-20260908",
+    "stale": false,
+    "status": "fresh"
+  },
+  "refreshAfterSeconds": 300
+}


### PR DESCRIPTION
## Summary
- Add **Butterball Run** (photo→Blender→three.js dinner-table mobile game) and **Chao Party** (SA2 Chao Garden browser multiplayer) from today's hourly X finds.
- Update `PLAYABLE.md` (78→80), `data/playable-demos.json`, and Pages `catalog-fallback.json` with trial links + X preview media.

## Test plan
- [ ] Cards show preview images on https://xianyu110.github.io/awesome-gpt-6-astra/
- [ ] Demo / source links open