### PR TITLE
fix: 自定义域名根路径 + SEO

### DIFF
--- a/sources/martin/website/index.html
+++ b/sources/martin/website/index.html
@@ -7,8 +7,8 @@
     <meta name="description" content="GPT-6 Astra 优秀作品集：发现社区构建的网站、应用、工具、游戏与交互实验，浏览案例预览、作者和源码。" />
     <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
     <meta name="author" content="xianyu110" />
-    <link rel="canonical" href="https://xianyu110.github.io/awesome-gpt-6-astra/" />
-    <link rel="sitemap" type="application/xml" href="https://xianyu110.github.io/awesome-gpt-6-astra/sitemap.xml" />
+    <link rel="canonical" href="https://gpt-6-astra.cc/" />
+    <link rel="sitemap" type="application/xml" href="https://gpt-6-astra.cc/sitemap.xml" />
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -17,9 +17,9 @@
     <meta property="og:title" content="GPT-6 Astra 优秀作品集" />
     <meta property="og:description" content="浏览 GPT-6 Astra 社区构建的网站、应用、工具、游戏与交互实验，查看真实作品预览与源码入口。" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://xianyu110.github.io/awesome-gpt-6-astra/" />
+    <meta property="og:url" content="https://gpt-6-astra.cc/" />
     <meta property="og:locale" content="zh_CN" />
-    <meta property="og:image" content="https://xianyu110.github.io/awesome-gpt-6-astra/previews/melon-lab.jpg" />
+    <meta property="og:image" content="https://gpt-6-astra.cc/previews/melon-lab.jpg" />
     <meta property="og:image:width" content="1440" />
     <meta property="og:image:height" content="950" />
     <meta property="og:image:type" content="image/jpeg" />
@@ -27,7 +27,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="GPT-6 Astra 优秀作品集" />
     <meta name="twitter:description" content="浏览 GPT-6 Astra 社区构建的网站、应用、工具、游戏与交互实验。" />
-    <meta name="twitter:image" content="https://xianyu110.github.io/awesome-gpt-6-astra/previews/melon-lab.jpg" />
+    <meta name="twitter:image" content="https://gpt-6-astra.cc/previews/melon-lab.jpg" />
     <meta name="twitter:image:alt" content="GPT-6 Astra 社区作品预览" />
     <title>GPT-6 Astra 优秀作品集｜社区案例与实验</title>
     <script type="application/ld+json">
@@ -36,8 +36,8 @@
         "@graph": [
           {
             "@type": "WebSite",
-            "@id": "https://xianyu110.github.io/awesome-gpt-6-astra/#website",
-            "url": "https://xianyu110.github.io/awesome-gpt-6-astra/",
+            "@id": "https://gpt-6-astra.cc/#website",
+            "url": "https://gpt-6-astra.cc/",
             "name": "Awesome GPT-6 Astra",
             "description": "GPT-6 Astra 社区作品集，收录网站、应用、工具、游戏与交互实验。",
             "inLanguage": ["zh-CN", "en"],
@@ -49,12 +49,12 @@
           },
           {
             "@type": "CollectionPage",
-            "@id": "https://xianyu110.github.io/awesome-gpt-6-astra/#collection",
-            "url": "https://xianyu110.github.io/awesome-gpt-6-astra/",
+            "@id": "https://gpt-6-astra.cc/#collection",
+            "url": "https://gpt-6-astra.cc/",
             "name": "GPT-6 Astra 优秀作品集",
             "description": "浏览 GPT-6 Astra 社区构建的真实作品、案例预览、作者和源码。",
             "isPartOf": {
-              "@id": "https://xianyu110.github.io/awesome-gpt-6-astra/#website"
+              "@id": "https://gpt-6-astra.cc/#website"
             },
             "about": {
               "@type": "Thing",

--- a/sources/martin/website/public/robots.txt
+++ b/sources/martin/website/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://xianyu110.github.io/awesome-gpt-6-astra/sitemap.xml
+Sitemap: https://gpt-6-astra.cc/sitemap.xml

--- a/sources/martin/website/public/sitemap.xml
+++ b/sources/martin/website/public/sitemap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://xianyu110.github.io/awesome-gpt-6-astra/</loc>
+    <loc>https://gpt-6-astra.cc/</loc>
   </url>
 </urlset>


### PR DESCRIPTION
Custom domain gpt-6-astra.cc needs PAGES_BASE_PATH=/ so JS/CSS load; update canonical/sitemap/robots to the new domain.