### PR TITLE
update: Model X Studio 源码与说明

### DIFF
--- a/PLAYABLE.md
+++ b/PLAYABLE.md
@@ -277,9 +277,11 @@
    - 试玩链接：`https://bernabeu-tres-d.antihero11.chatgpt.site/`
    - 原帖：https://x.com/davidcanci/status/2096201214178308538
 
-16. **Model X Studio** — [试玩](https://model-x-studio.vercel.app) · [原帖](https://x.com/grok/status/2096216661011439951)
-   - 试玩链接：`https://model-x-studio.vercel.app`
+16. **Model X Studio** — [试玩](https://model-x-studio.vercel.app/) · [源码](https://github.com/ashemag/model-x-studio) · [原帖](https://x.com/grok/status/2096216661011439951)
+   - 试玩链接：`https://model-x-studio.vercel.app/`
+   - 源码：https://github.com/ashemag/model-x-studio
    - 原帖：https://x.com/grok/status/2096216661011439951
+   - 简介：交互式 Tesla Model X 3D 工作室，圆形展台、零件说明、单件隔离，以及覆盖全部 **334** 个 mesh 的渐进爆炸视图
 
 17. **mosswing-quiet-flight** — [试玩](https://mosswing-quiet-flight.jack-514.chatgpt.site) · [原帖](https://x.com/i/status/2096263516181123300)
    - 试玩链接：`https://mosswing-quiet-flight.jack-514.chatgpt.site`

--- a/data/playable-demos.json
+++ b/data/playable-demos.json
@@ -393,10 +393,13 @@
   },
   {
     "title": "Model X Studio",
-    "demo_url": "https://model-x-studio.vercel.app",
+    "demo_url": "https://model-x-studio.vercel.app/",
     "post_url": "https://x.com/grok/status/2096216661011439951",
     "likes": 0,
-    "category": "3D 场景 / 氛围探索"
+    "category": "3D 场景 / 氛围探索",
+    "repo_url": "https://github.com/ashemag/model-x-studio",
+    "author": "ashemag",
+    "description": "Interactive Model X 3D studio with 334-piece explosion / isolation"
   },
   {
     "title": "mosswing-quiet-flight",

--- a/sources/martin/website/public/data/catalog-fallback.json
+++ b/sources/martin/website/public/data/catalog-fallback.json
@@ -399,16 +399,16 @@
     {
       "id": "work-7165f122f8556d68",
       "name": "Model X Studio",
-      "description": "可玩 Demo · 3D 场景 / 氛围探索",
+      "description": "交互式 Tesla Model X 3D 工作室：圆形展台、零件说明、单件隔离，以及覆盖全部 334 个 mesh 的渐进爆炸视图。可玩 Demo。",
       "category": "game",
       "sourceCategory": "PLAYABLE · 3D 场景 / 氛围探索",
       "author": {
-        "name": "grok",
-        "url": "https://x.com/grok"
+        "name": "ashemag",
+        "url": "https://github.com/ashemag"
       },
-      "demoUrl": "https://model-x-studio.vercel.app",
-      "sourceUrl": "https://x.com/grok/status/2096216661011439951",
-      "repoUrl": null,
+      "demoUrl": "https://model-x-studio.vercel.app/",
+      "sourceUrl": "https://github.com/ashemag/model-x-studio",
+      "repoUrl": "https://github.com/ashemag/model-x-studio",
       "imageUrl": "/previews/playable-7165f122f8556d68.jpg",
       "posterUrl": null,
       "videoUrl": null,


### PR DESCRIPTION
## Summary
- 补上 GitHub：https://github.com/ashemag/model-x-studio
- demo：https://model-x-studio.vercel.app/
- 更新作者为 ashemag，说明改为 334-piece 交互拆解工作室
- catalog「源码」入口指向仓库（原帖仍保留在 PLAYABLE）