### PR TITLE
sync: +8 alive GPT-6 Astra playables (PLAYABLE 99→107)

### DIFF
--- a/PLAYABLE.md
+++ b/PLAYABLE.md
@@ -2,163 +2,177 @@
 
 > 社区 GPT-6 Astra 可玩网页 / 浏览器 Demo 精选。每条都附带**试玩链接**；有原帖则附原帖。链接已探活，临时部署仍可能失效。
 
-- 收录：**99** 条（已剔除失效、新闻软文、PDF/指南、作品集等非试玩项）
+- 收录：**107** 条（已剔除失效、新闻软文、PDF/指南、作品集等非试玩项）
 - 整理日期：2026-09-09
 - 维护：MaynorAI / [@xianyu110](https://github.com/xianyu110)
 
 ## Contents
 
-- [经典复刻 / 知名玩法](#经典复刻--知名玩法) — 10
-- [竞速 / 驾驶](#竞速--驾驶) — 12
-- [射击 / 动作](#射击--动作) — 8
-- [模拟经营 / 策略](#模拟经营--策略) — 5
+- [经典复刻 / 知名玩法](#经典复刻--知名玩法) — 11
+- [竞速 / 驾驶](#竞速--驾驶) — 13
+- [射击 / 动作](#射击--动作) — 9
+- [模拟经营 / 策略](#模拟经营--策略) — 6
 - [联机 / 多人](#联机--多人) — 4
-- [街机 / 小游戏包](#街机--小游戏包) — 11
+- [街机 / 小游戏包](#街机--小游戏包) — 12
 - [音乐 / 表演](#音乐--表演) — 7
 - [教育 / 科普](#教育--科普) — 4
-- [3D 场景 / 氛围探索](#3D-场景--氛围探索) — 26
-- [工程 / 仿真](#工程--仿真) — 7
+- [3D 场景 / 氛围探索](#3D-场景--氛围探索) — 28
+- [工程 / 仿真](#工程--仿真) — 8
 - [其他可玩 Demo](#其他可玩-Demo) — 5
 
 ## 经典复刻 / 知名玩法
 
-1. **Monopoly City — A board worth exploring** — [试玩](https://monopoly-city.eekosystems.chatgpt.site) · [原帖](https://x.com/thomasunise/status/2097121832159609145) · ❤ 2
+1. **诡秘之主 · Tarot Club** — [试玩](https://combos.game/play/c7eea0b6846f90a102537819c9147bd4) · [原帖](https://x.com/TsinsiSun/status/2097214405373300859) · ❤ 5
+   - 试玩链接：`https://combos.game/play/c7eea0b6846f90a102537819c9147bd4`
+   - 原帖：https://x.com/TsinsiSun/status/2097214405373300859
+
+2. **Monopoly City — A board worth exploring** — [试玩](https://monopoly-city.eekosystems.chatgpt.site) · [原帖](https://x.com/thomasunise/status/2097121832159609145) · ❤ 2
    - 试玩链接：`https://monopoly-city.eekosystems.chatgpt.site`
    - 原帖：https://x.com/thomasunise/status/2097121832159609145
 
-2. **瓜体实验室 / 合成大西瓜** — [试玩](https://melon-game.jack-514.chatgpt.site/)
+3. **瓜体实验室 / 合成大西瓜** — [试玩](https://melon-game.jack-514.chatgpt.site/)
    - 试玩链接：`https://melon-game.jack-514.chatgpt.site/`
 
-3. **超级马里奥·蘑菇王国** — [试玩](https://mushroom-arcade-0905.jumaomaomaoju.chatgpt.site/)
+4. **超级马里奥·蘑菇王国** — [试玩](https://mushroom-arcade-0905.jumaomaomaoju.chatgpt.site/)
    - 试玩链接：`https://mushroom-arcade-0905.jumaomaomaoju.chatgpt.site/`
 
-4. **DUSTⅡ·沙漠行动** — [试玩](https://dust-ii-map.yelin8130.chatgpt.site/)
+5. **DUSTⅡ·沙漠行动** — [试玩](https://dust-ii-map.yelin8130.chatgpt.site/)
    - 试玩链接：`https://dust-ii-map.yelin8130.chatgpt.site/`
 
-5. **水果忍者** — [试玩](https://fruit-ninja-dojo-20260905.yongqixue666.chatgpt.site/)
+6. **水果忍者** — [试玩](https://fruit-ninja-dojo-20260905.yongqixue666.chatgpt.site/)
    - 试玩链接：`https://fruit-ninja-dojo-20260905.yongqixue666.chatgpt.site/`
 
-6. **植物大战僵尸** — [试玩](https://seth-xh.github.io/pvz/)
+7. **植物大战僵尸** — [试玩](https://seth-xh.github.io/pvz/)
    - 试玩链接：`https://seth-xh.github.io/pvz/`
 
-7. **小丑牌 Balatro** — [试玩](https://balatro-v1-1.longyh2333521818.chatgpt.site/)
+8. **小丑牌 Balatro** — [试玩](https://balatro-v1-1.longyh2333521818.chatgpt.site/)
    - 试玩链接：`https://balatro-v1-1.longyh2333521818.chatgpt.site/`
 
-8. **PAC-MAN: Ghost Sharks — Bite back.** — [试玩](https://pacman.demyx.workers.dev/) · [原帖](https://x.com/awildnpc/status/2096034211782099313)
+9. **PAC-MAN: Ghost Sharks — Bite back.** — [试玩](https://pacman.demyx.workers.dev/) · [原帖](https://x.com/awildnpc/status/2096034211782099313)
    - 试玩链接：`https://pacman.demyx.workers.dev/`
    - 原帖：https://x.com/awildnpc/status/2096034211782099313
 
-9. **Flappy Bird · Click to Fly** — [试玩](https://flappy-click-arcade-sept26.wesley-blomquist96.chatgpt.site/) · [原帖](https://x.com/i/status/2096347522226684105)
+10. **Flappy Bird · Click to Fly** — [试玩](https://flappy-click-arcade-sept26.wesley-blomquist96.chatgpt.site/) · [原帖](https://x.com/i/status/2096347522226684105)
    - 试玩链接：`https://flappy-click-arcade-sept26.wesley-blomquist96.chatgpt.site/`
    - 原帖：https://x.com/i/status/2096347522226684105
 
-10. **八荒幻世 · 热血归来（176 / Dragon Warrior）** — [试玩](https://mir176-dragon-warrior.geekcatxx.chatgpt.site/)
+11. **八荒幻世 · 热血归来（176 / Dragon Warrior）** — [试玩](https://mir176-dragon-warrior.geekcatxx.chatgpt.site/)
    - 试玩链接：`https://mir176-dragon-warrior.geekcatxx.chatgpt.site/`
 
 ## 竞速 / 驾驶
 
-1. **JUNK RUN** — [试玩](https://junk-run.pages.dev/) · [原帖](https://x.com/hermesailab/status/2097508053901840850)
+1. **Bengaluru ORR Rush** — [试玩](https://orr-rush-bengaluru.ravitheja.chatgpt.site/) · [原帖](https://x.com/ravithejads/status/2097181044625887392) · ❤ 22
+   - 试玩链接：`https://orr-rush-bengaluru.ravitheja.chatgpt.site/`
+   - 原帖：https://x.com/ravithejads/status/2097181044625887392
+
+2. **JUNK RUN** — [试玩](https://junk-run.pages.dev/) · [原帖](https://x.com/hermesailab/status/2097508053901840850)
    - 试玩链接：`https://junk-run.pages.dev/`
    - 原帖：https://x.com/hermesailab/status/2097508053901840850
 
-2. **STORM RACE · Tsuchiya Workshop** — [试玩](https://storm-race.vercel.app) · [原帖](https://x.com/BubuStd/status/2096587056755638553) · ❤ 4191
+3. **STORM RACE · Tsuchiya Workshop** — [试玩](https://storm-race.vercel.app) · [原帖](https://x.com/BubuStd/status/2096587056755638553) · ❤ 4191
    - 试玩链接：`https://storm-race.vercel.app`
    - 原帖：https://x.com/BubuStd/status/2096587056755638553
 
-3. **Ashen Road — A journey to Ravenwatch** — [试玩](https://ashen-road.emad349385.chatgpt.site) · [原帖](https://x.com/i/status/2096359789525639290) · ❤ 286
+4. **Ashen Road — A journey to Ravenwatch** — [试玩](https://ashen-road.emad349385.chatgpt.site) · [原帖](https://x.com/i/status/2096359789525639290) · ❤ 286
    - 试玩链接：`https://ashen-road.emad349385.chatgpt.site`
    - 原帖：https://x.com/i/status/2096359789525639290
 
-4. **Tidal Rush — Paradise Grand Prix** — [试玩](https://tidal-rush-paradise-gp.skirano.chatgpt.site) · [原帖](https://x.com/alexgetmancom/status/2095598460921614825) · ❤ 24
+5. **Tidal Rush — Paradise Grand Prix** — [试玩](https://tidal-rush-paradise-gp.skirano.chatgpt.site) · [原帖](https://x.com/alexgetmancom/status/2095598460921614825) · ❤ 24
    - 试玩链接：`https://tidal-rush-paradise-gp.skirano.chatgpt.site`
    - 原帖：https://x.com/alexgetmancom/status/2095598460921614825
 
-5. **Blue Bajaj Rally 1.0.1 | Highland Loop** — [试玩](https://bajaj.guzo.tech/) · [原帖](https://x.com/guzotech/status/2096209787864088638) · ❤ 12
+6. **Blue Bajaj Rally 1.0.1 | Highland Loop** — [试玩](https://bajaj.guzo.tech/) · [原帖](https://x.com/guzotech/status/2096209787864088638) · ❤ 12
    - 试玩链接：`https://bajaj.guzo.tech/`
    - 原帖：https://x.com/guzotech/status/2096209787864088638
 
-6. **THE ROAD DREAMS · 梦境之径** — [试玩](https://the-road-dreams.x2026283037.chatgpt.site) · [原帖](https://x.com/i/status/2096313256264765440) · ❤ 1
+7. **THE ROAD DREAMS · 梦境之径** — [试玩](https://the-road-dreams.x2026283037.chatgpt.site) · [原帖](https://x.com/i/status/2096313256264765440) · ❤ 1
    - 试玩链接：`https://the-road-dreams.x2026283037.chatgpt.site`
    - 原帖：https://x.com/i/status/2096313256264765440
 
-7. **Zombie Escape Driver** — [试玩](https://zombiedriver.z.madsoftware.co) · [原帖](https://x.com/MarcDagatan/status/2096667577326190631) · ❤ 1
+8. **Zombie Escape Driver** — [试玩](https://zombiedriver.z.madsoftware.co) · [原帖](https://x.com/MarcDagatan/status/2096667577326190631) · ❤ 1
    - 试玩链接：`https://zombiedriver.z.madsoftware.co`
    - 原帖：https://x.com/MarcDagatan/status/2096667577326190631
 
-8. **COURTSIDE NBA2K** — [试玩](https://huhuhu.page.gd/COURTSIDE26.html)
+9. **COURTSIDE NBA2K** — [试玩](https://huhuhu.page.gd/COURTSIDE26.html)
    - 试玩链接：`https://huhuhu.page.gd/COURTSIDE26.html`
 
-9. **AI Mini Racer - Astra Edition** — [试玩](https://ai-mini-racer.code-crunche-2353.chatgpt.site) · [原帖](https://x.com/i/status/2096320362736714233)
+10. **AI Mini Racer - Astra Edition** — [试玩](https://ai-mini-racer.code-crunche-2353.chatgpt.site) · [原帖](https://x.com/i/status/2096320362736714233)
    - 试玩链接：`https://ai-mini-racer.code-crunche-2353.chatgpt.site`
    - 原帖：https://x.com/i/status/2096320362736714233
 
-10. **CYBER SUV · 互动设计展厅** — [试玩](https://cyber-suv-studio.banny911.chatgpt.site) · [原帖](https://x.com/i/status/2096384563459334256)
+11. **CYBER SUV · 互动设计展厅** — [试玩](https://cyber-suv-studio.banny911.chatgpt.site) · [原帖](https://x.com/i/status/2096384563459334256)
    - 试玩链接：`https://cyber-suv-studio.banny911.chatgpt.site`
    - 原帖：https://x.com/i/status/2096384563459334256
 
-11. **DUSKLINE — Canyon Circuit** — [试玩](https://duskline-canyon-run.abdulhadi-ai.chatgpt.site) · [原帖](https://x.com/1banke/status/2096394721115390301)
+12. **DUSKLINE — Canyon Circuit** — [试玩](https://duskline-canyon-run.abdulhadi-ai.chatgpt.site) · [原帖](https://x.com/1banke/status/2096394721115390301)
    - 试玩链接：`https://duskline-canyon-run.abdulhadi-ai.chatgpt.site`
    - 原帖：https://x.com/1banke/status/2096394721115390301
 
-12. **Lantern Cove · The Borrowed Light** — [试玩](https://lantern-cove.akartit.chatgpt.site/) · [原帖](https://x.com/akartit/status/2096520784449613981)
+13. **Lantern Cove · The Borrowed Light** — [试玩](https://lantern-cove.akartit.chatgpt.site/) · [原帖](https://x.com/akartit/status/2096520784449613981)
    - 试玩链接：`https://lantern-cove.akartit.chatgpt.site/`
    - 原帖：https://x.com/akartit/status/2096520784449613981
 
 ## 射击 / 动作
 
-1. **Harbor Skirmish — Three.js naval battle** — [试玩](https://gpt6astra-game.vercel.app/) · [原帖](https://x.com/OpenDesignHQ/status/2097635757917983223)
+1. **Bonkshot** — [试玩](https://bonkshot.com) · [原帖](https://x.com/edmund5/status/2097603093819261002)
+   - 试玩链接：`https://bonkshot.com`
+   - 原帖：https://x.com/edmund5/status/2097603093819261002
+
+2. **Harbor Skirmish — Three.js naval battle** — [试玩](https://gpt6astra-game.vercel.app/) · [原帖](https://x.com/OpenDesignHQ/status/2097635757917983223)
    - 试玩链接：`https://gpt6astra-game.vercel.app/`
    - 原帖：https://x.com/OpenDesignHQ/status/2097635757917983223
 
-2. **LAST LIGHT — A Northline Story** — [试玩](https://last-light-northline.pages.dev) · [原帖](https://x.com/md_taqui_imam/status/2096255279650517081) · ❤ 5
+3. **LAST LIGHT — A Northline Story** — [试玩](https://last-light-northline.pages.dev) · [原帖](https://x.com/md_taqui_imam/status/2096255279650517081) · ❤ 5
    - 试玩链接：`https://last-light-northline.pages.dev`
    - 原帖：https://x.com/md_taqui_imam/status/2096255279650517081
 
-3. **FANG · STARLIGHT RUN** — [试玩](https://fang-starlight-run.yosshy666.chatgpt.site/) · [原帖](https://x.com/FANGsaikyou/status/2096192445667283326) · ❤ 2
+4. **FANG · STARLIGHT RUN** — [试玩](https://fang-starlight-run.yosshy666.chatgpt.site/) · [原帖](https://x.com/FANGsaikyou/status/2096192445667283326) · ❤ 2
    - 试玩链接：`https://fang-starlight-run.yosshy666.chatgpt.site/`
    - 原帖：https://x.com/FANGsaikyou/status/2096192445667283326
 
-4. **INFINITUM** — [试玩](https://infinitum-game.vercel.app/) · [原帖](https://x.com/HpMani56403/status/2097188417709002822) · ❤ 2
+5. **INFINITUM** — [试玩](https://infinitum-game.vercel.app/) · [原帖](https://x.com/HpMani56403/status/2097188417709002822) · ❤ 2
    - 试玩链接：`https://infinitum-game.vercel.app/`
    - 原帖：https://x.com/HpMani56403/status/2097188417709002822
 
-5. **Building Prism World ✳️ One idea, every feed.** — [试玩](https://prism-world-demo.krrish18.chatgpt.site) · [原帖](https://x.com/krishnap1810/status/2095633183567945941)
+6. **Building Prism World ✳️ One idea, every feed.** — [试玩](https://prism-world-demo.krrish18.chatgpt.site) · [原帖](https://x.com/krishnap1810/status/2095633183567945941)
    - 试玩链接：`https://prism-world-demo.krrish18.chatgpt.site`
    - 原帖：https://x.com/krishnap1810/status/2095633183567945941
 
-6. **마성전설 — 메두사의 신전** — [试玩](https://knightmare-medusa-3d.robin-hwang.chatgpt.site/) · [原帖](https://x.com/i/status/2096984386566815920)
+7. **마성전설 — 메두사의 신전** — [试玩](https://knightmare-medusa-3d.robin-hwang.chatgpt.site/) · [原帖](https://x.com/i/status/2096984386566815920)
    - 试玩链接：`https://knightmare-medusa-3d.robin-hwang.chatgpt.site/`
    - 原帖：https://x.com/i/status/2096984386566815920
 
-7. **Neural Sight — Play the demo** — [试玩](https://monstercameron.github.io/Neural-Sight/) · [原帖](https://x.com/monstercameron/status/2097117275127959629)
+8. **Neural Sight — Play the demo** — [试玩](https://monstercameron.github.io/Neural-Sight/) · [原帖](https://x.com/monstercameron/status/2097117275127959629)
    - 试玩链接：`https://monstercameron.github.io/Neural-Sight/`
    - 原帖：https://x.com/monstercameron/status/2097117275127959629
 
-8. **ASCII DISTRICT** — [试玩](https://ascii-district.vercel.app/) · [原帖](https://x.com/acker_code/status/2097542957070975286)
+9. **ASCII DISTRICT** — [试玩](https://ascii-district.vercel.app/) · [原帖](https://x.com/acker_code/status/2097542957070975286)
    - 试玩链接：`https://ascii-district.vercel.app/`
    - 原帖：https://x.com/acker_code/status/2097542957070975286
 
-
 ## 模拟经营 / 策略
 
-1. **Matter — law firm economics** — [试玩](https://matter-economics.shreya-vajpei.chatgpt.site) · [原帖](https://x.com/shreya_vajpei/status/2097619671339929620)
+1. **FOREX WARS** — [试玩](https://afterprime-forex-wars.argamon-2254.chatgpt.site/) · [原帖](https://x.com/afterprime_com/status/2097159628119535866) · ❤ 3
+   - 试玩链接：`https://afterprime-forex-wars.argamon-2254.chatgpt.site/`
+   - 原帖：https://x.com/afterprime_com/status/2097159628119535866
+
+2. **Matter — law firm economics** — [试玩](https://matter-economics.shreya-vajpei.chatgpt.site) · [原帖](https://x.com/shreya_vajpei/status/2097619671339929620)
    - 试玩链接：`https://matter-economics.shreya-vajpei.chatgpt.site`
    - 原帖：https://x.com/shreya_vajpei/status/2097619671339929620
 
-2. **秦王拧螺丝** — [试玩](https://qin-imperial-factory-221.xyjwyf123.chatgpt.site/)
+3. **秦王拧螺丝** — [试玩](https://qin-imperial-factory-221.xyjwyf123.chatgpt.site/)
    - 试玩链接：`https://qin-imperial-factory-221.xyjwyf123.chatgpt.site/`
 
-3. **Web 三国** — [试玩](https://sanguo-wind-cloud.amery2010.workers.dev/)
+4. **Web 三国** — [试玩](https://sanguo-wind-cloud.amery2010.workers.dev/)
    - 试玩链接：`https://sanguo-wind-cloud.amery2010.workers.dev/`
 
-4. **Little Kingdom — 작은 왕국 체스** — [试玩](https://little-kingdom-chess.echo3042.chatgpt.site) · [原帖](https://x.com/echo3042/status/2096123409029886250)
+5. **Little Kingdom — 작은 왕국 체스** — [试玩](https://little-kingdom-chess.echo3042.chatgpt.site) · [原帖](https://x.com/echo3042/status/2096123409029886250)
    - 试玩链接：`https://little-kingdom-chess.echo3042.chatgpt.site`
    - 原帖：https://x.com/echo3042/status/2096123409029886250
 
-5. **Le Bon Rayon — Épicerie de quartier** — [试玩](https://le-bon-rayon.alexxondre.chatgpt.site) · [原帖](https://x.com/i/status/2096652925527314554)
+6. **Le Bon Rayon — Épicerie de quartier** — [试玩](https://le-bon-rayon.alexxondre.chatgpt.site) · [原帖](https://x.com/i/status/2096652925527314554)
    - 试玩链接：`https://le-bon-rayon.alexxondre.chatgpt.site`
    - 原帖：https://x.com/i/status/2096652925527314554
-
 
 ## 联机 / 多人
 
@@ -180,47 +194,51 @@
 
 ## 街机 / 小游戏包
 
-1. **零点街区 · 弹壳特攻队 3D** — [试玩](https://iamsonic.net/2026/mini-games/shells-3d/play.html) · [原帖](https://x.com/sonic0828/status/2097601232877781344) · ❤ 13
+1. **One More** — [试玩](https://onemoreapp.vercel.app) · [原帖](https://x.com/gregavola/status/2097318437030690831) · ❤ 2
+   - 试玩链接：`https://onemoreapp.vercel.app`
+   - 原帖：https://x.com/gregavola/status/2097318437030690831
+
+2. **零点街区 · 弹壳特攻队 3D** — [试玩](https://iamsonic.net/2026/mini-games/shells-3d/play.html) · [原帖](https://x.com/sonic0828/status/2097601232877781344) · ❤ 13
    - 试玩链接：`https://iamsonic.net/2026/mini-games/shells-3d/play.html`
    - 原帖：https://x.com/sonic0828/status/2097601232877781344
 
-2. **SKICROSS · 极地速降** — [试玩](https://iamsonic.net/2026/mini-games/skicross.html) · [原帖](https://x.com/sonic0828/status/2097601232877781344) · ❤ 13
+3. **SKICROSS · 极地速降** — [试玩](https://iamsonic.net/2026/mini-games/skicross.html) · [原帖](https://x.com/sonic0828/status/2097601232877781344) · ❤ 13
    - 试玩链接：`https://iamsonic.net/2026/mini-games/skicross.html`
    - 原帖：https://x.com/sonic0828/status/2097601232877781344
 
-3. **UNDERGROUND — 地下拳场** — [试玩](https://iamsonic.net/2026/mini-games/underground-boxing.html) · [原帖](https://x.com/sonic0828/status/2097601232877781344) · ❤ 13
+4. **UNDERGROUND — 地下拳场** — [试玩](https://iamsonic.net/2026/mini-games/underground-boxing.html) · [原帖](https://x.com/sonic0828/status/2097601232877781344) · ❤ 13
    - 试玩链接：`https://iamsonic.net/2026/mini-games/underground-boxing.html`
    - 原帖：https://x.com/sonic0828/status/2097601232877781344
 
-4. **街头小子 · Urban Champion 3D** — [试玩](https://iamsonic.net/2026/mini-games/urban-champion.html) · [原帖](https://x.com/sonic0828/status/2097601232877781344) · ❤ 13
+5. **街头小子 · Urban Champion 3D** — [试玩](https://iamsonic.net/2026/mini-games/urban-champion.html) · [原帖](https://x.com/sonic0828/status/2097601232877781344) · ❤ 13
    - 试玩链接：`https://iamsonic.net/2026/mini-games/urban-champion.html`
    - 原帖：https://x.com/sonic0828/status/2097601232877781344
 
-5. **Butterball Run — dinner-table three.js** — [试玩](https://butterball-run.jeraldine-t.chatgpt.site) · [原帖](https://x.com/SecretSeoul/status/2097315757931811081) · ❤ 1
+6. **Butterball Run — dinner-table three.js** — [试玩](https://butterball-run.jeraldine-t.chatgpt.site) · [原帖](https://x.com/SecretSeoul/status/2097315757931811081) · ❤ 1
    - 试玩链接：`https://butterball-run.jeraldine-t.chatgpt.site`
    - 原帖：https://x.com/SecretSeoul/status/2097315757931811081
 
-6. **ASTRA Arcade — Six original games** — [试玩](https://astra-arcade.antonioleivag.chatgpt.site) · [原帖](https://x.com/antonioleivag/status/2096509898481651770) · ❤ 21
+7. **ASTRA Arcade — Six original games** — [试玩](https://astra-arcade.antonioleivag.chatgpt.site) · [原帖](https://x.com/antonioleivag/status/2096509898481651770) · ❤ 21
    - 试玩链接：`https://astra-arcade.antonioleivag.chatgpt.site`
    - 原帖：https://x.com/antonioleivag/status/2096509898481651770
 
-7. **ASTEROIDS · Deepfield** — [试玩](https://asteroids-deepfield-cockpit.dan200200.chatgpt.site/) · [原帖](https://x.com/DantesClown/status/2096085439052452064) · ❤ 3
+8. **ASTEROIDS · Deepfield** — [试玩](https://asteroids-deepfield-cockpit.dan200200.chatgpt.site/) · [原帖](https://x.com/DantesClown/status/2096085439052452064) · ❤ 3
    - 试玩链接：`https://asteroids-deepfield-cockpit.dan200200.chatgpt.site/`
    - 原帖：https://x.com/DantesClown/status/2096085439052452064
 
-8. **Play Games Built with GPT-6 Astra | Astragames** — [试玩](https://astragames.lol) · [原帖](https://x.com/i/status/2096377756062027894) · ❤ 2
+9. **Play Games Built with GPT-6 Astra | Astragames** — [试玩](https://astragames.lol) · [原帖](https://x.com/i/status/2096377756062027894) · ❤ 2
    - 试玩链接：`https://astragames.lol`
    - 原帖：https://x.com/i/status/2096377756062027894
 
-9. **Astra Games — Built with GPT-6 Astra** — [试玩](https://astragames.aigccreative.com/en) · [原帖](https://x.com/marindeloph/status/2096901528166793595) · ❤ 1
+10. **Astra Games — Built with GPT-6 Astra** — [试玩](https://astragames.aigccreative.com/en) · [原帖](https://x.com/marindeloph/status/2096901528166793595) · ❤ 1
    - 试玩链接：`https://astragames.aigccreative.com/en`
    - 原帖：https://x.com/marindeloph/status/2096901528166793595
 
-10. **Kutular – Büyük Ödül Oyunu** — [试玩](https://kutular-oyunu.tuned-lion-2154.chatgpt.site) · [原帖](https://x.com/nzmdgnc/status/2095803218135544027)
+11. **Kutular – Büyük Ödül Oyunu** — [试玩](https://kutular-oyunu.tuned-lion-2154.chatgpt.site) · [原帖](https://x.com/nzmdgnc/status/2095803218135544027)
    - 试玩链接：`https://kutular-oyunu.tuned-lion-2154.chatgpt.site`
    - 原帖：https://x.com/nzmdgnc/status/2095803218135544027
 
-11. **Chrome Slot Studio — fun-fact slot** — [试玩](https://chrome-slot-studio.sushmithanair1402.chatgpt.site/) · [原帖](https://x.com/sushmithanairws/status/2097539537652289872)
+12. **Chrome Slot Studio — fun-fact slot** — [试玩](https://chrome-slot-studio.sushmithanair1402.chatgpt.site/) · [原帖](https://x.com/sushmithanairws/status/2097539537652289872)
    - 试玩链接：`https://chrome-slot-studio.sushmithanair1402.chatgpt.site/`
    - 原帖：https://x.com/sushmithanairws/status/2097539537652289872
 
@@ -274,140 +292,151 @@
 
 ## 3D 场景 / 氛围探索
 
-1. **M—Dial / Motion study** — [试玩](https://video-to-3d.vercel.app/) · [原帖](https://x.com/henry19840301/status/2097588270171660321) · ❤ 45
+1. **Bangalore GTA-style Three.js** — [试玩](https://genaiexperiments.vercel.app) · [原帖](https://x.com/BuildFastWithAI/status/2097289129105223823) · ❤ 47
+   - 试玩链接：`https://genaiexperiments.vercel.app`
+   - 原帖：https://x.com/BuildFastWithAI/status/2097289129105223823
+
+2. **AFTERLIGHT** — [试玩](https://afterlight.a-9724.chatgpt.site) · [原帖](https://x.com/jhahimanshu653/status/2097172185513357794) · ❤ 6
+   - 试玩链接：`https://afterlight.a-9724.chatgpt.site`
+   - 原帖：https://x.com/jhahimanshu653/status/2097172185513357794
+
+3. **M—Dial / Motion study** — [试玩](https://video-to-3d.vercel.app/) · [原帖](https://x.com/henry19840301/status/2097588270171660321) · ❤ 45
    - 试玩链接：`https://video-to-3d.vercel.app/`
    - 原帖：https://x.com/henry19840301/status/2097588270171660321
 
-2. **Gamlebyen 3D · Fredrikstad** — [试玩](https://gamlebyen-3d-atlas.stefano-nichele.chatgpt.site/) · [原帖](https://x.com/stenichele/status/2097269732332249577)
+4. **Gamlebyen 3D · Fredrikstad** — [试玩](https://gamlebyen-3d-atlas.stefano-nichele.chatgpt.site/) · [原帖](https://x.com/stenichele/status/2097269732332249577)
    - 试玩链接：`https://gamlebyen-3d-atlas.stefano-nichele.chatgpt.site/`
    - 原帖：https://x.com/stenichele/status/2097269732332249577
 
-3. **20A Tarrant Drive · Spatial tour** — [试玩](https://tarrant-walkthrough.rongchenxuan12345.chatgpt.site/)
+5. **20A Tarrant Drive · Spatial tour** — [试玩](https://tarrant-walkthrough.rongchenxuan12345.chatgpt.site/)
    - 试玩链接：`https://tarrant-walkthrough.rongchenxuan12345.chatgpt.site/`
 
-4. **Pelagic — Ocean & Atmosphere** — [试玩](https://pelagic-ocean.lexn8.chatgpt.site) · [原帖](https://x.com/i/status/2096341945979383932) · ❤ 894
+6. **Pelagic — Ocean & Atmosphere** — [试玩](https://pelagic-ocean.lexn8.chatgpt.site) · [原帖](https://x.com/i/status/2096341945979383932) · ❤ 894
    - 试玩链接：`https://pelagic-ocean.lexn8.chatgpt.site`
    - 原帖：https://x.com/i/status/2096341945979383932
 
-5. **Moonlit Forge** — [试玩](https://moonlit-forge-studio.op7418.chatgpt.site) · [原帖](https://x.com/op7418/status/2096205141187956887) · ❤ 580
+7. **Moonlit Forge** — [试玩](https://moonlit-forge-studio.op7418.chatgpt.site) · [原帖](https://x.com/op7418/status/2096205141187956887) · ❤ 580
    - 试玩链接：`https://moonlit-forge-studio.op7418.chatgpt.site`
    - 原帖：https://x.com/op7418/status/2096205141187956887
 
-6. **Flora Brush** — [试玩](https://flora-brush.soumya-raj.chatgpt.site) · [原帖](https://x.com/soumyadesign/status/2096974030104666568) · ❤ 567
+8. **Flora Brush** — [试玩](https://flora-brush.soumya-raj.chatgpt.site) · [原帖](https://x.com/soumyadesign/status/2096974030104666568) · ❤ 567
    - 试玩链接：`https://flora-brush.soumya-raj.chatgpt.site`
    - 原帖：https://x.com/soumyadesign/status/2096974030104666568
 
-7. **Verdant Forest** — [试玩](https://verdant-forest.lexn8.chatgpt.site/) · [原帖](https://x.com/i/status/2096367614805373200) · ❤ 326
+9. **Verdant Forest** — [试玩](https://verdant-forest.lexn8.chatgpt.site/) · [原帖](https://x.com/i/status/2096367614805373200) · ❤ 326
    - 试玩链接：`https://verdant-forest.lexn8.chatgpt.site/`
    - 原帖：https://x.com/i/status/2096367614805373200
 
-8. **Diamond Light** — [试玩](https://diamond-light.lexn8.chatgpt.site/) · [原帖](https://x.com/LexnLin/status/2096103821470761033) · ❤ 113
+10. **Diamond Light** — [试玩](https://diamond-light.lexn8.chatgpt.site/) · [原帖](https://x.com/LexnLin/status/2096103821470761033) · ❤ 113
    - 试玩链接：`https://diamond-light.lexn8.chatgpt.site/`
    - 原帖：https://x.com/LexnLin/status/2096103821470761033
 
-9. **Skyward: The Gathering** — [试玩](https://edge-city-skyward-quests.vercel.app/) · [原帖](https://x.com/timourxyz/status/2096379521926840339) · ❤ 80
+11. **Skyward: The Gathering** — [试玩](https://edge-city-skyward-quests.vercel.app/) · [原帖](https://x.com/timourxyz/status/2096379521926840339) · ❤ 80
    - 试玩链接：`https://edge-city-skyward-quests.vercel.app/`
    - 原帖：https://x.com/timourxyz/status/2096379521926840339
 
-10. **Fluid — a little space to get lost** — [试玩](https://fluid-playground.lunar-labs-7954.chatgpt.site/) · [原帖](https://x.com/LukeYoungblood/status/2095974873772568778) · ❤ 57
+12. **Fluid — a little space to get lost** — [试玩](https://fluid-playground.lunar-labs-7954.chatgpt.site/) · [原帖](https://x.com/LukeYoungblood/status/2095974873772568778) · ❤ 57
    - 试玩链接：`https://fluid-playground.lunar-labs-7954.chatgpt.site/`
    - 原帖：https://x.com/LukeYoungblood/status/2095974873772568778
 
-11. **Eiffel — Light & Perspective** — [试玩](https://eiffel-tower-omega.vercel.app/) · [原帖](https://x.com/ayaboch/status/2096178212883587094) · ❤ 36
+13. **Eiffel — Light & Perspective** — [试玩](https://eiffel-tower-omega.vercel.app/) · [原帖](https://x.com/ayaboch/status/2096178212883587094) · ❤ 36
    - 试玩链接：`https://eiffel-tower-omega.vercel.app/`
    - 原帖：https://x.com/ayaboch/status/2096178212883587094
 
-12. **NAVI City — A living liquidity network** — [试玩](https://navi-emerald-city.elliscopef802081.chatgpt.site/) · [原帖](https://x.com/i/status/2096293372071747591) · ❤ 16
+14. **NAVI City — A living liquidity network** — [试玩](https://navi-emerald-city.elliscopef802081.chatgpt.site/) · [原帖](https://x.com/i/status/2096293372071747591) · ❤ 16
    - 试玩链接：`https://navi-emerald-city.elliscopef802081.chatgpt.site/`
    - 原帖：https://x.com/i/status/2096293372071747591
 
-13. **Manu.Vision — SP Edition** — [试玩](https://manu.vision/gb/) · [原帖](https://x.com/i/status/2095999334034690340) · ❤ 5
+15. **Manu.Vision — SP Edition** — [试玩](https://manu.vision/gb/) · [原帖](https://x.com/i/status/2095999334034690340) · ❤ 5
    - 试玩链接：`https://manu.vision/gb/`
    - 原帖：https://x.com/i/status/2095999334034690340
 
-14. **Wildwood — A little world of your own** — [试玩](https://krit22.github.io/browser-minecraft/) · [原帖](https://x.com/Krit12007/status/2096141849841029610) · ❤ 3
+16. **Wildwood — A little world of your own** — [试玩](https://krit22.github.io/browser-minecraft/) · [原帖](https://x.com/Krit12007/status/2096141849841029610) · ❤ 3
    - 试玩链接：`https://krit22.github.io/browser-minecraft/`
    - 原帖：https://x.com/Krit12007/status/2096141849841029610
 
-15. **Persepolis — An Ancient World, Rediscovered** — [试玩](https://persepolis-explorer.vercel.app) · [原帖](https://x.com/made_by_hossein/status/2096454262817534111) · ❤ 3
+17. **Persepolis — An Ancient World, Rediscovered** — [试玩](https://persepolis-explorer.vercel.app) · [原帖](https://x.com/made_by_hossein/status/2096454262817534111) · ❤ 3
    - 试玩链接：`https://persepolis-explorer.vercel.app`
    - 原帖：https://x.com/made_by_hossein/status/2096454262817534111
 
-16. **Komorebi — Cat World** — [试玩](https://komorebi-neon.vercel.app/) · [原帖](https://x.com/thisjiro/status/2096008437343949039) · ❤ 2
+18. **Komorebi — Cat World** — [试玩](https://komorebi-neon.vercel.app/) · [原帖](https://x.com/thisjiro/status/2096008437343949039) · ❤ 2
    - 试玩链接：`https://komorebi-neon.vercel.app/`
    - 原帖：https://x.com/thisjiro/status/2096008437343949039
 
-17. **Ember Causeway** — [试玩](https://ember-causeway.s0673468.chatgpt.site) · [原帖](https://x.com/i/status/2096331530951925840) · ❤ 2
+19. **Ember Causeway** — [试玩](https://ember-causeway.s0673468.chatgpt.site) · [原帖](https://x.com/i/status/2096331530951925840) · ❤ 2
    - 试玩链接：`https://ember-causeway.s0673468.chatgpt.site`
    - 原帖：https://x.com/i/status/2096331530951925840
 
-18. **Bernabéu · Visita 3D** — [试玩](https://bernabeu-tres-d.antihero11.chatgpt.site/) · [原帖](https://x.com/davidcanci/status/2096201214178308538)
+20. **Bernabéu · Visita 3D** — [试玩](https://bernabeu-tres-d.antihero11.chatgpt.site/) · [原帖](https://x.com/davidcanci/status/2096201214178308538)
    - 试玩链接：`https://bernabeu-tres-d.antihero11.chatgpt.site/`
    - 原帖：https://x.com/davidcanci/status/2096201214178308538
 
-19. **Model X Studio** — [试玩](https://model-x-studio.vercel.app/) · [源码](https://github.com/ashemag/model-x-studio) · [原帖](https://x.com/grok/status/2096216661011439951)
+21. **Model X Studio** — [试玩](https://model-x-studio.vercel.app/) · [源码](https://github.com/ashemag/model-x-studio) · [原帖](https://x.com/grok/status/2096216661011439951)
    - 试玩链接：`https://model-x-studio.vercel.app/`
    - 源码：https://github.com/ashemag/model-x-studio
    - 原帖：https://x.com/grok/status/2096216661011439951
    - 简介：交互式 Tesla Model X 3D 工作室，圆形展台、零件说明、单件隔离，以及覆盖全部 **334** 个 mesh 的渐进爆炸视图
 
-20. **mosswing-quiet-flight** — [试玩](https://mosswing-quiet-flight.jack-514.chatgpt.site) · [原帖](https://x.com/i/status/2096263516181123300)
+22. **mosswing-quiet-flight** — [试玩](https://mosswing-quiet-flight.jack-514.chatgpt.site) · [原帖](https://x.com/i/status/2096263516181123300)
    - 试玩链接：`https://mosswing-quiet-flight.jack-514.chatgpt.site`
    - 原帖：https://x.com/i/status/2096263516181123300
 
-21. **Craft3D — More than a mesh.** — [试玩](https://craft3d.app/gallery) · [原帖](https://x.com/Craft3dApp/status/2096281079510659558)
+23. **Craft3D — More than a mesh.** — [试玩](https://craft3d.app/gallery) · [原帖](https://x.com/Craft3dApp/status/2096281079510659558)
    - 试玩链接：`https://craft3d.app/gallery`
    - 原帖：https://x.com/Craft3dApp/status/2096281079510659558
 
-22. **无限庭院** — [试玩](https://infinite-garden.yelin8130.chatgpt.site/) · [原帖](https://x.com/i/status/2096317379034935342)
+24. **无限庭院** — [试玩](https://infinite-garden.yelin8130.chatgpt.site/) · [原帖](https://x.com/i/status/2096317379034935342)
    - 试玩链接：`https://infinite-garden.yelin8130.chatgpt.site/`
    - 原帖：https://x.com/i/status/2096317379034935342
 
-23. **One fingerprint button. Six Astra reconstructions.** — [试玩](https://magbicaleman.github.io/minis/fingerprint-study/) · [原帖](https://x.com/magbicaleman/status/2096393243508314176)
+25. **One fingerprint button. Six Astra reconstructions.** — [试玩](https://magbicaleman.github.io/minis/fingerprint-study/) · [原帖](https://x.com/magbicaleman/status/2096393243508314176)
    - 试玩链接：`https://magbicaleman.github.io/minis/fingerprint-study/`
    - 原帖：https://x.com/magbicaleman/status/2096393243508314176
 
-24. **Astra — a dream in orbit** — [试玩](https://astra-dream.nxank4.chatgpt.site) · [原帖](https://x.com/ReadEpoch/status/2096505770204655989)
+26. **Astra — a dream in orbit** — [试玩](https://astra-dream.nxank4.chatgpt.site) · [原帖](https://x.com/ReadEpoch/status/2096505770204655989)
    - 试玩链接：`https://astra-dream.nxank4.chatgpt.site`
    - 原帖：https://x.com/ReadEpoch/status/2096505770204655989
 
-25. **Peel — your new main squeezes** — [试玩](https://peel-squishies.vercel.app) · [原帖](https://x.com/Cryptosphere14/status/2096650466511737000)
+27. **Peel — your new main squeezes** — [试玩](https://peel-squishies.vercel.app) · [原帖](https://x.com/Cryptosphere14/status/2096650466511737000)
    - 试玩链接：`https://peel-squishies.vercel.app`
    - 原帖：https://x.com/Cryptosphere14/status/2096650466511737000
 
-26. **KLIPZI CITY** — [试玩](https://klipzi-city.deadcoolapps.chatgpt.site) · [原帖](https://x.com/i/status/2096951400106209628)
+28. **KLIPZI CITY** — [试玩](https://klipzi-city.deadcoolapps.chatgpt.site) · [原帖](https://x.com/i/status/2096951400106209628)
    - 试玩链接：`https://klipzi-city.deadcoolapps.chatgpt.site`
    - 原帖：https://x.com/i/status/2096951400106209628
 
 ## 工程 / 仿真
 
-1. **Topological Rubik’s Synchronizer** — [试玩](https://topological-rubik-synchronizer.ela-dev-27.chatgpt.site/) · [原帖](https://x.com/i/status/2096304797687099568) · ❤ 10
+1. **iPhone Inside** — [试玩](https://iphone-inside-vercel.vercel.app) · [原帖](https://x.com/OpenDesignHQ/status/2097256962497056962) · ❤ 21
+   - 试玩链接：`https://iphone-inside-vercel.vercel.app`
+   - 原帖：https://x.com/OpenDesignHQ/status/2097256962497056962
+
+2. **Topological Rubik’s Synchronizer** — [试玩](https://topological-rubik-synchronizer.ela-dev-27.chatgpt.site/) · [原帖](https://x.com/i/status/2096304797687099568) · ❤ 10
    - 试玩链接：`https://topological-rubik-synchronizer.ela-dev-27.chatgpt.site/`
    - 原帖：https://x.com/i/status/2096304797687099568
 
-2. **MECHANICA — W12 Engine Lab** — [试玩](https://mechanica-w12-engine-lab.nm-8755.chatgpt.site/) · [原帖](https://x.com/i/status/2096346500364206536) · ❤ 2
+3. **MECHANICA — W12 Engine Lab** — [试玩](https://mechanica-w12-engine-lab.nm-8755.chatgpt.site/) · [原帖](https://x.com/i/status/2096346500364206536) · ❤ 2
    - 试玩链接：`https://mechanica-w12-engine-lab.nm-8755.chatgpt.site/`
    - 原帖：https://x.com/i/status/2096346500364206536
 
-3. **RB19 交互仿真** — [试玩](https://rb19-engineering-lab.moraxc.chatgpt.site/)
+4. **RB19 交互仿真** — [试玩](https://rb19-engineering-lab.moraxc.chatgpt.site/)
    - 试玩链接：`https://rb19-engineering-lab.moraxc.chatgpt.site/`
 
-4. **スマートトレイン学習サイト｜マトレイン** — [试玩](https://matrain-smarttrain-learning.mato111.chatgpt.site/learn/lab/tracks) · [原帖](https://x.com/shosuke_railfan/status/2095825467886784550)
+5. **スマートトレイン学習サイト｜マトレイン** — [试玩](https://matrain-smarttrain-learning.mato111.chatgpt.site/learn/lab/tracks) · [原帖](https://x.com/shosuke_railfan/status/2095825467886784550)
    - 试玩链接：`https://matrain-smarttrain-learning.mato111.chatgpt.site/learn/lab/tracks`
    - 原帖：https://x.com/shosuke_railfan/status/2095825467886784550
 
-5. **Portal Viewer** — [试玩](https://portal-headview-3d.leo1973.chatgpt.site/) · [原帖](https://x.com/SexyTechNews/status/2095982479396188179)
+6. **Portal Viewer** — [试玩](https://portal-headview-3d.leo1973.chatgpt.site/) · [原帖](https://x.com/SexyTechNews/status/2095982479396188179)
    - 试玩链接：`https://portal-headview-3d.leo1973.chatgpt.site/`
    - 原帖：https://x.com/SexyTechNews/status/2095982479396188179
 
-6. **CARGO LAB · 컨테이너 적재 시뮬레이터** — [试玩](https://cargo-lab.nanggo.chatgpt.site) · [原帖](https://x.com/nanggos/status/2096582509035438291)
+7. **CARGO LAB · 컨테이너 적재 시뮬레이터** — [试玩](https://cargo-lab.nanggo.chatgpt.site) · [原帖](https://x.com/nanggos/status/2096582509035438291)
    - 试玩链接：`https://cargo-lab.nanggo.chatgpt.site`
    - 原帖：https://x.com/nanggos/status/2096582509035438291
 
-7. **B-29 Superfortress Atlas** — [试玩](https://b29-superfortress-atlas.ashujo.chatgpt.site/) · [原帖](https://x.com/curiouswavefn/status/2097555293676945853)
+8. **B-29 Superfortress Atlas** — [试玩](https://b29-superfortress-atlas.ashujo.chatgpt.site/) · [原帖](https://x.com/curiouswavefn/status/2097555293676945853)
    - 试玩链接：`https://b29-superfortress-atlas.ashujo.chatgpt.site/`
    - 原帖：https://x.com/curiouswavefn/status/2097555293676945853
-
 
 ## 其他可玩 Demo
 
@@ -436,3 +465,4 @@
 - 来源主要为 X 公开帖与社区部署；版权归原作者。
 - 欢迎 PR 补充：**必须带可打开的试玩 URL**。
 - 相关：[GPT-6 Astra 国内使用指南](https://xianyu110.github.io/GPT6/) · [Codex 国内站](https://codex.maynorai.top/)
+

--- a/data/playable-demos.json
+++ b/data/playable-demos.json
@@ -1,5 +1,61 @@
 [
   {
+    "title": "Bonkshot",
+    "demo_url": "https://bonkshot.com",
+    "post_url": "https://x.com/edmund5/status/2097603093819261002",
+    "likes": 0,
+    "category": "射击 / 动作"
+  },
+  {
+    "title": "One More",
+    "demo_url": "https://onemoreapp.vercel.app",
+    "post_url": "https://x.com/gregavola/status/2097318437030690831",
+    "likes": 2,
+    "category": "街机 / 小游戏包"
+  },
+  {
+    "title": "iPhone Inside",
+    "demo_url": "https://iphone-inside-vercel.vercel.app",
+    "post_url": "https://x.com/OpenDesignHQ/status/2097256962497056962",
+    "likes": 21,
+    "category": "工程 / 仿真"
+  },
+  {
+    "title": "Bangalore GTA-style Three.js",
+    "demo_url": "https://genaiexperiments.vercel.app",
+    "post_url": "https://x.com/BuildFastWithAI/status/2097289129105223823",
+    "likes": 47,
+    "category": "3D 场景 / 氛围探索"
+  },
+  {
+    "title": "FOREX WARS",
+    "demo_url": "https://afterprime-forex-wars.argamon-2254.chatgpt.site/",
+    "post_url": "https://x.com/afterprime_com/status/2097159628119535866",
+    "likes": 3,
+    "category": "模拟经营 / 策略"
+  },
+  {
+    "title": "Bengaluru ORR Rush",
+    "demo_url": "https://orr-rush-bengaluru.ravitheja.chatgpt.site/",
+    "post_url": "https://x.com/ravithejads/status/2097181044625887392",
+    "likes": 22,
+    "category": "竞速 / 驾驶"
+  },
+  {
+    "title": "AFTERLIGHT",
+    "demo_url": "https://afterlight.a-9724.chatgpt.site",
+    "post_url": "https://x.com/jhahimanshu653/status/2097172185513357794",
+    "likes": 6,
+    "category": "3D 场景 / 氛围探索"
+  },
+  {
+    "title": "诡秘之主 · Tarot Club",
+    "demo_url": "https://combos.game/play/c7eea0b6846f90a102537819c9147bd4",
+    "post_url": "https://x.com/TsinsiSun/status/2097214405373300859",
+    "likes": 5,
+    "category": "经典复刻 / 知名玩法"
+  },
+  {
     "title": "零点街区 · 弹壳特攻队 3D",
     "demo_url": "https://iamsonic.net/2026/mini-games/shells-3d/play.html",
     "post_url": "https://x.com/sonic0828/status/2097601232877781344",

--- a/sources/martin/website/public/data/catalog-fallback.json
+++ b/sources/martin/website/public/data/catalog-fallback.json
@@ -1,6 +1,150 @@
 {
   "works": [
     {
+      "id": "work-3821930997250fa7",
+      "name": "Bonkshot",
+      "description": "可玩 Demo · 射击 / 动作 · Three.js 物理破坏弹射，GPT-6 Astra + Suno",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 射击 / 动作",
+      "author": {
+        "name": "edmund5",
+        "url": "https://x.com/edmund5"
+      },
+      "demoUrl": "https://bonkshot.com",
+      "sourceUrl": "https://x.com/edmund5/status/2097603093819261002",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2097603026702028800%2Fimg%2Fl_Kq0ju2XY8aG701.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2097603026702028800%2Fimg%2Fl_Kq0ju2XY8aG701.jpg",
+      "videoUrl": null,
+      "sourceOrder": -1022
+    },
+    {
+      "id": "work-30060ec47d566636",
+      "name": "One More",
+      "description": "可玩 Demo · 街机 / 小游戏包 · 高低猜牌连胜小游戏",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 街机 / 小游戏包",
+      "author": {
+        "name": "gregavola",
+        "url": "https://x.com/gregavola"
+      },
+      "demoUrl": "https://onemoreapp.vercel.app",
+      "sourceUrl": "https://x.com/gregavola/status/2097318437030690831",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FHRsrlRqWoAAS7hJ.jpg%3Fname%3Dorig",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FHRsrlRqWoAAS7hJ.jpg%3Fname%3Dorig",
+      "videoUrl": null,
+      "sourceOrder": -1023
+    },
+    {
+      "id": "work-34d374bac1c93db3",
+      "name": "iPhone Inside",
+      "description": "可玩 Demo · 工程 / 仿真 · 交互式 iPhone 3D 拆解",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 工程 / 仿真",
+      "author": {
+        "name": "OpenDesignHQ",
+        "url": "https://x.com/OpenDesignHQ"
+      },
+      "demoUrl": "https://iphone-inside-vercel.vercel.app",
+      "sourceUrl": "https://x.com/OpenDesignHQ/status/2097256962497056962",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2097255752973127680%2Fimg%2F-pthZGJC6NWkROHO.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2097255752973127680%2Fimg%2F-pthZGJC6NWkROHO.jpg",
+      "videoUrl": null,
+      "sourceOrder": -1024
+    },
+    {
+      "id": "work-95b2fe4e6ce80a36",
+      "name": "Bangalore GTA-style Three.js",
+      "description": "可玩 Demo · 3D 场景 / 氛围探索 · 班加罗尔 GTA 风 Three.js 场景",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 3D 场景 / 氛围探索",
+      "author": {
+        "name": "BuildFastWithAI",
+        "url": "https://x.com/BuildFastWithAI"
+      },
+      "demoUrl": "https://genaiexperiments.vercel.app",
+      "sourceUrl": "https://x.com/BuildFastWithAI/status/2097289129105223823",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2097285091726938112%2Fimg%2F6sx4by4KjqLCad2t.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2097285091726938112%2Fimg%2F6sx4by4KjqLCad2t.jpg",
+      "videoUrl": null,
+      "sourceOrder": -1025
+    },
+    {
+      "id": "work-ac5bb6c0e86f2d2a",
+      "name": "FOREX WARS",
+      "description": "可玩 Demo · 模拟经营 / 策略 · 外汇战争可玩 Demo",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 模拟经营 / 策略",
+      "author": {
+        "name": "afterprime_com",
+        "url": "https://x.com/afterprime_com"
+      },
+      "demoUrl": "https://afterprime-forex-wars.argamon-2254.chatgpt.site/",
+      "sourceUrl": "https://x.com/afterprime_com/status/2097159628119535866",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FHRqbikqbMAAvjwB.jpg%3Fname%3Dorig",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Fmedia%2FHRqbikqbMAAvjwB.jpg%3Fname%3Dorig",
+      "videoUrl": null,
+      "sourceOrder": -1026
+    },
+    {
+      "id": "work-737515ccf06e471b",
+      "name": "Bengaluru ORR Rush",
+      "description": "可玩 Demo · 竞速 / 驾驶 · 班加罗尔外环路竞速",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 竞速 / 驾驶",
+      "author": {
+        "name": "ravithejads",
+        "url": "https://x.com/ravithejads"
+      },
+      "demoUrl": "https://orr-rush-bengaluru.ravitheja.chatgpt.site/",
+      "sourceUrl": "https://x.com/ravithejads/status/2097181044625887392",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2097180643365146624%2Fimg%2FiiGSdsb_AwhE3eRz.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2097180643365146624%2Fimg%2FiiGSdsb_AwhE3eRz.jpg",
+      "videoUrl": null,
+      "sourceOrder": -1027
+    },
+    {
+      "id": "work-7c487fafbc2bd83a",
+      "name": "AFTERLIGHT",
+      "description": "可玩 Demo · 3D 场景 / 氛围探索 · AFTERLIGHT 可玩场景",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 3D 场景 / 氛围探索",
+      "author": {
+        "name": "jhahimanshu653",
+        "url": "https://x.com/jhahimanshu653"
+      },
+      "demoUrl": "https://afterlight.a-9724.chatgpt.site",
+      "sourceUrl": "https://x.com/jhahimanshu653/status/2097172185513357794",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2097171752006844417%2Fimg%2F3Q_StgSWS-jTGdp2.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2097171752006844417%2Fimg%2F3Q_StgSWS-jTGdp2.jpg",
+      "videoUrl": null,
+      "sourceOrder": -1028
+    },
+    {
+      "id": "work-6f587c964e5ece3f",
+      "name": "诡秘之主 · Tarot Club",
+      "description": "可玩 Demo · 经典复刻 / 知名玩法 · 诡秘之主塔罗会可玩",
+      "category": "game",
+      "sourceCategory": "PLAYABLE · 经典复刻 / 知名玩法",
+      "author": {
+        "name": "TsinsiSun",
+        "url": "https://x.com/TsinsiSun"
+      },
+      "demoUrl": "https://combos.game/play/c7eea0b6846f90a102537819c9147bd4",
+      "sourceUrl": "https://x.com/TsinsiSun/status/2097214405373300859",
+      "repoUrl": null,
+      "imageUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2097208508039192576%2Fimg%2F2LclG1wrdgyqMEHu.jpg",
+      "posterUrl": "https://wsrv.nl/?url=https%3A%2F%2Fpbs.twimg.com%2Famplify_video_thumb%2F2097208508039192576%2Fimg%2F2LclG1wrdgyqMEHu.jpg",
+      "videoUrl": null,
+      "sourceOrder": -1029
+    },
+    {
       "id": "work-b804c57bcee1770a",
       "name": "零点街区 · 弹壳特攻队 3D",
       "description": "可玩 Demo · 街机 / 小游戏包 · Sonic Astra 小游戏：弹壳特攻队 3D 离线版",


### PR DESCRIPTION
## Summary
Add 8 newly found **alive** GPT-6 Astra playable demos (HTTP 200 verified), deduped against current PLAYABLE / catalog.

| Title | Category | Demo |
|---|---|---|
| Bonkshot | 射击 / 动作 | https://bonkshot.com |
| One More | 街机 / 小游戏包 | https://onemoreapp.vercel.app |
| iPhone Inside | 工程 / 仿真 | https://iphone-inside-vercel.vercel.app |
| Bangalore GTA-style Three.js | 3D 场景 / 氛围探索 | https://genaiexperiments.vercel.app |
| FOREX WARS | 模拟经营 / 策略 | https://afterprime-forex-wars.argamon-2254.chatgpt.site/ |
| Bengaluru ORR Rush | 竞速 / 驾驶 | https://orr-rush-bengaluru.ravitheja.chatgpt.site/ |
| AFTERLIGHT | 3D 场景 / 氛围探索 | https://afterlight.a-9724.chatgpt.site |
| 诡秘之主 · Tarot Club | 经典复刻 / 知名玩法 | https://combos.game/play/c7eea0b6846f90a102537819c9147bd4 |

## Files
- `PLAYABLE.md` — 收录 99→107, section counts bumped, items at top of categories
- `data/playable-demos.json` — prepended
- `sources/martin/website/public/data/catalog-fallback.json` — prepended works (`sourceOrder` -1022..-1029), wsrv.nl thumbs

## Test plan
- [ ] Spot-check demo URLs open
- [ ] Showcase catalog picks up new works after Pages deploy